### PR TITLE
refactor: ETag 기반 캐싱으로 전환 및 메타데이터 시스템 제거

### DIFF
--- a/daramjwee.go
+++ b/daramjwee.go
@@ -55,18 +55,13 @@ type Cache interface {
 
 // Metadata holds essential metadata about a cached item.
 type Metadata struct {
-	Key        string
 	ETag       string
-	CreatedAt  time.Time
-	TTL        time.Duration
-	IsNegative bool
 }
 
 // FetchResult holds the data and metadata returned from a successful fetch operation.
 type FetchResult struct {
 	Body io.ReadCloser
 	ETag string
-	TTL  time.Duration
 	// NOTE: The []byte Data field is removed to enforce a stream-only workflow.
 }
 
@@ -76,17 +71,17 @@ type Fetcher interface {
 }
 
 type Store interface {
-	GetStream(key string) (io.ReadCloser, Metadata, error)
-	SetWithWriter(key string, meta Metadata) (io.WriteCloser, error)
+	GetStream(key string) (io.ReadCloser, string, error)
+	SetWithWriter(key string, etag string) (io.WriteCloser, error)
 	Delete(key string) error
-	Stat(key string) (Metadata, error)
+	Stat(key string) (string, error)
 }
 
 type ContextAwareStore interface {
-	GetStreamContext(ctx context.Context, key string) (io.ReadCloser, Metadata, error)
-	SetWithWriterContext(ctx context.Context, key string, meta Metadata) (io.WriteCloser, error)
+	GetStreamContext(ctx context.Context, key string) (io.ReadCloser, string, error)
+	SetWithWriterContext(ctx context.Context, key string, etag string) (io.WriteCloser, error)
 	DeleteContext(ctx context.Context, key string) error
-	StatContext(ctx context.Context, key string) (Metadata, error)
+	StatContext(ctx context.Context, key string) (string, error)
 }
 
 func New(logger log.Logger, opts ...Option) (Cache, error) {


### PR DESCRIPTION
기존의 다목적 메타데이터 시스템을 제거하고 ETag만을 사용하는 방식으로 캐시 로직을 수정했습니다.

주요 변경 사항:
1.  `daramjwee.go`:
    *   `Metadata` 구조체에서 `ETag`를 제외한 모든 필드(Key, CreatedAt, TTL, IsNegative) 제거.
    *   `FetchResult` 구조체에서 `TTL` 필드 제거.
    *   `Store` 및 `ContextAwareStore` 인터페이스의 메소드들 (`GetStream`, `SetWithWriter`, `Stat` 등)이 전체 `Metadata` 객체 대신 ETag 문자열을 직접 사용하도록 변경.

2.  `cache.go`:
    *   `DaramjweeCache` 구현 변경:
        *   `IsNegative` (부정 캐시), `isStale` (오래된 캐시 확인 로직) 관련 기능 제거.
        *   ETag를 사용하여 캐시를 가져오고, 설정하고, 백그라운드에서 갱신하는 로직 수정.
        *   `setNegativeCache`, `isStale` 메소드 제거.

3.  `storage/filestore/storage.go` 및 `storage/memstore/memstore.go`:
    *   `Store` 인터페이스 변경에 맞춰 파일 저장소 및 메모리 저장소 구현 수정.
    *   ETag 정보만을 저장하고 검색하도록 내부 로직 변경 (예: filestore의 `.meta.json` 파일, memstore의 내부 entry 구조체).

4.  테스트 파일:
    *   저장소 내에서 테스트 파일 (`_test.go`)을 찾을 수 없어 테스트 코드는 수정하지 못했습니다. 이 부분은 추후 검토가 필요할 수 있습니다.

이번 변경으로 캐시 시스템이 단순화되었으며, ETag를 이용한 HTTP 캐싱 전략에 더 부합하도록 개선되었습니다.