### PR TITLE
Refactor API to use Metadata struct instead of ETag string

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -74,7 +74,7 @@ func (c *DaramjweeCache) handleColdHit(ctx context.Context, key string, fetcher 
 	}
 
 	// Cold 캐시의 데이터를 클라이언트로 스트리밍하면서 동시에 Hot 캐시로 승격시킵니다.
-	return c.promoteAndTeeStream(ctx, key, coldMeta.ETag, coldStream)
+	return c.promoteAndTeeStream(ctx, key, coldMeta, coldStream)
 }
 
 // handleMiss는 Hot/Cold 캐시에서 모두 객체를 찾지 못했을 때의 로직을 처리합니다.
@@ -82,13 +82,13 @@ func (c *DaramjweeCache) handleMiss(ctx context.Context, key string, fetcher Fet
 	level.Debug(c.Logger).Log("msg", "full cache miss, fetching from origin", "key", key)
 
 	// Origin에 요청하기 전에, 만료되었을 수 있는 로컬 캐시의 ETag를 확인합니다.
-	var oldETag string
-	if meta, err := c.statFromStore(ctx, c.HotStore, key); err == nil && meta != nil {
-		oldETag = meta.ETag
+	var oldMetadata *Metadata
+	if meta, err := c.statFromStore(ctx, c.HotStore, key); err == nil {
+		oldMetadata = meta
 	}
 
 	// Origin에서 데이터를 가져옵니다.
-	result, err := fetcher.Fetch(ctx, oldETag)
+	result, err := fetcher.Fetch(ctx, oldMetadata)
 	if err != nil {
 		// Origin의 데이터가 변경되지 않은 경우 (HTTP 304 Not Modified)
 		if err == ErrNotModified {
@@ -121,14 +121,14 @@ func (c *DaramjweeCache) handleMiss(ctx context.Context, key string, fetcher Fet
 // The cache entry is finalized only when the returned writer is closed.
 // IMPORTANT: The caller MUST call Close() on the returned io.WriteCloser to finalize
 // the operation and release associated resources, including the context timeout.
-func (c *DaramjweeCache) Set(ctx context.Context, key string, etag string) (io.WriteCloser, error) {
+func (c *DaramjweeCache) Set(ctx context.Context, key string, metadata *Metadata) (io.WriteCloser, error) {
 	if c.HotStore == nil {
 		return nil, &ConfigError{"hotStore is not configured"}
 	}
 
 	ctx, cancel := c.newCtxWithTimeout(ctx)
 
-	wc, err := c.setStreamToStore(ctx, c.HotStore, key, etag)
+	wc, err := c.setStreamToStore(ctx, c.HotStore, key, metadata)
 	if err != nil {
 		cancel()
 		return nil, err
@@ -179,12 +179,12 @@ func (c *DaramjweeCache) ScheduleRefresh(ctx context.Context, key string, fetche
 	job := func(jobCtx context.Context) {
 		level.Info(c.Logger).Log("msg", "starting background refresh", "key", key)
 
-		var oldETag string
+		var oldMetadata *Metadata
 		if meta, err := c.statFromStore(jobCtx, c.HotStore, key); err == nil && meta != nil {
-			oldETag = meta.ETag
+			oldMetadata = meta
 		}
 
-		result, err := fetcher.Fetch(jobCtx, oldETag)
+		result, err := fetcher.Fetch(jobCtx, oldMetadata)
 		if err != nil {
 			if err == ErrNotModified {
 				level.Debug(c.Logger).Log("msg", "background refresh: object not modified", "key", key)
@@ -199,7 +199,7 @@ func (c *DaramjweeCache) ScheduleRefresh(ctx context.Context, key string, fetche
 			}
 		}()
 
-		writer, err := c.setStreamToStore(jobCtx, c.HotStore, key, result.Metadata.ETag)
+		writer, err := c.setStreamToStore(jobCtx, c.HotStore, key, result.Metadata)
 		if err != nil {
 			level.Error(c.Logger).Log("msg", "failed to get cache writer for refresh", "key", key, "err", err)
 			return
@@ -240,8 +240,8 @@ func (c *DaramjweeCache) getStreamFromStore(ctx context.Context, store Store, ke
 	return store.GetStream(ctx, key)
 }
 
-func (c *DaramjweeCache) setStreamToStore(ctx context.Context, store Store, key string, etag string) (io.WriteCloser, error) {
-	return store.SetWithWriter(ctx, key, etag)
+func (c *DaramjweeCache) setStreamToStore(ctx context.Context, store Store, key string, metadata *Metadata) (io.WriteCloser, error) {
+	return store.SetWithWriter(ctx, key, metadata)
 }
 
 func (c *DaramjweeCache) deleteFromStore(ctx context.Context, store Store, key string) error {
@@ -272,7 +272,7 @@ func (c *DaramjweeCache) scheduleSetToStore(ctx context.Context, destStore Store
 			}
 		}()
 
-		destWriter, err := c.setStreamToStore(jobCtx, destStore, key, meta.ETag)
+		destWriter, err := c.setStreamToStore(jobCtx, destStore, key, meta)
 		if err != nil {
 			level.Error(c.Logger).Log("msg", "failed to get writer for dest store for background set", "key", key, "err", err)
 			return
@@ -291,8 +291,8 @@ func (c *DaramjweeCache) scheduleSetToStore(ctx context.Context, destStore Store
 	c.Worker.Submit(job)
 }
 
-func (c *DaramjweeCache) promoteAndTeeStream(ctx context.Context, key, etag string, coldStream io.ReadCloser) (io.ReadCloser, error) {
-	hotWriter, err := c.setStreamToStore(ctx, c.HotStore, key, etag)
+func (c *DaramjweeCache) promoteAndTeeStream(ctx context.Context, key string, metadata *Metadata, coldStream io.ReadCloser) (io.ReadCloser, error) {
+	hotWriter, err := c.setStreamToStore(ctx, c.HotStore, key, metadata)
 	if err != nil {
 		level.Error(c.Logger).Log("msg", "failed to get hot store writer for promotion", "key", key, "err", err)
 		return coldStream, nil
@@ -304,7 +304,7 @@ func (c *DaramjweeCache) promoteAndTeeStream(ctx context.Context, key, etag stri
 
 func (c *DaramjweeCache) cacheAndTeeStream(ctx context.Context, key string, result *FetchResult) (io.ReadCloser, error) {
 	if c.HotStore != nil && result.Metadata != nil {
-		cacheWriter, err := c.setStreamToStore(ctx, c.HotStore, key, result.Metadata.ETag)
+		cacheWriter, err := c.setStreamToStore(ctx, c.HotStore, key, result.Metadata)
 		if err != nil {
 			level.Error(c.Logger).Log("msg", "failed to get cache writer", "key", key, "err", err)
 			return result.Body, err

--- a/daramjwee.go
+++ b/daramjwee.go
@@ -41,7 +41,7 @@ type Cache interface {
 	// response-to-client and writing-to-cache scenarios.
 	// NOTE: The caller is responsible for calling Close() on the returned
 	// io.WriteCloser to ensure the cache entry is committed and resources are released.
-	Set(ctx context.Context, key string, etag string) (io.WriteCloser, error)
+	Set(ctx context.Context, key string, metadata *Metadata) (io.WriteCloser, error)
 
 	// Delete removes an object from the cache.
 	Delete(ctx context.Context, key string) error
@@ -69,7 +69,7 @@ type FetchResult struct {
 
 // Fetcher defines the contract for fetching an object from an origin.
 type Fetcher interface {
-	Fetch(ctx context.Context, oldETag string) (*FetchResult, error)
+	Fetch(ctx context.Context, oldMetadata *Metadata) (*FetchResult, error)
 }
 
 // Store defines the interface for a single cache storage tier (e.g., memory, disk).
@@ -77,7 +77,7 @@ type Store interface {
 	// GetStream retrieves an object and its metadata as a stream.
 	GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error)
 	// SetWithWriter returns a writer that streams data into the store.
-	SetWithWriter(ctx context.Context, key string, etag string) (io.WriteCloser, error)
+	SetWithWriter(ctx context.Context, key string, metadata *Metadata) (io.WriteCloser, error)
 	// Delete removes an object from the store.
 	Delete(ctx context.Context, key string) error
 	// Stat retrieves metadata for an object without its data.

--- a/examples/main.go
+++ b/examples/main.go
@@ -32,8 +32,12 @@ type originFetcher struct {
 	key string
 }
 
-func (f *originFetcher) Fetch(ctx context.Context, oldETag string) (*daramjwee.FetchResult, error) {
-	fmt.Printf("[Origin] Fetching key: %s, (old ETag: '%s')\n", f.key, oldETag)
+func (f *originFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	oldETagVal := "none"
+	if oldMetadata != nil {
+		oldETagVal = oldMetadata.ETag
+	}
+	fmt.Printf("[Origin] Fetching key: %s, (old ETag: '%s')\n", f.key, oldETagVal)
 	time.Sleep(500 * time.Millisecond) // 원본과의 통신 지연 시뮬레이션
 
 	obj, ok := fakeOrigin[f.key]
@@ -42,7 +46,7 @@ func (f *originFetcher) Fetch(ctx context.Context, oldETag string) (*daramjwee.F
 	}
 
 	// ETag가 동일하면, 데이터 변경이 없음을 알립니다.
-	if oldETag != "" && oldETag == obj.etag {
+	if oldMetadata != nil && oldMetadata.ETag == obj.etag {
 		return nil, daramjwee.ErrNotModified
 	}
 

--- a/nullstore.go
+++ b/nullstore.go
@@ -24,7 +24,7 @@ func (ns *nullStore) GetStream(ctx context.Context, key string) (io.ReadCloser, 
 }
 
 // SetWithWriter는 모든 데이터를 버리는 io.WriteCloser를 반환합니다.
-func (ns *nullStore) SetWithWriter(ctx context.Context, key string, etag string) (io.WriteCloser, error) {
+func (ns *nullStore) SetWithWriter(ctx context.Context, key string, metadata *Metadata) (io.WriteCloser, error) {
 	return &nullWriteCloser{}, nil
 }
 

--- a/pkg/store/adapter/objstore_test.go
+++ b/pkg/store/adapter/objstore_test.go
@@ -38,7 +38,7 @@ func TestObjstoreAdapter_SetAndGetStream(t *testing.T) {
 	content := "hello, daramjwee!"
 
 	// 1. SetWithWriter를 사용하여 스트리밍 업로더를 가져옵니다.
-	wc, err := testStore.SetWithWriter(ctx, key, etag)
+	wc, err := testStore.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: etag})
 	require.NoError(t, err, "SetWithWriter should not return an error")
 	require.NotNil(t, wc, "writer should not be nil")
 
@@ -78,7 +78,7 @@ func TestObjstoreAdapter_Stat(t *testing.T) {
 	assert.ErrorIs(t, err, daramjwee.ErrNotFound, "Stat for a non-existent key should return ErrNotFound")
 
 	// Create an object to test Stat
-	wc, err := testStore.SetWithWriter(ctx, key, etag)
+	wc, err := testStore.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: etag})
 	require.NoError(t, err)
 	_, err = wc.Write([]byte("some data"))
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestObjstoreAdapter_Delete(t *testing.T) {
 	etag := "etag-for-delete"
 
 	// Create an object to delete
-	wc, err := testStore.SetWithWriter(ctx, key, etag)
+	wc, err := testStore.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: etag})
 	require.NoError(t, err)
 	_, err = wc.Write([]byte("data to be deleted"))
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestObjstoreAdapter_StreamingWriter_UploadError(t *testing.T) {
 		testStore.(*objstoreAdapter).bucket = originalBucket
 	}()
 
-	wc, err := testStore.SetWithWriter(ctx, key, etag)
+	wc, err := testStore.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: etag})
 	require.NoError(t, err)
 
 	_, err = wc.Write([]byte("this will fail"))

--- a/pkg/store/distributed/store.go
+++ b/pkg/store/distributed/store.go
@@ -59,8 +59,8 @@ func (d *DistributedStore) GetStream(ctx context.Context, key string) (io.ReadCl
 	return nil, nil, nil
 }
 
-func (d *DistributedStore) SetWithWriter(ctx context.Context, key string, etag string) (io.WriteCloser, error) {
-	return d.localStore.SetWithWriter(ctx, key, etag)
+func (d *DistributedStore) SetWithWriter(ctx context.Context, key string, metadata *daramjwee.Metadata) (io.WriteCloser, error) {
+	return d.localStore.SetWithWriter(ctx, key, metadata)
 }
 
 func (d *DistributedStore) Delete(ctx context.Context, key string) error {

--- a/pkg/store/filestore/storage_test.go
+++ b/pkg/store/filestore/storage_test.go
@@ -58,7 +58,7 @@ func TestFileStore_SetWithCopyAndTruncate_ErrorOnCopy(t *testing.T) {
 	//    임시 파일 삭제는 성공할 수 있습니다.
 	key := "non-existent-dir/copy-error-key"
 
-	writer, err := fs.SetWithWriter(ctx, key, "v1")
+	writer, err := fs.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: "v1"})
 	if err != nil {
 		t.Fatalf("SetWithWriter 초기화 실패: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestFileStore_SetAndGet(t *testing.T) {
 	content := "hello daramjwee"
 
 	// 1. 데이터 쓰기
-	writer, err := fs.SetWithWriter(ctx, key, etag)
+	writer, err := fs.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: etag})
 	if err != nil {
 		t.Fatalf("SetWithWriter 실패: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestFileStore_Stat(t *testing.T) {
 	etag := "etag-for-stat"
 
 	// 테스트 데이터 설정
-	writer, _ := fs.SetWithWriter(ctx, key, etag)
+	writer, _ := fs.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: etag})
 	if _, err := writer.Write([]byte("some data")); err != nil {
 		t.Fatalf("Error writing data for stat test: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestFileStore_Delete(t *testing.T) {
 	key := "delete-key"
 
 	// 테스트 데이터 설정
-	writer, _ := fs.SetWithWriter(ctx, key, "v1")
+	writer, _ := fs.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: "v1"})
 	if _, err := writer.Write([]byte("to be deleted")); err != nil {
 		t.Fatalf("Error writing data for delete test: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestFileStore_Overwrite(t *testing.T) {
 	key := "overwrite-key"
 
 	// Version 1 쓰기
-	writer1, _ := fs.SetWithWriter(ctx, key, "v1")
+	writer1, _ := fs.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: "v1"})
 	if _, err := writer1.Write([]byte("version 1")); err != nil {
 		t.Fatalf("Error writing data for overwrite test (initial): %v", err)
 	}
@@ -238,7 +238,7 @@ func TestFileStore_Overwrite(t *testing.T) {
 	}
 
 	// Version 2 쓰기 (덮어쓰기)
-	writer2, _ := fs.SetWithWriter(ctx, key, "v2")
+	writer2, _ := fs.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: "v2"})
 	if _, err := writer2.Write([]byte("version 2")); err != nil {
 		t.Fatalf("Error writing data for overwrite test (new): %v", err)
 	}
@@ -273,7 +273,7 @@ func TestFileStore_PathTraversal(t *testing.T) {
 
 	// "../"를 포함하는 악의적인 키
 	maliciousKey := "../malicious-file"
-	writer, err := fs.SetWithWriter(ctx, maliciousKey, "v1")
+	writer, err := fs.SetWithWriter(ctx, maliciousKey, &daramjwee.Metadata{ETag: "v1"})
 	if err != nil {
 		t.Fatalf("SetWithWriter 실패: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestFileStore_Set_ErrorOnWriteMeta(t *testing.T) {
 	err := os.Mkdir(metaPath, 0755)
 	require.NoError(t, err)
 
-	writer, err := fs.SetWithWriter(ctx, key, "v1")
+	writer, err := fs.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: "v1"})
 	require.NoError(t, err)
 
 	_, err = writer.Write([]byte("this should be cleaned up"))
@@ -343,7 +343,7 @@ func TestFileStore_SetWithRename_ErrorOnRename(t *testing.T) {
 	err := os.Mkdir(dataPath, 0755)
 	require.NoError(t, err)
 
-	writer, err := fs.SetWithWriter(ctx, key, "v1")
+	writer, err := fs.SetWithWriter(ctx, key, &daramjwee.Metadata{ETag: "v1"})
 	require.NoError(t, err)
 	_, err = writer.Write([]byte("some data"))
 	require.NoError(t, err)

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -66,12 +66,12 @@ func (ms *MemStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *
 
 // SetWithWriter returns a writer that streams data into an in-memory buffer.
 // When the writer is closed, the buffered data is committed to the main map.
-func (ms *MemStore) SetWithWriter(ctx context.Context, key string, etag string) (io.WriteCloser, error) {
+func (ms *MemStore) SetWithWriter(ctx context.Context, key string, metadata *daramjwee.Metadata) (io.WriteCloser, error) {
 	return &memStoreWriter{
-		ms:   ms,
-		key:  key,
-		etag: etag,
-		buf:  &bytes.Buffer{},
+		ms:       ms,
+		key:      key,
+		metadata: metadata,
+		buf:      &bytes.Buffer{},
 	}, nil
 }
 
@@ -114,10 +114,10 @@ func (ms *MemStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, 
 
 // memStoreWriter는 io.WriteCloser 인터페이스를 만족하는 헬퍼 타입입니다.
 type memStoreWriter struct {
-	ms   *MemStore
-	key  string
-	etag string
-	buf  *bytes.Buffer
+	ms       *MemStore
+	key      string
+	metadata *daramjwee.Metadata
+	buf      *bytes.Buffer
 }
 
 // Write는 받은 데이터를 내부 버퍼에 씁니다.
@@ -140,7 +140,7 @@ func (w *memStoreWriter) Close() error {
 
 	newEntry := entry{
 		value: finalData,
-		etag:  w.etag,
+		etag:  w.metadata.ETag,
 	}
 
 	w.ms.data[w.key] = newEntry


### PR DESCRIPTION
This commit introduces a `daramjwee.Metadata` struct to replace the standalone `etag string` parameter across various interfaces and implementations. This change enhances API consistency and allows for future extensions with additional metadata fields (e.g., Last-Modified) without breaking API compatibility.

Key changes include:

- Updated `Fetcher`, `Store`, and `Cache` interfaces to use `*Metadata`.
- Modified implementations in `cache.go`, `memstore`, `filestore`, and `objstore` adapter to align with the new interfaces.
- `filestore` and `objstore` now directly marshal/unmarshal the `Metadata` struct for their metadata files, removing the intermediate `metaFilePayload` type.
- Updated all relevant test code in `cache_test.go` and other test files to use `&daramjwee.Metadata{}` and ensure all tests pass.
- Updated example code in `examples/main.go` to reflect the API changes.