### PR TITLE
update coldstorage when cold store's data is not stale

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -188,7 +188,7 @@ func (c *DaramjweeCache) ScheduleRefresh(ctx context.Context, key string, fetche
 
 func (c *DaramjweeCache) isColdStoreCachedStale(oldMeta *Metadata) bool {
 	if oldMeta == nil {
-		return false
+		return true
 	}
 
 	freshnessLifetime := c.ColdStorePositiveFreshFor

--- a/cache.go
+++ b/cache.go
@@ -19,15 +19,17 @@ var ErrCacheClosed = errors.New("daramjwee: cache is closed")
 
 // DaramjweeCache is a concrete implementation of the Cache interface.
 type DaramjweeCache struct {
-	HotStore         Store
-	ColdStore        Store // Optional
-	Logger           log.Logger
-	Worker           *worker.Manager
-	DefaultTimeout   time.Duration
-	ShutdownTimeout  time.Duration
-	PositiveFreshFor time.Duration
-	NegativeFreshFor time.Duration
-	isClosed         atomic.Bool
+	HotStore                  Store
+	ColdStore                 Store // Optional
+	Logger                    log.Logger
+	Worker                    *worker.Manager
+	DefaultTimeout            time.Duration
+	ShutdownTimeout           time.Duration
+	PositiveFreshFor          time.Duration
+	NegativeFreshFor          time.Duration
+	ColdStorePositiveFreshFor time.Duration
+	ColdStoreNegativeFreshFor time.Duration
+	isClosed                  atomic.Bool
 }
 
 var _ Cache = (*DaramjweeCache)(nil)
@@ -169,13 +171,32 @@ func (c *DaramjweeCache) ScheduleRefresh(ctx context.Context, key string, fetche
 			level.Error(c.Logger).Log("msg", "failed background set", "key", key, "copyErr", copyErr, "closeErr", closeErr)
 		} else {
 			level.Info(c.Logger).Log("msg", "background set successful", "key", key)
-			// After refreshing hot cache successfully, schedule background copy to cold store
-			c.scheduleSetToStore(context.Background(), c.ColdStore, key)
+
+			// WARN: if oldMetadata's data is changed in Fetcher, we need to be careful about stale data
+			isStale := c.isColdStoreCachedStale(oldMetadata)
+
+			if isStale {
+				// schedule background copy to cold store
+				c.scheduleSetToStore(context.Background(), c.ColdStore, key)
+			}
 		}
 	}
 
 	c.Worker.Submit(job)
 	return nil
+}
+
+func (c *DaramjweeCache) isColdStoreCachedStale(oldMeta *Metadata) bool {
+	if oldMeta == nil {
+		return false
+	}
+
+	freshnessLifetime := c.ColdStorePositiveFreshFor
+	if oldMeta.IsNegative {
+		freshnessLifetime = c.ColdStoreNegativeFreshFor
+	}
+
+	return freshnessLifetime == 0 || (freshnessLifetime > 0 && time.Now().After(oldMeta.CachedAt.Add(freshnessLifetime)))
 }
 
 // Close safely shuts down the worker.

--- a/daramjwee.go
+++ b/daramjwee.go
@@ -156,14 +156,16 @@ func New(logger log.Logger, opts ...Option) (Cache, error) {
 	}
 
 	c := &DaramjweeCache{
-		Logger:           logger,
-		HotStore:         cfg.HotStore,
-		ColdStore:        cfg.ColdStore,
-		Worker:           workerManager,
-		DefaultTimeout:   cfg.DefaultTimeout,
-		ShutdownTimeout:  cfg.ShutdownTimeout,
-		PositiveFreshFor: cfg.PositiveFreshFor,
-		NegativeFreshFor: cfg.NegativeFreshFor,
+		Logger:                    logger,
+		HotStore:                  cfg.HotStore,
+		ColdStore:                 cfg.ColdStore,
+		Worker:                    workerManager,
+		DefaultTimeout:            cfg.DefaultTimeout,
+		ShutdownTimeout:           cfg.ShutdownTimeout,
+		PositiveFreshFor:          cfg.PositiveFreshFor,
+		NegativeFreshFor:          cfg.NegativeFreshFor,
+		ColdStorePositiveFreshFor: cfg.ColdStorePositiveFreshFor,
+		ColdStoreNegativeFreshFor: cfg.ColdStoreNegativeFreshFor,
 	}
 
 	level.Info(logger).Log("msg", "daramjwee cache initialized", "default_timeout", c.DefaultTimeout)

--- a/options.go
+++ b/options.go
@@ -31,6 +31,9 @@ type Config struct {
 
 	PositiveFreshFor time.Duration
 	NegativeFreshFor time.Duration
+
+	ColdStorePositiveFreshFor time.Duration
+	ColdStoreNegativeFreshFor time.Duration
 }
 
 // Option is a function type that modifies the Config.
@@ -120,6 +123,26 @@ func WithNegativeCache(freshFor time.Duration) Option {
 			return &ConfigError{"negative cache TTL cannot be a negative value"}
 		}
 		cfg.NegativeFreshFor = freshFor
+		return nil
+	}
+}
+
+func WithColdStorePositiveFreshFor(freshFor time.Duration) Option {
+	return func(cfg *Config) error {
+		if freshFor < 0 {
+			return &ConfigError{"cold store positive cache TTL cannot be a negative value"}
+		}
+		cfg.ColdStorePositiveFreshFor = freshFor
+		return nil
+	}
+}
+
+func WithColdStoreNegativeFreshFor(freshFor time.Duration) Option {
+	return func(cfg *Config) error {
+		if freshFor < 0 {
+			return &ConfigError{"cold store negative cache TTL cannot be a negative value"}
+		}
+		cfg.ColdStoreNegativeFreshFor = freshFor
 		return nil
 	}
 }


### PR DESCRIPTION
Current updating cold store's data logic is not good for financial point.
Add cold store's freshness and update only when it's not stale anymore.