### PR TITLE
feat(store/redisstore): Implement Redis-based store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.50.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0 // indirect
+	github.com/alicebob/miniredis/v2 v2.35.0 // indirect
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible // indirect
 	github.com/aws/aws-sdk-go-v2 v1.30.4 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.27.30 // indirect
@@ -48,6 +49,7 @@ require (
 	github.com/clbanning/mxj v1.8.4 // indirect
 	github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/efficientgo/core v1.0.0-rc.0.0.20221201130417-ba593f67d2a4 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
@@ -84,9 +86,11 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
+	github.com/redis/go-redis/v9 v9.12.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/sony/gobreaker v0.5.0 // indirect
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.40 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.34.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0 h1:ig/FpDD2JofP/NExKQUbn7uOSZzJAQqogfqluZK4ed4=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0/go.mod h1:otE2jQekW/PqXk1Awf5lmfokJx4uwuqcj1ab5SpGeW0=
 github.com/QcloudApi/qcloud_sign_golang v0.0.0-20141224014652-e4130a326409/go.mod h1:1pk82RBxDY/JZnPQrtqHlUFfCctgdorsd9M06fMynOM=
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible h1:9gWa46nstkJ9miBReJcN8Gq34cBFbzSpQZVVT9N09TM=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/aws/aws-sdk-go-v2 v1.30.4 h1:frhcagrVNrzmT95RJImMHgabt99vkXGslubDaDagTk8=
@@ -86,6 +88,8 @@ github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42/go.mod h1:W+zGtBO5Y1Ig
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -194,6 +198,8 @@ github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdO
 github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
+github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
+github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
@@ -215,6 +221,8 @@ github.com/tencentyun/cos-go-sdk-v5 v0.7.40 h1:W6vDGKCHe4wBACI1d2UgE6+50sJFhRWU4
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7yZxQuYwgSJM87icDaw=
 github.com/thanos-io/objstore v0.0.0-20250317105316-a0136a6f898d h1:L4k+8i1cl0h3MscslVUAcBpvA5i9UYzE0DybcOxzvlM=
 github.com/thanos-io/objstore v0.0.0-20250317105316-a0136a6f898d/go.mod h1:Nmy3+M2UM7wu2sEvg0h5M/c3mu1QaxmdyPvoGUPGlaU=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=

--- a/pkg/store/redisstore/redis.go
+++ b/pkg/store/redisstore/redis.go
@@ -1,0 +1,138 @@
+
+package redisstore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/mrchypark/daramjwee"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	dataKeyPrefix = "daramjwee:data:"
+	metaKeyPrefix = "daramjwee:meta:"
+)
+
+// RedisStore is a Redis-based implementation of the daramjwee.Store.
+type RedisStore struct {
+	client redis.UniversalClient
+	logger log.Logger
+}
+
+// New creates a new RedisStore.
+func New(client redis.UniversalClient, logger log.Logger) daramjwee.Store {
+	return &RedisStore{
+		client: client,
+		logger: logger,
+	}
+}
+
+// GetStream retrieves an object and its metadata as a stream from Redis.
+func (rs *RedisStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	pipe := rs.client.Pipeline()
+	metaCmd := pipe.Get(ctx, metaKeyPrefix+key)
+	dataCmd := pipe.Get(ctx, dataKeyPrefix+key)
+
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		if err == redis.Nil {
+			return nil, nil, daramjwee.ErrNotFound
+		}
+		return nil, nil, err
+	}
+
+	metaBytes, err := metaCmd.Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, nil, daramjwee.ErrNotFound
+		}
+		return nil, nil, err
+	}
+
+	var meta daramjwee.Metadata
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		return nil, nil, err
+	}
+
+	data, err := dataCmd.Bytes()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return io.NopCloser(bytes.NewReader(data)), &meta, nil
+}
+
+// SetWithWriter returns a writer that streams data into Redis.
+func (rs *RedisStore) SetWithWriter(ctx context.Context, key string, metadata *daramjwee.Metadata) (io.WriteCloser, error) {
+	w := &redisStoreWriter{
+		ctx:      ctx,
+		rs:       rs,
+		key:      key,
+		metadata: metadata,
+		buf:      new(bytes.Buffer),
+	}
+	return w, nil
+}
+
+// Delete removes an object and its metadata from Redis.
+func (rs *RedisStore) Delete(ctx context.Context, key string) error {
+	return rs.client.Del(ctx, metaKeyPrefix+key, dataKeyPrefix+key).Err()
+}
+
+// Stat retrieves metadata for an object without its data from Redis.
+func (rs *RedisStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	metaBytes, err := rs.client.Get(ctx, metaKeyPrefix+key).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, daramjwee.ErrNotFound
+		}
+		return nil, err
+	}
+
+	var meta daramjwee.Metadata
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		return nil, err
+	}
+
+	return &meta, nil
+}
+
+// redisStoreWriter is a helper type that satisfies the io.WriteCloser interface.
+type redisStoreWriter struct {
+	ctx      context.Context
+	rs       *RedisStore
+	key      string
+	metadata *daramjwee.Metadata
+	buf      *bytes.Buffer
+}
+
+// Write writes the provided data to the internal buffer.
+func (w *redisStoreWriter) Write(p []byte) (n int, err error) {
+	return w.buf.Write(p)
+}
+
+// Close commits the buffered data and metadata to Redis atomically.
+func (w *redisStoreWriter) Close() error {
+	metaBytes, err := json.Marshal(w.metadata)
+	if err != nil {
+		level.Error(w.rs.logger).Log("msg", "failed to marshal metadata", "key", w.key, "err", err)
+		return err
+	}
+
+	_, err = w.rs.client.Pipelined(w.ctx, func(pipe redis.Pipeliner) error {
+		pipe.Set(w.ctx, metaKeyPrefix+w.key, metaBytes, 0)
+		pipe.Set(w.ctx, dataKeyPrefix+w.key, w.buf.Bytes(), 0)
+		return nil
+	})
+
+	if err != nil {
+		level.Error(w.rs.logger).Log("msg", "failed to set data and metadata in redis", "key", w.key, "err", err)
+	}
+
+	return err
+}

--- a/pkg/store/redisstore/redis.go
+++ b/pkg/store/redisstore/redis.go
@@ -1,8 +1,6 @@
-
 package redisstore
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +11,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mrchypark/daramjwee"
 	"github.com/redis/go-redis/v9"
+)
+
+const (
+	chunkSize = 512 * 1024 // 512KB
 )
 
 // RedisStore is a Redis-based implementation of the daramjwee.Store.
@@ -29,32 +31,32 @@ func New(client redis.UniversalClient, logger log.Logger) daramjwee.Store {
 	}
 }
 
-// dataKey generates the Redis key for the data part of an object.
+// DataKey generates the Redis key for the data part of an object.
 // It uses a hash tag `{key}` to ensure that the data and metadata keys for the
 // same object are stored in the same Redis hash slot, which is necessary for
 // multi-key operations in a Redis Cluster.
-func (rs *RedisStore) dataKey(key string) string {
+func (rs *RedisStore) DataKey(key string) string {
 	return fmt.Sprintf("daramjwee:{%s}:data", key)
 }
 
-// metaKey generates the Redis key for the metadata part of an object.
+// MetaKey generates the Redis key for the metadata part of an object.
 // It uses a hash tag `{key}` to ensure that the data and metadata keys for the
 // same object are stored in the same Redis hash slot, which is necessary for
 // multi-key operations in a Redis Cluster.
-func (rs *RedisStore) metaKey(key string) string {
+func (rs *RedisStore) MetaKey(key string) string {
 	return fmt.Sprintf("daramjwee:{%s}:meta", key)
 }
 
-// tempKey generates a temporary Redis key for writing data.
+// TempKey generates a temporary Redis key for writing data.
 // It uses a hash tag `{key}` to ensure that the temporary key is in the same
 // hash slot as the final data and metadata keys.
-func (rs *RedisStore) tempKey(key string) string {
+func (rs *RedisStore) TempKey(key string) string {
 	return fmt.Sprintf("daramjwee:{%s}:temp:%s", key, uuid.New().String())
 }
 
 // getMetadata retrieves and unmarshals the metadata for a given key.
 func (rs *RedisStore) getMetadata(ctx context.Context, key string) (*daramjwee.Metadata, error) {
-	metaBytes, err := rs.client.Get(ctx, rs.metaKey(key)).Bytes()
+	metaBytes, err := rs.client.Get(ctx, rs.MetaKey(key)).Bytes()
 	if err != nil {
 		if err == redis.Nil {
 			return nil, daramjwee.ErrNotFound
@@ -82,17 +84,31 @@ func (rs *RedisStore) GetStream(ctx context.Context, key string) (io.ReadCloser,
 		return nil, nil, err
 	}
 
-	data, err := rs.client.Get(ctx, rs.dataKey(key)).Bytes()
+	// Check if the data key exists
+	exists, err := rs.client.Exists(ctx, rs.DataKey(key)).Result()
 	if err != nil {
-		if err == redis.Nil {
-			// This indicates an inconsistent state where metadata exists but data does not.
-			level.Warn(rs.logger).Log("msg", "metadata found but data is missing", "key", key)
-			return nil, nil, daramjwee.ErrNotFound
-		}
+		return nil, nil, err
+	}
+	if exists == 0 {
+		level.Warn(rs.logger).Log("msg", "metadata found but data is missing", "key", key)
+		return nil, nil, daramjwee.ErrNotFound
+	}
+
+	// Get the total size of the data
+	size, err := rs.client.StrLen(ctx, rs.DataKey(key)).Result()
+	if err != nil {
 		return nil, nil, err
 	}
 
-	return io.NopCloser(bytes.NewReader(data)), meta, nil
+	reader := &redisStreamReader{
+		ctx:    ctx,
+		client: rs.client,
+		key:    rs.DataKey(key),
+		size:   size,
+		offset: 0,
+	}
+
+	return reader, meta, nil
 }
 
 // SetWithWriter returns a writer that streams data into Redis.
@@ -107,7 +123,7 @@ func (rs *RedisStore) SetWithWriter(ctx context.Context, key string, metadata *d
 		ctx:      ctx,
 		rs:       rs,
 		key:      key,
-		tempKey:  rs.tempKey(key),
+		tempKey:  rs.TempKey(key),
 		metadata: metadata,
 	}
 	return w, nil
@@ -120,7 +136,7 @@ func (rs *RedisStore) Delete(ctx context.Context, key string) error {
 		return ctx.Err()
 	default:
 	}
-	return rs.client.Del(ctx, rs.metaKey(key), rs.dataKey(key)).Err()
+	return rs.client.Del(ctx, rs.MetaKey(key), rs.DataKey(key)).Err()
 }
 
 // Stat retrieves metadata for an object without its data from Redis.
@@ -169,8 +185,8 @@ func (w *redisStoreWriter) Close() error {
 	}
 
 	pipe := w.rs.client.Pipeline()
-	pipe.Set(w.ctx, w.rs.metaKey(w.key), metaBytes, 0)
-	pipe.Rename(w.ctx, w.tempKey, w.rs.dataKey(w.key))
+	pipe.Set(w.ctx, w.rs.MetaKey(w.key), metaBytes, 0)
+	pipe.Rename(w.ctx, w.tempKey, w.rs.DataKey(w.key))
 
 	if _, err := pipe.Exec(w.ctx); err != nil {
 		level.Error(w.rs.logger).Log("msg", "failed to commit data and metadata", "key", w.key, "err", err)
@@ -181,5 +197,45 @@ func (w *redisStoreWriter) Close() error {
 		return err
 	}
 
+	return nil
+}
+
+// redisStreamReader is a helper type that satisfies the io.ReadCloser interface
+// for streaming data from Redis.
+type redisStreamReader struct {
+	ctx    context.Context
+	client redis.UniversalClient
+	key    string
+	size   int64
+	offset int64
+}
+
+// Read reads a chunk of data from Redis.
+func (r *redisStreamReader) Read(p []byte) (n int, err error) {
+	if r.offset >= r.size {
+		return 0, io.EOF
+	}
+
+	// Calculate the end of the range to read
+	end := r.offset + int64(len(p)) - 1
+	if end >= r.size {
+		end = r.size - 1
+	}
+
+	// Read the chunk from Redis
+	chunk, err := r.client.GetRange(r.ctx, r.key, r.offset, end).Result()
+	if err != nil {
+		return 0, err
+	}
+
+	// Copy the chunk to the buffer
+	n = copy(p, chunk)
+	r.offset += int64(n)
+
+	return n, nil
+}
+
+// Close is a no-op for the redisStreamReader.
+func (r *redisStreamReader) Close() error {
 	return nil
 }

--- a/pkg/store/redisstore/redis.go
+++ b/pkg/store/redisstore/redis.go
@@ -5,17 +5,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
 	"github.com/mrchypark/daramjwee"
 	"github.com/redis/go-redis/v9"
-)
-
-const (
-	dataKeyPrefix = "daramjwee:data:"
-	metaKeyPrefix = "daramjwee:meta:"
 )
 
 // RedisStore is a Redis-based implementation of the daramjwee.Store.
@@ -32,88 +29,32 @@ func New(client redis.UniversalClient, logger log.Logger) daramjwee.Store {
 	}
 }
 
-// GetStream retrieves an object and its metadata as a stream from Redis.
-func (rs *RedisStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
-	select {
-	case <-ctx.Done():
-		return nil, nil, ctx.Err()
-	default:
-	}
-
-	pipe := rs.client.Pipeline()
-	metaCmd := pipe.Get(ctx, metaKeyPrefix+key)
-	dataCmd := pipe.Get(ctx, dataKeyPrefix+key)
-
-	_, err := pipe.Exec(ctx)
-	// Exec returns errors from individual commands, so we check them below.
-	// We only need to check for redis.Nil here if the pipeline is empty, which it is not.
-	if err != nil && err != redis.Nil {
-		return nil, nil, err
-	}
-
-	metaBytes, err := metaCmd.Bytes()
-	if err != nil {
-		if err == redis.Nil {
-			return nil, nil, daramjwee.ErrNotFound
-		}
-		return nil, nil, err
-	}
-
-	var meta daramjwee.Metadata
-	if err := json.Unmarshal(metaBytes, &meta); err != nil {
-		return nil, nil, err
-	}
-
-	data, err := dataCmd.Bytes()
-	if err != nil {
-		if err == redis.Nil {
-			// This case indicates data inconsistency, as metadata exists but data does not.
-			// For simplicity, we treat this as not found.
-			return nil, nil, daramjwee.ErrNotFound
-		}
-		return nil, nil, err
-	}
-
-	return io.NopCloser(bytes.NewReader(data)), &meta, nil
+// dataKey generates the Redis key for the data part of an object.
+// It uses a hash tag `{key}` to ensure that the data and metadata keys for the
+// same object are stored in the same Redis hash slot, which is necessary for
+// multi-key operations in a Redis Cluster.
+func (rs *RedisStore) dataKey(key string) string {
+	return fmt.Sprintf("daramjwee:{%s}:data", key)
 }
 
-// SetWithWriter returns a writer that streams data into Redis.
-// NOTE: This implementation buffers the entire object in memory before writing to Redis.
-// This can lead to high memory consumption for large objects.
-func (rs *RedisStore) SetWithWriter(ctx context.Context, key string, metadata *daramjwee.Metadata) (io.WriteCloser, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-	w := &redisStoreWriter{
-		ctx:      ctx,
-		rs:       rs,
-		key:      key,
-		metadata: metadata,
-		buf:      new(bytes.Buffer),
-	}
-	return w, nil
+// metaKey generates the Redis key for the metadata part of an object.
+// It uses a hash tag `{key}` to ensure that the data and metadata keys for the
+// same object are stored in the same Redis hash slot, which is necessary for
+// multi-key operations in a Redis Cluster.
+func (rs *RedisStore) metaKey(key string) string {
+	return fmt.Sprintf("daramjwee:{%s}:meta", key)
 }
 
-// Delete removes an object and its metadata from Redis.
-func (rs *RedisStore) Delete(ctx context.Context, key string) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
-	return rs.client.Del(ctx, metaKeyPrefix+key, dataKeyPrefix+key).Err()
+// tempKey generates a temporary Redis key for writing data.
+// It uses a hash tag `{key}` to ensure that the temporary key is in the same
+// hash slot as the final data and metadata keys.
+func (rs *RedisStore) tempKey(key string) string {
+	return fmt.Sprintf("daramjwee:{%s}:temp:%s", key, uuid.New().String())
 }
 
-// Stat retrieves metadata for an object without its data from Redis.
-func (rs *RedisStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-	metaBytes, err := rs.client.Get(ctx, metaKeyPrefix+key).Bytes()
+// getMetadata retrieves and unmarshals the metadata for a given key.
+func (rs *RedisStore) getMetadata(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	metaBytes, err := rs.client.Get(ctx, rs.metaKey(key)).Bytes()
 	if err != nil {
 		if err == redis.Nil {
 			return nil, daramjwee.ErrNotFound
@@ -125,25 +66,95 @@ func (rs *RedisStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata
 	if err := json.Unmarshal(metaBytes, &meta); err != nil {
 		return nil, err
 	}
-
 	return &meta, nil
 }
 
+// GetStream retrieves an object and its metadata as a stream from Redis.
+func (rs *RedisStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	default:
+	}
+
+	meta, err := rs.getMetadata(ctx, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	data, err := rs.client.Get(ctx, rs.dataKey(key)).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			// This indicates an inconsistent state where metadata exists but data does not.
+			level.Warn(rs.logger).Log("msg", "metadata found but data is missing", "key", key)
+			return nil, nil, daramjwee.ErrNotFound
+		}
+		return nil, nil, err
+	}
+
+	return io.NopCloser(bytes.NewReader(data)), meta, nil
+}
+
+// SetWithWriter returns a writer that streams data into Redis.
+func (rs *RedisStore) SetWithWriter(ctx context.Context, key string, metadata *daramjwee.Metadata) (io.WriteCloser, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	w := &redisStoreWriter{
+		ctx:      ctx,
+		rs:       rs,
+		key:      key,
+		tempKey:  rs.tempKey(key),
+		metadata: metadata,
+	}
+	return w, nil
+}
+
+// Delete removes an object and its metadata from Redis.
+func (rs *RedisStore) Delete(ctx context.Context, key string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	return rs.client.Del(ctx, rs.metaKey(key), rs.dataKey(key)).Err()
+}
+
+// Stat retrieves metadata for an object without its data from Redis.
+func (rs *RedisStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	return rs.getMetadata(ctx, key)
+}
+
 // redisStoreWriter is a helper type that satisfies the io.WriteCloser interface.
+// It streams data to a temporary key in Redis and, upon closing, atomically
+// renames the temporary key to the final key and sets the metadata.
+// This approach ensures that the write operation is atomic and avoids buffering
+// the entire file in memory.
 type redisStoreWriter struct {
 	ctx      context.Context
 	rs       *RedisStore
 	key      string
+	tempKey  string
 	metadata *daramjwee.Metadata
-	buf      *bytes.Buffer
 }
 
-// Write writes the provided data to the internal buffer.
+// Write appends the provided data to the Redis key.
 func (w *redisStoreWriter) Write(p []byte) (n int, err error) {
-	return w.buf.Write(p)
+	if err := w.rs.client.Append(w.ctx, w.tempKey, string(p)).Err(); err != nil {
+		return 0, err
+	}
+	return len(p), nil
 }
 
-// Close commits the buffered data and metadata to Redis atomically.
+// Close commits the metadata to Redis.
 func (w *redisStoreWriter) Close() error {
 	select {
 	case <-w.ctx.Done():
@@ -157,15 +168,18 @@ func (w *redisStoreWriter) Close() error {
 		return err
 	}
 
-	_, err = w.rs.client.Pipelined(w.ctx, func(pipe redis.Pipeliner) error {
-		pipe.Set(w.ctx, metaKeyPrefix+w.key, metaBytes, 0)
-		pipe.Set(w.ctx, dataKeyPrefix+w.key, w.buf.Bytes(), 0)
-		return nil
-	})
+	pipe := w.rs.client.Pipeline()
+	pipe.Set(w.ctx, w.rs.metaKey(w.key), metaBytes, 0)
+	pipe.Rename(w.ctx, w.tempKey, w.rs.dataKey(w.key))
 
-	if err != nil {
-		level.Error(w.rs.logger).Log("msg", "failed to set data and metadata in redis", "key", w.key, "err", err)
+	if _, err := pipe.Exec(w.ctx); err != nil {
+		level.Error(w.rs.logger).Log("msg", "failed to commit data and metadata", "key", w.key, "err", err)
+		// Attempt to clean up the temporary key
+		if delErr := w.rs.client.Del(w.ctx, w.tempKey).Err(); delErr != nil {
+			level.Error(w.rs.logger).Log("msg", "failed to delete temporary key", "key", w.key, "err", delErr)
+		}
+		return err
 	}
 
-	return err
+	return nil
 }

--- a/pkg/store/redisstore/redis_test.go
+++ b/pkg/store/redisstore/redis_test.go
@@ -1,0 +1,135 @@
+
+package redisstore
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupMiniRedis(t *testing.T) *miniredis.Miniredis {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	return mr
+}
+
+func TestRedisStore_SetAndGet(t *testing.T) {
+	mr := setupMiniRedis(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	logger := log.NewNopLogger()
+	store := New(client, logger)
+
+	ctx := context.Background()
+	key := "test-key"
+	testData := []byte("hello world")
+	testMetadata := &daramjwee.Metadata{
+		ETag:       "v1.0.0",
+		CachedAt:   time.Now().UTC().Truncate(time.Second),
+		IsNegative: false,
+	}
+
+	// 1. Set data using SetWithWriter
+	writer, err := store.SetWithWriter(ctx, key, testMetadata)
+	require.NoError(t, err)
+	n, err := writer.Write(testData)
+	require.NoError(t, err)
+	assert.Equal(t, len(testData), n)
+	require.NoError(t, writer.Close())
+
+	// 2. Get data using GetStream
+	reader, meta, err := store.GetStream(ctx, key)
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+	defer reader.Close()
+
+	// 3. Verify metadata
+	assert.Equal(t, testMetadata.ETag, meta.ETag)
+	assert.Equal(t, testMetadata.CachedAt, meta.CachedAt.UTC().Truncate(time.Second))
+	assert.Equal(t, testMetadata.IsNegative, meta.IsNegative)
+
+	// 4. Verify data
+	readData, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, testData, readData)
+}
+
+func TestRedisStore_Stat(t *testing.T) {
+	mr := setupMiniRedis(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	logger := log.NewNopLogger()
+	store := New(client, logger)
+
+	ctx := context.Background()
+	key := "test-stat-key"
+	testData := []byte("hello stat")
+	testMetadata := &daramjwee.Metadata{
+		ETag:       "v1.0.1",
+		CachedAt:   time.Now().UTC().Truncate(time.Second),
+		IsNegative: false,
+	}
+
+	// 1. Set data first
+	writer, err := store.SetWithWriter(ctx, key, testMetadata)
+	require.NoError(t, err)
+	_, err = writer.Write(testData)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	// 2. Stat the key
+	meta, err := store.Stat(ctx, key)
+	require.NoError(t, err)
+
+	// 3. Verify metadata
+	assert.Equal(t, testMetadata.ETag, meta.ETag)
+	assert.Equal(t, testMetadata.CachedAt, meta.CachedAt.UTC().Truncate(time.Second))
+	assert.Equal(t, testMetadata.IsNegative, meta.IsNegative)
+}
+
+func TestRedisStore_Delete(t *testing.T) {
+	mr := setupMiniRedis(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	logger := log.NewNopLogger()
+	store := New(client, logger)
+
+	ctx := context.Background()
+	key := "test-delete-key"
+	testData := []byte("data to be deleted")
+	testMetadata := &daramjwee.Metadata{ETag: "v1"}
+
+	// 1. Set data first
+	writer, err := store.SetWithWriter(ctx, key, testMetadata)
+	require.NoError(t, err)
+	_, err = writer.Write(testData)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	// 2. Verify it exists
+	_, err = store.Stat(ctx, key)
+	require.NoError(t, err, "Stat should find the key before delete")
+
+	// 3. Delete the key
+	err = store.Delete(ctx, key)
+	require.NoError(t, err)
+
+	// 4. Verify it's gone
+	_, _, err = store.GetStream(ctx, key)
+	assert.ErrorIs(t, err, daramjwee.ErrNotFound, "GetStream should return ErrNotFound after delete")
+
+	_, err = store.Stat(ctx, key)
+	assert.ErrorIs(t, err, daramjwee.ErrNotFound, "Stat should return ErrNotFound after delete")
+}

--- a/pkg/store/redisstore/redis_test.go
+++ b/pkg/store/redisstore/redis_test.go
@@ -1,10 +1,10 @@
-
 package redisstore
 
 import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,7 +29,7 @@ func TestRedisStore_SetAndGet(t *testing.T) {
 		Addr: mr.Addr(),
 	})
 	logger := log.NewNopLogger()
-	store := New(client, logger)
+	store := New(client, logger).(*RedisStore)
 
 	ctx := context.Background()
 	key := "test-key"
@@ -63,6 +63,38 @@ func TestRedisStore_SetAndGet(t *testing.T) {
 	readData, err := io.ReadAll(reader)
 	require.NoError(t, err)
 	assert.Equal(t, testData, readData)
+}
+
+func TestRedisStore_GetStream_Streaming(t *testing.T) {
+	mr := setupMiniRedis(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	logger := log.NewNopLogger()
+	store := New(client, logger).(*RedisStore)
+
+	ctx := context.Background()
+	key := "test-streaming-key"
+	// Create a large data slice to force multiple reads
+	largeData := []byte(strings.Repeat("a", chunkSize*2))
+	testMetadata := &daramjwee.Metadata{ETag: "v1"}
+
+	// 1. Set data
+	writer, err := store.SetWithWriter(ctx, key, testMetadata)
+	require.NoError(t, err)
+	_, err = writer.Write(largeData)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	// 2. Get stream
+	reader, _, err := store.GetStream(ctx, key)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	// 3. Read from the stream and verify
+	readData, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, largeData, readData)
 }
 
 func TestRedisStore_Stat(t *testing.T) {
@@ -141,7 +173,7 @@ func TestRedisStore_GetStream_DataInconsistency(t *testing.T) {
 		Addr: mr.Addr(),
 	})
 	logger := log.NewNopLogger()
-	store := New(client, logger)
+	store := New(client, logger).(*RedisStore)
 
 	ctx := context.Background()
 	key := "test-inconsistent-key"
@@ -150,7 +182,7 @@ func TestRedisStore_GetStream_DataInconsistency(t *testing.T) {
 	// Manually set metadata but not data to simulate inconsistency
 	metaBytes, err := json.Marshal(testMetadata)
 	require.NoError(t, err)
-	require.NoError(t, client.Set(ctx, metaKeyPrefix+key, metaBytes, 0).Err())
+	require.NoError(t, client.Set(ctx, store.MetaKey(key), metaBytes, 0).Err())
 
 	// GetStream should detect this and return ErrNotFound
 	_, _, err = store.GetStream(ctx, key)


### PR DESCRIPTION
This commit introduces a new daramjwee.Store implementation that uses Redis as a backend.

It provides implementations for the GetStream, SetWithWriter, Stat, and Delete methods. The implementation is tested using miniredis to ensure correctness without requiring a live Redis server for tests.