### PR TITLE
Harden cache refresh and race handling

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -17,6 +17,8 @@ var ErrCacheClosed = errors.New("daramjwee: cache is closed")
 var ErrNilMetadata = errors.New("daramjwee: nil metadata encountered")
 var ErrBackgroundJobRejected = errors.New("daramjwee: background job rejected")
 
+var errTopWriteInvalidated = errors.New("daramjwee: top-tier write invalidated")
+
 // DaramjweeCache is a concrete implementation of the Cache interface.
 type DaramjweeCache struct {
 	Tiers                  []Store
@@ -24,11 +26,17 @@ type DaramjweeCache struct {
 	Worker                 *worker.Manager
 	OpTimeout              time.Duration
 	CloseTimeout           time.Duration
+	WorkerTimeout          time.Duration
 	PositiveFreshness      time.Duration
 	NegativeFreshness      time.Duration
 	TierFreshnessOverrides map[int]TierFreshnessOverride
 	loggingDisabled        bool
 	isClosed               atomic.Bool
+	topWriteStates         sync.Map
+	topWritePruneCounter   atomic.Uint64
+	fanoutTopologyOnce     sync.Once
+	persistAfterTop        []tierDestination
+	regularFanoutBySource  [][]tierDestination
 }
 
 var _ Cache = (*DaramjweeCache)(nil)
@@ -110,6 +118,7 @@ func (c *DaramjweeCache) Delete(ctx context.Context, key string) error {
 	if c.isClosed.Load() {
 		return ErrCacheClosed
 	}
+	c.noteTopWriteGeneration(key)
 	ctx, cancel := c.newCtxWithTimeout(ctx)
 	defer cancel()
 
@@ -151,27 +160,41 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 
 	job := func(jobCtx context.Context) {
 		c.infoLog("msg", "starting background refresh", "key", key)
+		checkCtx, cancelChecks := c.newCtxWithTimeout(jobCtx)
+		defer cancelChecks()
 
 		var oldMetadata *Metadata
-		if meta, err := c.statFromStore(jobCtx, c.topWriteStore(), key); err == nil && meta != nil {
+		hadTopEntry := false
+		if meta, err := c.statFromStore(checkCtx, c.topWriteStore(), key); err == nil && meta != nil {
 			oldMetadata = meta
+			hadTopEntry = true
 		} else if fallbackMetadata != nil {
 			copied := *fallbackMetadata
 			oldMetadata = &copied
 		}
+		startGeneration := c.currentTopWriteGeneration(key)
 
 		result, err := fetcher.Fetch(jobCtx, oldMetadata)
 		if err != nil {
 			if errors.Is(err, ErrCacheableNotFound) {
+				shouldPublish, checkErr := c.backgroundRefreshStillOwnsTop(checkCtx, key, hadTopEntry, oldMetadata, startGeneration)
+				if checkErr != nil {
+					c.warnLog("msg", "failed to validate top-tier state before negative refresh publish", "key", key, "err", checkErr)
+					return
+				}
+				if !shouldPublish {
+					c.infoLog("msg", "skipping negative refresh publish because top-tier state changed", "key", key)
+					return
+				}
 				c.debugLog("msg", "re-caching as negative entry during background refresh", "key", key)
-				c.handleNegativeCache(jobCtx, jobCtx, key, nil)
+				c.handleNegativeCacheWithGeneration(jobCtx, jobCtx, key, nil, &startGeneration)
 			} else if errors.Is(err, ErrNotModified) {
 				c.debugLog("msg", "background refresh: object not modified", "key", key)
 				if fallbackSource != nil {
-					if promoteErr := c.promoteRefreshFallbackToTop(jobCtx, key, *fallbackSource, fallbackMetadata); promoteErr != nil {
+					if promoteErr := c.promoteRefreshFallbackToTop(jobCtx, key, *fallbackSource, fallbackMetadata, startGeneration); promoteErr != nil {
 						c.warnLog("msg", "failed to promote fallback entry after not-modified refresh", "key", key, "source_tier", fallbackSource.tierIndex, "err", promoteErr)
 					}
-				} else if refreshErr := c.refreshTopEntryCachedAt(jobCtx, key, oldMetadata); refreshErr != nil {
+				} else if refreshErr := c.refreshTopEntryCachedAt(jobCtx, key, oldMetadata, startGeneration); refreshErr != nil {
 					c.warnLog("msg", "failed to refresh top-tier metadata after not-modified refresh", "key", key, "err", refreshErr)
 				}
 			} else {
@@ -186,9 +209,23 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 		}
 		result.Metadata.CachedAt = time.Now()
 
+		shouldPublish, checkErr := c.backgroundRefreshStillOwnsTop(checkCtx, key, hadTopEntry, oldMetadata, startGeneration)
+		if checkErr != nil {
+			c.warnLog("msg", "failed to validate top-tier state before background refresh publish", "key", key, "err", checkErr)
+			return
+		}
+		if !shouldPublish {
+			c.infoLog("msg", "skipping background refresh publish because top-tier state changed", "key", key)
+			return
+		}
+
 		target := c.topWriteStore()
-		writer, err := c.setStreamToStore(jobCtx, target, key, result.Metadata)
+		writer, err := c.setStreamToStoreWithTopGeneration(jobCtx, target, key, result.Metadata, &startGeneration)
 		if err != nil {
+			if errors.Is(err, errTopWriteInvalidated) {
+				c.infoLog("msg", "skipping background refresh publish because top-tier generation changed", "key", key)
+				return
+			}
 			c.errorLog("msg", "failed to get cache writer for refresh", "key", key, "err", err)
 			return
 		}
@@ -198,14 +235,23 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 		if copyErr != nil {
 			closeErr = writer.Abort()
 		} else {
-			closeErr = writer.Close()
+			stillOwnsTop, ownErr := c.backgroundRefreshMatchesSnapshot(checkCtx, key, hadTopEntry, oldMetadata)
+			if ownErr != nil {
+				closeErr = errors.Join(writer.Abort(), ownErr)
+			} else if !stillOwnsTop {
+				closeErr = writer.Abort()
+			} else {
+				closeErr = writer.Close()
+			}
 		}
 
 		if copyErr != nil || closeErr != nil {
 			c.errorLog("msg", "failed background set", "key", key, "copyErr", copyErr, "closeErr", closeErr)
 		} else {
 			c.infoLog("msg", "background set successful", "key", key)
-			c.schedulePersistFromTop(key, c.persistDestinationsAfterTop()...)
+			if destinations := c.persistDestinationsAfterTop(); len(destinations) > 0 {
+				c.schedulePersistFromTop(key, *result.Metadata, destinations...)
+			}
 		}
 	}
 
@@ -213,6 +259,43 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 		return ErrBackgroundJobRejected
 	}
 	return nil
+}
+
+func (c *DaramjweeCache) backgroundRefreshStillOwnsTop(ctx context.Context, key string, hadTopEntry bool, oldMetadata *Metadata, expectedGeneration uint64) (bool, error) {
+	matchesSnapshot, err := c.backgroundRefreshMatchesSnapshot(ctx, key, hadTopEntry, oldMetadata)
+	if !matchesSnapshot || err != nil {
+		return matchesSnapshot, err
+	}
+	return c.currentTopWriteGeneration(key) == expectedGeneration, nil
+}
+
+func (c *DaramjweeCache) backgroundRefreshMatchesSnapshot(ctx context.Context, key string, hadTopEntry bool, oldMetadata *Metadata) (bool, error) {
+	target := c.topWriteStore()
+	if !hasRealStore(target) {
+		return false, nil
+	}
+
+	currentMeta, err := c.statFromStore(ctx, target, key)
+	if errors.Is(err, ErrNotFound) {
+		return !hadTopEntry, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if currentMeta == nil {
+		return false, ErrNilMetadata
+	}
+	if !hadTopEntry || oldMetadata == nil {
+		return false, nil
+	}
+
+	sameTag := currentMeta.CacheTag == oldMetadata.CacheTag
+	sameNegative := currentMeta.IsNegative == oldMetadata.IsNegative
+	sameCachedAt := currentMeta.CachedAt.Equal(oldMetadata.CachedAt)
+	if !sameTag || !sameNegative || !sameCachedAt {
+		return false, nil
+	}
+	return true, nil
 }
 
 func (c *DaramjweeCache) isCachedStale(oldMeta *Metadata, positive, negative time.Duration) bool {
@@ -349,7 +432,7 @@ func (c *DaramjweeCache) handleLowerTierHit(requestCtx, setupCtx context.Context
 		closeErr := writer.Close()
 		if closeErr == nil {
 			if destinations := c.regularFanoutDestinations(tierIndex); len(destinations) > 0 {
-				c.schedulePersistFromTop(key, destinations...)
+				c.schedulePersistFromTop(key, *metaToPromote, destinations...)
 			}
 		}
 		cancel()
@@ -370,7 +453,7 @@ func (c *DaramjweeCache) handleLowerTierHit(requestCtx, setupCtx context.Context
 	destinations := c.regularFanoutDestinations(tierIndex)
 	if len(destinations) > 0 {
 		onPublish = func() {
-			c.schedulePersistFromTop(key, destinations...)
+			c.schedulePersistFromTop(key, *metaToPromote, destinations...)
 		}
 	}
 	return newGetResponse(GetStatusOK, streamThrough(src, writer, cancel, onPublish), meta), nil
@@ -392,7 +475,7 @@ func (c *DaramjweeCache) promoteLowerTierHitToTop(requestCtx, setupCtx context.C
 		return err
 	}
 	if destinations := c.regularFanoutDestinations(tierIndex); len(destinations) > 0 {
-		c.schedulePersistFromTop(key, destinations...)
+		c.schedulePersistFromTop(key, *metadata, destinations...)
 	}
 	return nil
 }
@@ -415,7 +498,7 @@ func (c *DaramjweeCache) lowerTierRefreshOnCloseCallback(key string, fetcher Fet
 	}
 }
 
-func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key string, source tierDestination, fallbackMetadata *Metadata) error {
+func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key string, source tierDestination, fallbackMetadata *Metadata, expectedGeneration uint64) error {
 	target := c.topWriteStore()
 	if !hasRealStore(target) || !hasRealStore(source.store) || sameStoreInstance(source.store, target) {
 		return nil
@@ -433,15 +516,21 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 	metaToPromote.CachedAt = time.Now()
 
 	if metaToPromote.IsNegative {
-		writer, err := c.setStreamToStore(ctx, target, key, metaToPromote)
+		writer, err := c.setStreamToStoreWithTopGeneration(ctx, target, key, metaToPromote, &expectedGeneration)
 		if err != nil {
+			if errors.Is(err, errTopWriteInvalidated) {
+				return nil
+			}
 			return err
+		}
+		if !c.topEntryAbsent(ctx, key) {
+			return writer.Abort()
 		}
 		if err := writer.Close(); err != nil {
 			return err
 		}
 		if destinations := c.regularFanoutDestinations(source.tierIndex); len(destinations) > 0 {
-			c.schedulePersistFromTop(key, destinations...)
+			c.schedulePersistFromTop(key, *metaToPromote, destinations...)
 		}
 		return nil
 	}
@@ -452,8 +541,11 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 	}
 	defer srcStream.Close()
 
-	writer, err := c.setStreamToStore(ctx, target, key, metaToPromote)
+	writer, err := c.setStreamToStoreWithTopGeneration(ctx, target, key, metaToPromote, &expectedGeneration)
 	if err != nil {
+		if errors.Is(err, errTopWriteInvalidated) {
+			return nil
+		}
 		return err
 	}
 
@@ -461,22 +553,24 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 		abortErr := writer.Abort()
 		return errors.Join(copyErr, abortErr)
 	}
+	if !c.topEntryAbsent(ctx, key) {
+		return writer.Abort()
+	}
 	if err := writer.Close(); err != nil {
 		return err
 	}
 	if destinations := c.regularFanoutDestinations(source.tierIndex); len(destinations) > 0 {
-		c.schedulePersistFromTop(key, destinations...)
+		c.schedulePersistFromTop(key, *metaToPromote, destinations...)
 	}
 	return nil
 }
 
-func (c *DaramjweeCache) refreshTopEntryCachedAt(ctx context.Context, key string, oldMetadata *Metadata) error {
+func (c *DaramjweeCache) refreshTopEntryCachedAt(ctx context.Context, key string, oldMetadata *Metadata, expectedGeneration uint64) error {
 	target := c.topWriteStore()
 	if !hasRealStore(target) {
 		return nil
 	}
-
-	currentMeta, err := c.statFromStore(ctx, target, key)
+	srcStream, currentMeta, err := c.getStreamFromStore(ctx, target, key)
 	if errors.Is(err, ErrNotFound) {
 		return nil
 	}
@@ -487,45 +581,56 @@ func (c *DaramjweeCache) refreshTopEntryCachedAt(ctx context.Context, key string
 		return ErrNilMetadata
 	}
 	if !c.isTierCachedStale(currentMeta, 0) {
+		_ = srcStream.Close()
 		return nil
 	}
-	if oldMetadata != nil {
-		if currentMeta.CacheTag != oldMetadata.CacheTag || currentMeta.IsNegative != oldMetadata.IsNegative || !currentMeta.CachedAt.Equal(oldMetadata.CachedAt) {
-			return nil
-		}
+	if oldMetadata != nil && !metadataEqual(currentMeta, oldMetadata) {
+		_ = srcStream.Close()
+		return nil
 	}
 
 	metaToRefresh := *currentMeta
 	metaToRefresh.CachedAt = time.Now()
 
 	if metaToRefresh.IsNegative {
-		writer, err := c.setStreamToStore(ctx, target, key, &metaToRefresh)
+		srcCloseErr := srcStream.Close()
+		if srcCloseErr != nil {
+			return srcCloseErr
+		}
+		writer, err := c.setStreamToStoreWithTopGeneration(ctx, target, key, &metaToRefresh, &expectedGeneration)
 		if err != nil {
+			if errors.Is(err, errTopWriteInvalidated) {
+				return nil
+			}
 			return err
+		}
+		if !c.topMetadataMatches(ctx, key, currentMeta) {
+			return writer.Abort()
 		}
 		return writer.Close()
 	}
 
-	srcStream, _, err := c.getStreamFromStore(ctx, target, key)
-	if err != nil {
-		return err
-	}
-	content, err := io.ReadAll(srcStream)
-	closeErr := srcStream.Close()
-	if err != nil {
-		return errors.Join(err, closeErr)
-	}
-	if closeErr != nil {
-		return closeErr
+	content, copyErr := io.ReadAll(srcStream)
+	srcCloseErr := srcStream.Close()
+	if copyErr != nil || srcCloseErr != nil {
+		return errors.Join(copyErr, srcCloseErr)
 	}
 
-	writer, err := c.setStreamToStore(ctx, target, key, &metaToRefresh)
+	writer, err := c.setStreamToStoreWithTopGeneration(ctx, target, key, &metaToRefresh, &expectedGeneration)
 	if err != nil {
+		if errors.Is(err, errTopWriteInvalidated) {
+			return nil
+		}
 		return err
 	}
-	if _, copyErr := writer.Write(content); copyErr != nil {
+
+	if _, writeErr := writer.Write(content); writeErr != nil {
 		abortErr := writer.Abort()
-		return errors.Join(copyErr, abortErr)
+		return errors.Join(writeErr, abortErr)
+	}
+	if !c.topMetadataMatches(ctx, key, currentMeta) {
+		abortErr := writer.Abort()
+		return abortErr
 	}
 	return writer.Close()
 }
@@ -585,12 +690,18 @@ func (c *DaramjweeCache) handleMiss(requestCtx, setupCtx context.Context, key st
 	}
 
 	return newGetResponse(GetStatusOK, streamThrough(result.Body, writer, cancel, func() {
-		c.schedulePersistFromTop(key, c.persistDestinationsAfterTop()...)
+		if destinations := c.persistDestinationsAfterTop(); len(destinations) > 0 {
+			c.schedulePersistFromTop(key, *result.Metadata, destinations...)
+		}
 	}), result.Metadata), nil
 }
 
 // handleNegativeCache processes the logic for storing a negative cache entry.
 func (c *DaramjweeCache) handleNegativeCache(requestCtx, setupCtx context.Context, key string, cancel context.CancelFunc) (*GetResponse, error) {
+	return c.handleNegativeCacheWithGeneration(requestCtx, setupCtx, key, cancel, nil)
+}
+
+func (c *DaramjweeCache) handleNegativeCacheWithGeneration(requestCtx, setupCtx context.Context, key string, cancel context.CancelFunc, expectedGeneration *uint64) (*GetResponse, error) {
 	_, negativeFreshFor := c.tierFreshness(0)
 	c.debugLog("msg", "caching as negative entry", "key", key, "negative_fresh_for", negativeFreshFor)
 
@@ -599,12 +710,16 @@ func (c *DaramjweeCache) handleNegativeCache(requestCtx, setupCtx context.Contex
 		CachedAt:   time.Now(),
 	}
 
-	writer, err := c.setStreamToStore(c.beginSetContextForStore(requestCtx, setupCtx, c.topWriteStore()), c.topWriteStore(), key, meta)
+	writer, err := c.setStreamToStoreWithTopGeneration(c.beginSetContextForStore(requestCtx, setupCtx, c.topWriteStore()), c.topWriteStore(), key, meta, expectedGeneration)
 	if err != nil {
-		c.warnLog("msg", "failed to get writer for negative cache entry", "key", key, "err", err)
+		if !errors.Is(err, errTopWriteInvalidated) {
+			c.warnLog("msg", "failed to get writer for negative cache entry", "key", key, "err", err)
+		}
 	} else {
 		if closeErr := writer.Close(); closeErr != nil {
-			c.warnLog("msg", "failed to close writer for negative cache entry", "key", key, "err", closeErr)
+			if !errors.Is(closeErr, errTopWriteInvalidated) {
+				c.warnLog("msg", "failed to close writer for negative cache entry", "key", key, "err", closeErr)
+			}
 		}
 	}
 	if cancel != nil {
@@ -665,6 +780,13 @@ func cloneMetadata(meta *Metadata) *Metadata {
 	return &cloned
 }
 
+func metadataEqual(a, b *Metadata) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.CacheTag == b.CacheTag && a.IsNegative == b.IsNegative && a.CachedAt.Equal(b.CachedAt)
+}
+
 func newGetResponse(status GetStatus, body io.ReadCloser, meta *Metadata) *GetResponse {
 	resp := &GetResponse{
 		Status: status,
@@ -693,7 +815,32 @@ func (c *DaramjweeCache) getStreamFromStore(ctx context.Context, store Store, ke
 
 // setStreamToStore is a wrapper that calls the Store interface's BeginSet method.
 func (c *DaramjweeCache) setStreamToStore(ctx context.Context, store Store, key string, metadata *Metadata) (WriteSink, error) {
-	return store.BeginSet(ctx, key, metadata)
+	return c.setStreamToStoreWithTopGeneration(ctx, store, key, metadata, nil)
+}
+
+func (c *DaramjweeCache) setStreamToStoreWithTopGeneration(ctx context.Context, store Store, key string, metadata *Metadata, expectedGeneration *uint64) (WriteSink, error) {
+	sink, err := store.BeginSet(ctx, key, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	if !sameStoreInstance(store, c.topWriteStore()) {
+		return sink, nil
+	}
+
+	state, generation, ok := c.reserveTopWrite(key, expectedGeneration)
+	if !ok {
+		_ = sink.Abort()
+		return nil, errTopWriteInvalidated
+	}
+	return &topWriteSink{
+		WriteSink:  sink,
+		cache:      c,
+		key:        key,
+		store:      store,
+		state:      state,
+		generation: generation,
+	}, nil
 }
 
 // deleteFromStore is a wrapper that calls the Store interface's Delete method.
@@ -706,6 +853,177 @@ func (c *DaramjweeCache) statFromStore(ctx context.Context, store Store, key str
 	opCtx, cancel := c.newCtxWithTimeout(ctx)
 	defer cancel()
 	return store.Stat(opCtx, key)
+}
+
+func (c *DaramjweeCache) topMetadataMatches(ctx context.Context, key string, expected *Metadata) bool {
+	currentMeta, err := c.statFromStore(ctx, c.topWriteStore(), key)
+	if err != nil {
+		return false
+	}
+	return metadataEqual(currentMeta, expected)
+}
+
+func (c *DaramjweeCache) topEntryAbsent(ctx context.Context, key string) bool {
+	_, err := c.statFromStore(ctx, c.topWriteStore(), key)
+	return errors.Is(err, ErrNotFound)
+}
+
+func (c *DaramjweeCache) deleteDestinationIfMetadataMatches(ctx context.Context, store Store, key string, expected *Metadata) error {
+	currentMeta, err := c.statFromStore(ctx, store, key)
+	if errors.Is(err, ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !metadataEqual(currentMeta, expected) {
+		return nil
+	}
+	return c.deleteFromStore(ctx, store, key)
+}
+
+type topWriteState struct {
+	commitMu    sync.Mutex
+	generation  atomic.Uint64
+	lastTouched atomic.Int64
+}
+
+func (c *DaramjweeCache) topWriteStateForKey(key string) *topWriteState {
+	if state, ok := c.topWriteStates.Load(key); ok {
+		typed := state.(*topWriteState)
+		typed.lastTouched.Store(time.Now().UnixNano())
+		return typed
+	}
+
+	state := &topWriteState{}
+	state.lastTouched.Store(time.Now().UnixNano())
+	actual, _ := c.topWriteStates.LoadOrStore(key, state)
+	typed := actual.(*topWriteState)
+	typed.lastTouched.Store(time.Now().UnixNano())
+	c.maybePruneTopWriteStates(time.Now())
+	return typed
+}
+
+func (c *DaramjweeCache) currentTopWriteGeneration(key string) uint64 {
+	state, ok := c.topWriteStates.Load(key)
+	if !ok {
+		return 0
+	}
+	typed := state.(*topWriteState)
+	typed.lastTouched.Store(time.Now().UnixNano())
+	return typed.generation.Load()
+}
+
+func (c *DaramjweeCache) reserveTopWrite(key string, expectedGeneration *uint64) (*topWriteState, uint64, bool) {
+	state := c.topWriteStateForKey(key)
+	state.commitMu.Lock()
+	for {
+		currentGeneration := state.generation.Load()
+		if expectedGeneration != nil && currentGeneration != *expectedGeneration {
+			state.commitMu.Unlock()
+			return nil, 0, false
+		}
+		if state.generation.CompareAndSwap(currentGeneration, currentGeneration+1) {
+			state.commitMu.Unlock()
+			return state, currentGeneration + 1, true
+		}
+	}
+}
+
+func (c *DaramjweeCache) noteTopWriteGeneration(key string) {
+	state := c.topWriteStateForKey(key)
+	state.generation.Add(1)
+	state.lastTouched.Store(time.Now().UnixNano())
+}
+
+type topWriteSink struct {
+	WriteSink
+	cache      *DaramjweeCache
+	key        string
+	store      Store
+	state      *topWriteState
+	generation uint64
+	once       sync.Once
+	err        error
+}
+
+func (s *topWriteSink) Close() error {
+	s.once.Do(func() {
+		s.state.commitMu.Lock()
+		if s.generation != s.state.generation.Load() {
+			s.err = s.WriteSink.Abort()
+			s.state.commitMu.Unlock()
+			return
+		}
+		s.err = s.WriteSink.Close()
+		if s.err == nil && s.generation != s.state.generation.Load() {
+			s.err = s.cache.cleanupInvalidatedTopWrite(s.store, s.key)
+		}
+		s.state.lastTouched.Store(time.Now().UnixNano())
+		s.state.commitMu.Unlock()
+	})
+	return s.err
+}
+
+func (s *topWriteSink) Abort() error {
+	s.once.Do(func() {
+		s.err = s.WriteSink.Abort()
+		s.state.lastTouched.Store(time.Now().UnixNano())
+	})
+	return s.err
+}
+
+func (s *topWriteSink) Write(p []byte) (int, error) {
+	return s.WriteSink.Write(p)
+}
+
+func (c *DaramjweeCache) cleanupInvalidatedTopWrite(store Store, key string) error {
+	ctx, cancel := c.newCtxWithTimeout(context.Background())
+	defer cancel()
+	return c.deleteFromStore(ctx, store, key)
+}
+
+func (c *DaramjweeCache) topWriteStateRetention() time.Duration {
+	retention := c.OpTimeout
+	if c.WorkerTimeout > retention {
+		retention = c.WorkerTimeout
+	}
+	if c.CloseTimeout > retention {
+		retention = c.CloseTimeout
+	}
+	if retention <= 0 {
+		retention = 30 * time.Second
+	}
+	return retention*2 + time.Second
+}
+
+func (c *DaramjweeCache) maybePruneTopWriteStates(now time.Time) {
+	if c.topWritePruneCounter.Add(1)%256 != 0 {
+		return
+	}
+	c.pruneIdleTopWriteStates(now)
+}
+
+func (c *DaramjweeCache) pruneIdleTopWriteStates(now time.Time) {
+	cutoff := now.Add(-c.topWriteStateRetention()).UnixNano()
+	c.topWriteStates.Range(func(key, value any) bool {
+		state := value.(*topWriteState)
+		if state.lastTouched.Load() > cutoff {
+			return true
+		}
+		if !state.commitMu.TryLock() {
+			return true
+		}
+		defer state.commitMu.Unlock()
+		if state.lastTouched.Load() > cutoff {
+			return true
+		}
+		current, ok := c.topWriteStates.Load(key)
+		if ok && current == state {
+			c.topWriteStates.CompareAndDelete(key, state)
+		}
+		return true
+	})
 }
 
 func (c *DaramjweeCache) fetchFromOrigin(ctx context.Context, fetcher Fetcher, oldMetadata *Metadata) (*FetchResult, error) {
@@ -733,34 +1051,51 @@ type tierDestination struct {
 }
 
 func (c *DaramjweeCache) persistDestinationsAfterTop() []tierDestination {
-	if len(c.Tiers) <= 1 {
-		return nil
-	}
-
-	dests := make([]tierDestination, 0, len(c.Tiers)-1)
-	for idx, tier := range c.Tiers[1:] {
-		if hasRealStore(tier) {
-			dests = append(dests, tierDestination{tierIndex: idx + 1, store: tier})
-		}
-	}
-	return dests
+	c.initFanoutTopology()
+	return c.persistAfterTop
 }
 
 func (c *DaramjweeCache) regularFanoutDestinations(sourceIndex int) []tierDestination {
-	if sourceIndex <= 1 {
+	c.initFanoutTopology()
+	if sourceIndex <= 1 || sourceIndex >= len(c.regularFanoutBySource) {
 		return nil
 	}
-
-	dests := make([]tierDestination, 0, sourceIndex-1)
-	for idx, tier := range c.Tiers[1:sourceIndex] {
-		if hasRealStore(tier) {
-			dests = append(dests, tierDestination{tierIndex: idx + 1, store: tier})
-		}
-	}
-	return dests
+	return c.regularFanoutBySource[sourceIndex]
 }
 
-func (c *DaramjweeCache) schedulePersistFromTop(key string, destinations ...tierDestination) {
+func (c *DaramjweeCache) initFanoutTopology() {
+	c.fanoutTopologyOnce.Do(func() {
+		if len(c.Tiers) <= 1 {
+			return
+		}
+
+		persist := make([]tierDestination, 0, len(c.Tiers)-1)
+		regularBySource := make([][]tierDestination, len(c.Tiers))
+		for sourceIndex := 1; sourceIndex < len(c.Tiers); sourceIndex++ {
+			tier := c.Tiers[sourceIndex]
+			if hasRealStore(tier) {
+				dest := tierDestination{tierIndex: sourceIndex, store: tier}
+				persist = append(persist, dest)
+			}
+
+			if sourceIndex <= 1 {
+				continue
+			}
+
+			dests := make([]tierDestination, 0, sourceIndex-1)
+			for idx, lowerTier := range c.Tiers[1:sourceIndex] {
+				if hasRealStore(lowerTier) {
+					dests = append(dests, tierDestination{tierIndex: idx + 1, store: lowerTier})
+				}
+			}
+			regularBySource[sourceIndex] = dests
+		}
+		c.persistAfterTop = persist
+		c.regularFanoutBySource = regularBySource
+	})
+}
+
+func (c *DaramjweeCache) schedulePersistFromTop(key string, expectedTopMetadata Metadata, destinations ...tierDestination) {
 	srcStore := c.topWriteStore()
 	if !hasRealStore(srcStore) || len(destinations) == 0 {
 		return
@@ -779,6 +1114,14 @@ func (c *DaramjweeCache) schedulePersistFromTop(key string, destinations ...tier
 		destTierIndex := destination.tierIndex
 		dest := destStore
 		job := func(jobCtx context.Context) {
+			checkCtx, cancelChecks := c.newCtxWithTimeout(jobCtx)
+			defer cancelChecks()
+
+			if !c.topMetadataMatches(checkCtx, key, &expectedTopMetadata) {
+				c.infoLog("msg", "skipping background set because top-tier state changed", "key", key, "dest_tier", destTierIndex)
+				return
+			}
+
 			c.infoLog("msg", "starting background set", "key", key, "dest_tier", destTierIndex)
 
 			srcStream, meta, err := c.getStreamFromStore(jobCtx, srcStore, key)
@@ -787,10 +1130,19 @@ func (c *DaramjweeCache) schedulePersistFromTop(key string, destinations ...tier
 				return
 			}
 			defer srcStream.Close()
+			if !metadataEqual(meta, &expectedTopMetadata) {
+				c.infoLog("msg", "skipping background set because top-tier stream metadata changed", "key", key, "dest_tier", destTierIndex)
+				return
+			}
 
 			destWriter, err := c.setStreamToStore(jobCtx, dest, key, meta)
 			if err != nil {
 				c.errorLog("msg", "failed to get writer for destination store", "key", key, "dest_tier", destTierIndex, "err", err)
+				return
+			}
+			if !c.topMetadataMatches(checkCtx, key, &expectedTopMetadata) {
+				_ = destWriter.Abort()
+				c.infoLog("msg", "aborted background set because top-tier state changed", "key", key, "dest_tier", destTierIndex)
 				return
 			}
 
@@ -798,12 +1150,23 @@ func (c *DaramjweeCache) schedulePersistFromTop(key string, destinations ...tier
 			var closeErr error
 			if copyErr != nil {
 				closeErr = destWriter.Abort()
+			} else if !c.topMetadataMatches(checkCtx, key, &expectedTopMetadata) {
+				closeErr = destWriter.Abort()
+				c.infoLog("msg", "aborted background set before publish because top-tier state changed", "key", key, "dest_tier", destTierIndex)
 			} else {
 				closeErr = destWriter.Close()
 			}
 
 			if copyErr != nil || closeErr != nil {
 				c.errorLog("msg", "failed background set", "key", key, "dest_tier", destTierIndex, "copyErr", copyErr, "closeErr", closeErr)
+				return
+			}
+			if !c.topMetadataMatches(checkCtx, key, &expectedTopMetadata) {
+				if cleanupErr := c.deleteDestinationIfMetadataMatches(checkCtx, dest, key, &expectedTopMetadata); cleanupErr != nil {
+					c.warnLog("msg", "failed to clean up stale background set after top-tier change", "key", key, "dest_tier", destTierIndex, "err", cleanupErr)
+				} else {
+					c.infoLog("msg", "cleaned up stale background set after top-tier change", "key", key, "dest_tier", destTierIndex)
+				}
 				return
 			}
 			c.infoLog("msg", "background set successful", "key", key, "dest_tier", destTierIndex)

--- a/cache.go
+++ b/cache.go
@@ -997,7 +997,11 @@ func (s *topWriteSink) Abort() error {
 }
 
 func (s *topWriteSink) Write(p []byte) (int, error) {
-	return s.WriteSink.Write(p)
+	n, err := s.WriteSink.Write(p)
+	if n > 0 {
+		s.state.lastTouched.Store(time.Now().UnixNano())
+	}
+	return n, err
 }
 
 func (c *DaramjweeCache) cleanupInvalidatedTopWrite(store Store, key string) error {

--- a/cache.go
+++ b/cache.go
@@ -819,20 +819,21 @@ func (c *DaramjweeCache) setStreamToStore(ctx context.Context, store Store, key 
 }
 
 func (c *DaramjweeCache) setStreamToStoreWithTopGeneration(ctx context.Context, store Store, key string, metadata *Metadata, expectedGeneration *uint64) (WriteSink, error) {
-	sink, err := store.BeginSet(ctx, key, metadata)
-	if err != nil {
-		return nil, err
-	}
-
 	if !sameStoreInstance(store, c.topWriteStore()) {
-		return sink, nil
+		return store.BeginSet(ctx, key, metadata)
 	}
 
-	state, generation, ok := c.reserveTopWrite(key, expectedGeneration)
+	state, generation, ok := c.beginTopWriteReservation(key, expectedGeneration)
 	if !ok {
-		_ = sink.Abort()
 		return nil, errTopWriteInvalidated
 	}
+
+	sink, err := store.BeginSet(ctx, key, metadata)
+	if err != nil {
+		c.cancelTopWriteReservation(state, generation)
+		return nil, err
+	}
+	c.finishTopWriteReservation(state)
 	return &topWriteSink{
 		WriteSink:  sink,
 		cache:      c,
@@ -883,6 +884,7 @@ func (c *DaramjweeCache) deleteDestinationIfMetadataMatches(ctx context.Context,
 }
 
 type topWriteState struct {
+	beginMu     sync.Mutex
 	commitMu    sync.Mutex
 	generation  atomic.Uint64
 	lastTouched atomic.Int64
@@ -914,26 +916,37 @@ func (c *DaramjweeCache) currentTopWriteGeneration(key string) uint64 {
 	return typed.generation.Load()
 }
 
-func (c *DaramjweeCache) reserveTopWrite(key string, expectedGeneration *uint64) (*topWriteState, uint64, bool) {
+func (c *DaramjweeCache) beginTopWriteReservation(key string, expectedGeneration *uint64) (*topWriteState, uint64, bool) {
 	state := c.topWriteStateForKey(key)
-	state.commitMu.Lock()
-	for {
-		currentGeneration := state.generation.Load()
-		if expectedGeneration != nil && currentGeneration != *expectedGeneration {
-			state.commitMu.Unlock()
-			return nil, 0, false
-		}
-		if state.generation.CompareAndSwap(currentGeneration, currentGeneration+1) {
-			state.commitMu.Unlock()
-			return state, currentGeneration + 1, true
-		}
+	state.beginMu.Lock()
+	currentGeneration := state.generation.Load()
+	if expectedGeneration != nil && currentGeneration != *expectedGeneration {
+		state.beginMu.Unlock()
+		return nil, 0, false
 	}
+	generation := currentGeneration + 1
+	state.generation.Store(generation)
+	state.lastTouched.Store(time.Now().UnixNano())
+	return state, generation, true
+}
+
+func (c *DaramjweeCache) finishTopWriteReservation(state *topWriteState) {
+	state.lastTouched.Store(time.Now().UnixNano())
+	state.beginMu.Unlock()
+}
+
+func (c *DaramjweeCache) cancelTopWriteReservation(state *topWriteState, generation uint64) {
+	state.generation.Store(generation - 1)
+	state.lastTouched.Store(time.Now().UnixNano())
+	state.beginMu.Unlock()
 }
 
 func (c *DaramjweeCache) noteTopWriteGeneration(key string) {
 	state := c.topWriteStateForKey(key)
+	state.beginMu.Lock()
 	state.generation.Add(1)
 	state.lastTouched.Store(time.Now().UnixNano())
+	state.beginMu.Unlock()
 }
 
 type topWriteSink struct {
@@ -951,7 +964,11 @@ func (s *topWriteSink) Close() error {
 	s.once.Do(func() {
 		s.state.commitMu.Lock()
 		if s.generation != s.state.generation.Load() {
-			s.err = s.WriteSink.Abort()
+			abortErr := s.WriteSink.Abort()
+			s.err = errTopWriteInvalidated
+			if abortErr != nil {
+				s.err = errors.Join(s.err, abortErr)
+			}
 			s.state.commitMu.Unlock()
 			return
 		}
@@ -1011,6 +1028,10 @@ func (c *DaramjweeCache) pruneIdleTopWriteStates(now time.Time) {
 		if state.lastTouched.Load() > cutoff {
 			return true
 		}
+		if !state.beginMu.TryLock() {
+			return true
+		}
+		defer state.beginMu.Unlock()
 		if !state.commitMu.TryLock() {
 			return true
 		}

--- a/cache.go
+++ b/cache.go
@@ -936,17 +936,15 @@ func (c *DaramjweeCache) finishTopWriteReservation(state *topWriteState) {
 }
 
 func (c *DaramjweeCache) cancelTopWriteReservation(state *topWriteState, generation uint64) {
-	state.generation.Store(generation - 1)
+	state.generation.CompareAndSwap(generation, generation-1)
 	state.lastTouched.Store(time.Now().UnixNano())
 	state.beginMu.Unlock()
 }
 
 func (c *DaramjweeCache) noteTopWriteGeneration(key string) {
 	state := c.topWriteStateForKey(key)
-	state.beginMu.Lock()
 	state.generation.Add(1)
 	state.lastTouched.Store(time.Now().UnixNano())
-	state.beginMu.Unlock()
 }
 
 type topWriteSink struct {

--- a/cache.go
+++ b/cache.go
@@ -890,6 +890,8 @@ type topWriteState struct {
 	lastTouched atomic.Int64
 }
 
+var testHookAfterTopWriteReservationValidation func()
+
 func (c *DaramjweeCache) topWriteStateForKey(key string) *topWriteState {
 	if state, ok := c.topWriteStates.Load(key); ok {
 		typed := state.(*topWriteState)
@@ -919,15 +921,21 @@ func (c *DaramjweeCache) currentTopWriteGeneration(key string) uint64 {
 func (c *DaramjweeCache) beginTopWriteReservation(key string, expectedGeneration *uint64) (*topWriteState, uint64, bool) {
 	state := c.topWriteStateForKey(key)
 	state.beginMu.Lock()
-	currentGeneration := state.generation.Load()
-	if expectedGeneration != nil && currentGeneration != *expectedGeneration {
-		state.beginMu.Unlock()
-		return nil, 0, false
+	for {
+		currentGeneration := state.generation.Load()
+		if expectedGeneration != nil && currentGeneration != *expectedGeneration {
+			state.beginMu.Unlock()
+			return nil, 0, false
+		}
+		if testHookAfterTopWriteReservationValidation != nil {
+			testHookAfterTopWriteReservationValidation()
+		}
+		generation := currentGeneration + 1
+		if state.generation.CompareAndSwap(currentGeneration, generation) {
+			state.lastTouched.Store(time.Now().UnixNano())
+			return state, generation, true
+		}
 	}
-	generation := currentGeneration + 1
-	state.generation.Store(generation)
-	state.lastTouched.Store(time.Now().UnixNano())
-	return state, generation, true
 }
 
 func (c *DaramjweeCache) finishTopWriteReservation(state *topWriteState) {

--- a/cache_benchmark_test.go
+++ b/cache_benchmark_test.go
@@ -1,0 +1,46 @@
+package daramjwee
+
+import "testing"
+
+func BenchmarkTopWriteSinkWrite_4KiB(b *testing.B) {
+	payload := make([]byte, 4*1024)
+
+	b.Run("DirectSink", func(b *testing.B) {
+		sink := &benchmarkCountSink{}
+		b.SetBytes(int64(len(payload)))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := sink.Write(payload); err != nil {
+				b.Fatalf("write: %v", err)
+			}
+		}
+	})
+
+	b.Run("TopWriteSink", func(b *testing.B) {
+		state := &topWriteState{}
+		sink := &topWriteSink{
+			WriteSink:  &benchmarkCountSink{},
+			state:      state,
+			generation: 1,
+		}
+		b.SetBytes(int64(len(payload)))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := sink.Write(payload); err != nil {
+				b.Fatalf("write: %v", err)
+			}
+		}
+		b.StopTimer()
+		if state.lastTouched.Load() == 0 {
+			b.Fatal("expected lastTouched to be updated")
+		}
+	})
+}
+
+type benchmarkCountSink struct{}
+
+func (s *benchmarkCountSink) Write(p []byte) (int, error) { return len(p), nil }
+func (s *benchmarkCountSink) Close() error                { return nil }
+func (s *benchmarkCountSink) Abort() error                { return nil }

--- a/cache_state_test.go
+++ b/cache_state_test.go
@@ -1,0 +1,58 @@
+package daramjwee
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPruneIdleTopWriteStatesRemovesExpiredEntries(t *testing.T) {
+	cache := &DaramjweeCache{
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+
+	state := cache.topWriteStateForKey("expired")
+	state.lastTouched.Store(time.Now().Add(-10 * time.Second).UnixNano())
+
+	cache.pruneIdleTopWriteStates(time.Now())
+
+	if _, ok := cache.topWriteStates.Load("expired"); ok {
+		t.Fatal("expected expired top write state to be pruned")
+	}
+}
+
+func TestPruneIdleTopWriteStatesKeepsRecentEntries(t *testing.T) {
+	cache := &DaramjweeCache{
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+
+	cache.topWriteStateForKey("recent")
+
+	cache.pruneIdleTopWriteStates(time.Now())
+
+	if _, ok := cache.topWriteStates.Load("recent"); !ok {
+		t.Fatal("expected recent top write state to remain")
+	}
+}
+
+func TestPruneIdleTopWriteStatesSkipsLockedEntries(t *testing.T) {
+	cache := &DaramjweeCache{
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+
+	state := cache.topWriteStateForKey("locked")
+	state.lastTouched.Store(time.Now().Add(-10 * time.Second).UnixNano())
+	state.commitMu.Lock()
+	defer state.commitMu.Unlock()
+
+	cache.pruneIdleTopWriteStates(time.Now())
+
+	if _, ok := cache.topWriteStates.Load("locked"); !ok {
+		t.Fatal("expected locked top write state to remain")
+	}
+}

--- a/cache_state_test.go
+++ b/cache_state_test.go
@@ -224,6 +224,47 @@ func TestTopWriteSinkCloseReturnsInvalidationErrorWhenAbortSucceeds(t *testing.T
 	}
 }
 
+func TestTopWriteSinkWriteKeepsStateAliveForInvalidation(t *testing.T) {
+	cache := &DaramjweeCache{
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+	state := cache.topWriteStateForKey("key")
+	state.generation.Store(1)
+	state.lastTouched.Store(time.Now().Add(-10 * time.Second).UnixNano())
+
+	writeSink := &trackingTopWriteSink{}
+	sink := &topWriteSink{
+		WriteSink:  writeSink,
+		cache:      cache,
+		key:        "key",
+		state:      state,
+		generation: 1,
+	}
+
+	if _, err := sink.Write([]byte("payload")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	cache.pruneIdleTopWriteStates(time.Now())
+	cache.noteTopWriteGeneration("key")
+
+	err := sink.Close()
+	if !errors.Is(err, errTopWriteInvalidated) {
+		t.Fatalf("expected invalidation after concurrent generation bump, got %v", err)
+	}
+	if writeSink.closeCalls != 0 {
+		t.Fatalf("expected invalidated sink not to close underlying writer, got %d closes", writeSink.closeCalls)
+	}
+	if writeSink.abortCalls != 1 {
+		t.Fatalf("expected invalidated sink to abort once, got %d aborts", writeSink.abortCalls)
+	}
+	if current, ok := cache.topWriteStates.Load("key"); !ok || current != state {
+		t.Fatal("expected active top write state to survive pruning")
+	}
+}
+
 type destructiveReservationStore struct {
 	beginSetCalls int
 	data          []byte
@@ -277,3 +318,20 @@ type stubWriteSink struct{}
 func (s *stubWriteSink) Write(p []byte) (int, error) { return len(p), nil }
 func (s *stubWriteSink) Close() error                { return nil }
 func (s *stubWriteSink) Abort() error                { return nil }
+
+type trackingTopWriteSink struct {
+	closeCalls int
+	abortCalls int
+}
+
+func (s *trackingTopWriteSink) Write(p []byte) (int, error) { return len(p), nil }
+
+func (s *trackingTopWriteSink) Close() error {
+	s.closeCalls++
+	return nil
+}
+
+func (s *trackingTopWriteSink) Abort() error {
+	s.abortCalls++
+	return nil
+}

--- a/cache_state_test.go
+++ b/cache_state_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 	"time"
 )
@@ -145,6 +146,63 @@ func TestCancelTopWriteReservationDoesNotUndoConcurrentInvalidation(t *testing.T
 
 	if got := cache.currentTopWriteGeneration("key"); got != generation+1 {
 		t.Fatalf("expected concurrent invalidation to survive rollback, got %d", got)
+	}
+}
+
+func TestBeginTopWriteReservationRejectsStaleWriterAfterConcurrentInvalidation(t *testing.T) {
+	cache := &DaramjweeCache{
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+
+	expectedGeneration := uint64(0)
+	var once sync.Once
+	testHookAfterTopWriteReservationValidation = func() {
+		once.Do(func() {
+			cache.noteTopWriteGeneration("key")
+		})
+	}
+	defer func() {
+		testHookAfterTopWriteReservationValidation = nil
+	}()
+
+	state, generation, ok := cache.beginTopWriteReservation("key", &expectedGeneration)
+	if ok || state != nil || generation != 0 {
+		t.Fatalf("expected stale reservation to be rejected, got state=%v generation=%d ok=%v", state, generation, ok)
+	}
+	if got := cache.currentTopWriteGeneration("key"); got != 1 {
+		t.Fatalf("expected delete invalidation generation to survive, got %d", got)
+	}
+}
+
+func TestBeginTopWriteReservationRetriesPublicWriterAfterConcurrentInvalidation(t *testing.T) {
+	cache := &DaramjweeCache{
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+
+	var once sync.Once
+	testHookAfterTopWriteReservationValidation = func() {
+		once.Do(func() {
+			cache.noteTopWriteGeneration("key")
+		})
+	}
+	defer func() {
+		testHookAfterTopWriteReservationValidation = nil
+	}()
+
+	state, generation, ok := cache.beginTopWriteReservation("key", nil)
+	if !ok || state == nil {
+		t.Fatalf("expected public writer reservation to retry and succeed, got state=%v generation=%d ok=%v", state, generation, ok)
+	}
+	cache.finishTopWriteReservation(state)
+	if generation != 2 {
+		t.Fatalf("expected reservation to advance past concurrent invalidation, got %d", generation)
+	}
+	if got := cache.currentTopWriteGeneration("key"); got != 2 {
+		t.Fatalf("expected current generation to include invalidation and reservation, got %d", got)
 	}
 }
 

--- a/cache_state_test.go
+++ b/cache_state_test.go
@@ -1,6 +1,10 @@
 package daramjwee
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
 	"testing"
 	"time"
 )
@@ -56,3 +60,142 @@ func TestPruneIdleTopWriteStatesSkipsLockedEntries(t *testing.T) {
 		t.Fatal("expected locked top write state to remain")
 	}
 }
+
+func TestPruneIdleTopWriteStatesSkipsBeginLockedEntries(t *testing.T) {
+	cache := &DaramjweeCache{
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+
+	state := cache.topWriteStateForKey("begin-locked")
+	state.lastTouched.Store(time.Now().Add(-10 * time.Second).UnixNano())
+	state.beginMu.Lock()
+	defer state.beginMu.Unlock()
+
+	cache.pruneIdleTopWriteStates(time.Now())
+
+	if _, ok := cache.topWriteStates.Load("begin-locked"); !ok {
+		t.Fatal("expected begin-locked top write state to remain")
+	}
+}
+
+func TestSetStreamToStoreWithTopGenerationRejectsStaleWriterBeforeBeginSet(t *testing.T) {
+	store := &destructiveReservationStore{
+		data: []byte("live-body"),
+		meta: Metadata{CacheTag: "live"},
+	}
+	cache := &DaramjweeCache{
+		Tiers:         []Store{store},
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+	cache.noteTopWriteGeneration("key")
+
+	expectedGeneration := uint64(0)
+	writer, err := cache.setStreamToStoreWithTopGeneration(context.Background(), store, "key", &Metadata{CacheTag: "stale"}, &expectedGeneration)
+	if !errors.Is(err, errTopWriteInvalidated) {
+		t.Fatalf("expected invalidated error, got writer=%v err=%v", writer, err)
+	}
+	if store.beginSetCalls != 0 {
+		t.Fatalf("expected BeginSet not to be called for stale writer, got %d", store.beginSetCalls)
+	}
+	if got := string(store.data); got != "live-body" {
+		t.Fatalf("expected live body to remain intact, got %q", got)
+	}
+}
+
+func TestSetStreamToStoreWithTopGenerationRestoresGenerationOnBeginSetFailure(t *testing.T) {
+	store := &failingBeginSetStore{err: errors.New("boom")}
+	cache := &DaramjweeCache{
+		Tiers:         []Store{store},
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+
+	expectedGeneration := uint64(0)
+	writer, err := cache.setStreamToStoreWithTopGeneration(context.Background(), store, "key", &Metadata{CacheTag: "v1"}, &expectedGeneration)
+	if writer != nil {
+		t.Fatalf("expected no writer on BeginSet failure, got %T", writer)
+	}
+	if !errors.Is(err, store.err) {
+		t.Fatalf("expected BeginSet error, got %v", err)
+	}
+	if got := cache.currentTopWriteGeneration("key"); got != 0 {
+		t.Fatalf("expected generation to be restored after BeginSet failure, got %d", got)
+	}
+}
+
+func TestTopWriteSinkCloseReturnsInvalidationErrorWhenAbortSucceeds(t *testing.T) {
+	state := &topWriteState{}
+	state.generation.Store(2)
+
+	sink := &topWriteSink{
+		WriteSink:  &stubWriteSink{},
+		cache:      &DaramjweeCache{},
+		key:        "key",
+		store:      nil,
+		state:      state,
+		generation: 1,
+	}
+	err := sink.Close()
+	if !errors.Is(err, errTopWriteInvalidated) {
+		t.Fatalf("expected invalidated error, got %v", err)
+	}
+}
+
+type destructiveReservationStore struct {
+	beginSetCalls int
+	data          []byte
+	meta          Metadata
+}
+
+func (s *destructiveReservationStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	meta := s.meta
+	return io.NopCloser(bytes.NewReader(bytes.Clone(s.data))), &meta, nil
+}
+
+func (s *destructiveReservationStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	s.beginSetCalls++
+	s.data = nil
+	return &stubWriteSink{}, nil
+}
+
+func (s *destructiveReservationStore) Delete(ctx context.Context, key string) error {
+	s.data = nil
+	s.meta = Metadata{}
+	return nil
+}
+
+func (s *destructiveReservationStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	meta := s.meta
+	return &meta, nil
+}
+
+type failingBeginSetStore struct {
+	err error
+}
+
+func (s *failingBeginSetStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *failingBeginSetStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	return nil, s.err
+}
+
+func (s *failingBeginSetStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *failingBeginSetStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type stubWriteSink struct{}
+
+func (s *stubWriteSink) Write(p []byte) (int, error) { return len(p), nil }
+func (s *stubWriteSink) Close() error                { return nil }
+func (s *stubWriteSink) Abort() error                { return nil }

--- a/cache_state_test.go
+++ b/cache_state_test.go
@@ -128,6 +128,26 @@ func TestSetStreamToStoreWithTopGenerationRestoresGenerationOnBeginSetFailure(t 
 	}
 }
 
+func TestCancelTopWriteReservationDoesNotUndoConcurrentInvalidation(t *testing.T) {
+	cache := &DaramjweeCache{
+		OpTimeout:     time.Second,
+		WorkerTimeout: time.Second,
+		CloseTimeout:  time.Second,
+	}
+
+	state, generation, ok := cache.beginTopWriteReservation("key", nil)
+	if !ok {
+		t.Fatal("expected reservation to succeed")
+	}
+
+	cache.noteTopWriteGeneration("key")
+	cache.cancelTopWriteReservation(state, generation)
+
+	if got := cache.currentTopWriteGeneration("key"); got != generation+1 {
+		t.Fatalf("expected concurrent invalidation to survive rollback, got %d", got)
+	}
+}
+
 func TestTopWriteSinkCloseReturnsInvalidationErrorWhenAbortSucceeds(t *testing.T) {
 	state := &topWriteState{}
 	state.generation.Store(2)

--- a/daramjwee.go
+++ b/daramjwee.go
@@ -327,6 +327,7 @@ func New(logger log.Logger, opts ...Option) (Cache, error) {
 		Worker:                 workerManager,
 		OpTimeout:              cfg.OpTimeout,
 		CloseTimeout:           cfg.CloseTimeout,
+		WorkerTimeout:          cfg.WorkerTimeout,
 		PositiveFreshness:      cfg.PositiveFreshness,
 		NegativeFreshness:      cfg.NegativeFreshness,
 		TierFreshnessOverrides: cloneTierFreshnessOverrides(cfg.TierFreshnessOverrides),

--- a/if_none_match_fuzz_test.go
+++ b/if_none_match_fuzz_test.go
@@ -1,0 +1,63 @@
+package daramjwee
+
+import (
+	"strings"
+	"testing"
+)
+
+func FuzzIfNoneMatchMatchesCacheTag(f *testing.F) {
+	seeds := []struct {
+		header   string
+		cacheTag string
+	}{
+		{header: `W/"cache-v1"`, cacheTag: "cache-v1"},
+		{header: `"other", "cache-v1"`, cacheTag: `"cache-v1"`},
+		{header: `"rev,42"`, cacheTag: "rev,42"},
+		{header: "*", cacheTag: ""},
+		{header: "", cacheTag: "cache-v1"},
+	}
+	for _, seed := range seeds {
+		f.Add(seed.header, seed.cacheTag)
+	}
+
+	f.Fuzz(func(t *testing.T, header, cacheTag string) {
+		_ = ifNoneMatchMatchesCacheTag(header, cacheTag)
+
+		if ifNoneMatchMatchesCacheTag("*", cacheTag) != true {
+			t.Fatalf("wildcard should always match cacheTag %q", cacheTag)
+		}
+
+		if strings.TrimSpace(header) == "" && ifNoneMatchMatchesCacheTag(header, cacheTag) {
+			t.Fatalf("empty header unexpectedly matched cacheTag %q", cacheTag)
+		}
+
+		normalizedTag := normalizeEntityTag(cacheTag)
+		if normalizedTag == "" {
+			return
+		}
+		if strings.ContainsAny(normalizedTag, `"\`) {
+			return
+		}
+
+		quoted := `"` + escapeEntityTag(normalizedTag) + `"`
+		var variants []string
+		if !strings.Contains(normalizedTag, ",") && normalizedTag == strings.TrimSpace(normalizedTag) && normalizedTag != "" {
+			variants = append(variants, normalizedTag)
+		}
+		variants = append(variants,
+			quoted,
+			"W/"+quoted,
+			`"other", W/`+quoted,
+		)
+		for _, variant := range variants {
+			if !ifNoneMatchMatchesCacheTag(variant, cacheTag) {
+				t.Fatalf("variant %q did not match cacheTag %q", variant, cacheTag)
+			}
+		}
+	})
+}
+
+func escapeEntityTag(tag string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+	return replacer.Replace(tag)
+}

--- a/metadata_json_fuzz_test.go
+++ b/metadata_json_fuzz_test.go
@@ -1,0 +1,74 @@
+package daramjwee
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+func FuzzMetadataJSONRoundTrip(f *testing.F) {
+	f.Add("cache-v1", "legacy-v1", false, int64(0))
+	f.Add("", "legacy-only", true, int64(1712664000))
+	f.Add("rev,42", "", false, int64(253402300799))
+
+	f.Fuzz(func(t *testing.T, cacheTag, legacyETag string, isNegative bool, unixSeconds int64) {
+		cachedAt := fuzzTime(unixSeconds)
+
+		original := Metadata{
+			CacheTag:   cacheTag,
+			IsNegative: isNegative,
+			CachedAt:   cachedAt,
+		}
+
+		data, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("marshal metadata: %v", err)
+		}
+
+		var roundTrip Metadata
+		if err := json.Unmarshal(data, &roundTrip); err != nil {
+			t.Fatalf("unmarshal round-trip metadata: %v", err)
+		}
+		if roundTrip.IsNegative != original.IsNegative || !roundTrip.CachedAt.Equal(original.CachedAt) {
+			t.Fatalf("round trip mismatch: got %+v want %+v", roundTrip, original)
+		}
+		if utf8.ValidString(original.CacheTag) && roundTrip.CacheTag != original.CacheTag {
+			t.Fatalf("cache tag mismatch: got %q want %q", roundTrip.CacheTag, original.CacheTag)
+		}
+
+		payloadBytes, err := json.Marshal(metadataJSONPayload{
+			CacheTag:   cacheTag,
+			LegacyETag: legacyETag,
+			IsNegative: isNegative,
+			CachedAt:   cachedAt,
+		})
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+
+		var decoded Metadata
+		if err := json.Unmarshal(payloadBytes, &decoded); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+
+		expectedTag := cacheTag
+		if expectedTag == "" {
+			expectedTag = legacyETag
+		}
+		if decoded.IsNegative != isNegative || !decoded.CachedAt.Equal(cachedAt) {
+			t.Fatalf("decoded mismatch: got %+v", decoded)
+		}
+		if utf8.ValidString(expectedTag) && decoded.CacheTag != expectedTag {
+			t.Fatalf("cache tag mismatch: got %q want %q", decoded.CacheTag, expectedTag)
+		}
+	})
+}
+
+func fuzzTime(unixSeconds int64) time.Time {
+	const minUnix = -62135596800
+	const span = 315537897599
+
+	normalized := minUnix + int64(uint64(unixSeconds)%uint64(span+1))
+	return time.Unix(normalized, 0).UTC()
+}

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -118,11 +118,14 @@ type memStoreSink struct {
 	key      string
 	metadata *daramjwee.Metadata
 	buf      *bytes.Buffer
+	mu       sync.Mutex
 	done     bool
 }
 
 // Write writes the provided data to the internal buffer.
 func (w *memStoreSink) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.done {
 		return 0, io.ErrClosedPipe
 	}
@@ -132,12 +135,15 @@ func (w *memStoreSink) Write(p []byte) (n int, err error) {
 // Close is called when the write operation is complete.
 // It commits the buffered data to the MemStore and handles eviction if capacity is exceeded.
 func (w *memStoreSink) Close() error {
+	w.mu.Lock()
 	if w.done {
+		w.mu.Unlock()
 		return nil
 	}
 	w.done = true
 	w.ms.mu.Lock()
 	defer w.ms.mu.Unlock()
+	defer w.mu.Unlock()
 
 	finalData := make([]byte, w.buf.Len())
 	copy(finalData, w.buf.Bytes())
@@ -193,11 +199,15 @@ func (w *memStoreSink) Close() error {
 }
 
 func (w *memStoreSink) Abort() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.done {
 		return nil
 	}
 	w.done = true
-	w.buf.Reset()
+	if w.buf != nil {
+		w.buf.Reset()
+	}
 	w.release()
 	return nil
 }

--- a/pkg/store/memstore/memory_test.go
+++ b/pkg/store/memstore/memory_test.go
@@ -2,6 +2,7 @@ package memstore
 
 import (
 	"context"
+	"errors"
 	"io"
 	"math/rand"
 	"sync"
@@ -544,6 +545,113 @@ func TestMemStore_OldSinkTerminalCallsDoNotAffectNewWrite(t *testing.T) {
 	require.Equal(t, "second-value", string(body))
 	require.NotNil(t, meta)
 	require.Equal(t, "v2", meta.CacheTag)
+}
+
+func TestMemStoreSink_ConcurrentTerminalCallsDoNotTearState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := New(0, nil)
+
+	for i := 0; i < 32; i++ {
+		key := "terminal-key"
+		writer, err := store.BeginSet(ctx, key, &daramjwee.Metadata{CacheTag: "v1"})
+		require.NoError(t, err)
+		_, err = writer.Write([]byte("value"))
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		for j := 0; j < 16; j++ {
+			wg.Add(1)
+			go func(call int) {
+				defer wg.Done()
+				if call%2 == 0 {
+					_ = writer.Close()
+					return
+				}
+				_ = writer.Abort()
+			}(j)
+		}
+		wg.Wait()
+
+		_, err = writer.Write([]byte("after-close"))
+		require.ErrorIs(t, err, io.ErrClosedPipe)
+
+		reader, meta, err := store.GetStream(ctx, key)
+		if err == nil {
+			body, readErr := io.ReadAll(reader)
+			_ = reader.Close()
+			require.NoError(t, readErr)
+			require.Equal(t, "value", string(body))
+			require.NotNil(t, meta)
+			require.Equal(t, "v1", meta.CacheTag)
+		} else {
+			require.ErrorIs(t, err, daramjwee.ErrNotFound)
+		}
+
+		require.NoError(t, store.Delete(ctx, key))
+	}
+}
+
+func TestMemStoreSink_ConcurrentWriteAndCloseDoNotRace(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := New(0, nil)
+
+	for i := 0; i < 32; i++ {
+		writer, err := store.BeginSet(ctx, "write-close-key", &daramjwee.Metadata{CacheTag: "v1"})
+		require.NoError(t, err)
+
+		writeDone := make(chan error, 1)
+		go func() {
+			_, writeErr := writer.Write([]byte("value"))
+			writeDone <- writeErr
+		}()
+
+		closeErr := writer.Close()
+		writeErr := <-writeDone
+
+		if closeErr != nil {
+			t.Fatalf("unexpected close error: %v", closeErr)
+		}
+		if writeErr != nil && !errors.Is(writeErr, io.ErrClosedPipe) {
+			t.Fatalf("unexpected write error: %v", writeErr)
+		}
+
+		require.NoError(t, store.Delete(ctx, "write-close-key"))
+	}
+}
+
+func TestMemStoreSink_ConcurrentWriteAndAbortDoNotRace(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := New(0, nil)
+
+	for i := 0; i < 32; i++ {
+		writer, err := store.BeginSet(ctx, "write-abort-key", &daramjwee.Metadata{CacheTag: "v1"})
+		require.NoError(t, err)
+
+		writeDone := make(chan error, 1)
+		go func() {
+			_, writeErr := writer.Write([]byte("value"))
+			writeDone <- writeErr
+		}()
+
+		abortErr := writer.Abort()
+		writeErr := <-writeDone
+
+		if abortErr != nil {
+			t.Fatalf("unexpected abort error: %v", abortErr)
+		}
+		if writeErr != nil && !errors.Is(writeErr, io.ErrClosedPipe) {
+			t.Fatalf("unexpected write error: %v", writeErr)
+		}
+
+		_, _, err = store.GetStream(ctx, "write-abort-key")
+		require.ErrorIs(t, err, daramjwee.ErrNotFound)
+	}
 }
 
 func TestMemStore_ReturnsMetadataCopies(t *testing.T) {

--- a/refresh_benchmark_test.go
+++ b/refresh_benchmark_test.go
@@ -1,0 +1,118 @@
+package daramjwee
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+)
+
+func BenchmarkRefreshTopEntryCachedAt_1MiB(b *testing.B) {
+	const payloadSize = 1 * 1024 * 1024
+
+	payload := bytes.Repeat([]byte("r"), payloadSize)
+	store := newBenchmarkRefreshStore(payload)
+	cache := &DaramjweeCache{
+		Tiers:        []Store{store},
+		OpTimeout:    2 * time.Second,
+		CloseTimeout: 2 * time.Second,
+	}
+
+	b.SetBytes(payloadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		oldMetadata := store.resetStale()
+		if err := cache.refreshTopEntryCachedAt(context.Background(), "refresh-key", oldMetadata, cache.currentTopWriteGeneration("refresh-key")); err != nil {
+			b.Fatalf("refreshTopEntryCachedAt: %v", err)
+		}
+	}
+}
+
+type benchmarkRefreshStore struct {
+	data []byte
+	meta Metadata
+}
+
+func newBenchmarkRefreshStore(payload []byte) *benchmarkRefreshStore {
+	return &benchmarkRefreshStore{
+		data: bytes.Clone(payload),
+		meta: Metadata{
+			CacheTag: "v1",
+			CachedAt: time.Now().Add(-time.Hour),
+		},
+	}
+}
+
+func (s *benchmarkRefreshStore) resetStale() *Metadata {
+	s.meta.CachedAt = time.Now().Add(-time.Hour)
+	copied := s.meta
+	return &copied
+}
+
+func (s *benchmarkRefreshStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	metaCopy := s.meta
+	return io.NopCloser(bytes.NewReader(s.data)), &metaCopy, nil
+}
+
+func (s *benchmarkRefreshStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	metaCopy := &Metadata{}
+	if metadata != nil {
+		*metaCopy = *metadata
+	}
+
+	var buf bytes.Buffer
+	buf.Grow(len(s.data))
+	return &benchmarkRefreshSink{
+		store: s,
+		meta:  metaCopy,
+		buf:   &buf,
+	}, nil
+}
+
+func (s *benchmarkRefreshStore) Delete(ctx context.Context, key string) error {
+	s.data = nil
+	s.meta = Metadata{}
+	return nil
+}
+
+func (s *benchmarkRefreshStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	metaCopy := s.meta
+	return &metaCopy, nil
+}
+
+type benchmarkRefreshSink struct {
+	store *benchmarkRefreshStore
+	meta  *Metadata
+	buf   *bytes.Buffer
+	done  bool
+}
+
+func (s *benchmarkRefreshSink) Write(p []byte) (int, error) {
+	if s.done {
+		return 0, io.ErrClosedPipe
+	}
+	return s.buf.Write(p)
+}
+
+func (s *benchmarkRefreshSink) Close() error {
+	if s.done {
+		return nil
+	}
+	s.done = true
+
+	s.store.data = bytes.Clone(s.buf.Bytes())
+	if s.meta != nil {
+		s.store.meta = *s.meta
+	} else {
+		s.store.meta = Metadata{}
+	}
+	return nil
+}
+
+func (s *benchmarkRefreshSink) Abort() error {
+	s.done = true
+	return nil
+}

--- a/refresh_regression_test.go
+++ b/refresh_regression_test.go
@@ -1,0 +1,127 @@
+package daramjwee
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRefreshTopEntryCachedAtReadsBodyBeforeBeginSet(t *testing.T) {
+	store := &destructiveBeginSetStore{
+		data: []byte("original-body"),
+		meta: Metadata{
+			CacheTag: "v1",
+			CachedAt: time.Now().Add(-time.Hour),
+		},
+	}
+	cache := &DaramjweeCache{
+		Tiers:         []Store{store},
+		OpTimeout:     2 * time.Second,
+		WorkerTimeout: 2 * time.Second,
+		CloseTimeout:  2 * time.Second,
+	}
+
+	old := store.snapshot()
+	err := cache.refreshTopEntryCachedAt(context.Background(), "key", old, cache.currentTopWriteGeneration("key"))
+	if err != nil {
+		t.Fatalf("refreshTopEntryCachedAt: %v", err)
+	}
+
+	reader, meta, err := store.GetStream(context.Background(), "key")
+	if err != nil {
+		t.Fatalf("GetStream after refresh: %v", err)
+	}
+	defer reader.Close()
+
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll after refresh: %v", err)
+	}
+	if string(body) != "original-body" {
+		t.Fatalf("expected original body, got %q", string(body))
+	}
+	if !meta.CachedAt.After(old.CachedAt) {
+		t.Fatalf("expected CachedAt to move forward")
+	}
+}
+
+type destructiveBeginSetStore struct {
+	mu   sync.Mutex
+	data []byte
+	meta Metadata
+}
+
+func (s *destructiveBeginSetStore) snapshot() *Metadata {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copied := s.meta
+	return &copied
+}
+
+func (s *destructiveBeginSetStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	meta := s.meta
+	return io.NopCloser(bytes.NewReader(bytes.Clone(s.data))), &meta, nil
+}
+
+func (s *destructiveBeginSetStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	s.mu.Lock()
+	s.data = nil
+	s.mu.Unlock()
+
+	var buf bytes.Buffer
+	return &destructiveBeginSetSink{
+		store: s,
+		meta:  cloneMetadata(metadata),
+		buf:   &buf,
+	}, nil
+}
+
+func (s *destructiveBeginSetStore) Delete(ctx context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data = nil
+	s.meta = Metadata{}
+	return nil
+}
+
+func (s *destructiveBeginSetStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	meta := s.meta
+	return &meta, nil
+}
+
+type destructiveBeginSetSink struct {
+	store *destructiveBeginSetStore
+	meta  *Metadata
+	buf   *bytes.Buffer
+	done  bool
+}
+
+func (s *destructiveBeginSetSink) Write(p []byte) (int, error) {
+	return s.buf.Write(p)
+}
+
+func (s *destructiveBeginSetSink) Close() error {
+	if s.done {
+		return nil
+	}
+	s.done = true
+	s.store.mu.Lock()
+	defer s.store.mu.Unlock()
+	s.store.data = bytes.Clone(s.buf.Bytes())
+	if s.meta != nil {
+		s.store.meta = *s.meta
+	}
+	return nil
+}
+
+func (s *destructiveBeginSetSink) Abort() error {
+	s.done = true
+	return nil
+}

--- a/streaming.go
+++ b/streaming.go
@@ -1,7 +1,6 @@
 package daramjwee
 
 import (
-	"errors"
 	"io"
 	"sync"
 )
@@ -87,10 +86,13 @@ func (r *fillReadCloser) Read(p []byte) (int, error) {
 			return n, writeErr
 		}
 	}
+	if err == nil {
+		return n, nil
+	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if errors.Is(err, io.EOF) {
+	if err == io.EOF {
 		r.sawEOF = true
 		return n, err
 	}
@@ -124,7 +126,7 @@ func (r *fillReadCloser) WriteTo(dst io.Writer) (int64, error) {
 					break
 				}
 			}
-			if errors.Is(readErr, io.EOF) {
+			if readErr == io.EOF {
 				err = nil
 				break
 			}
@@ -169,7 +171,12 @@ func (r *fillReadCloser) Close() error {
 	} else {
 		err = r.sink.Abort()
 	}
-	err = errors.Join(err, r.src.Close())
+	srcCloseErr := r.src.Close()
+	if err == nil {
+		err = srcCloseErr
+	} else if srcCloseErr != nil {
+		err = joinTwoErrors(err, srcCloseErr)
+	}
 	if r.cancel != nil {
 		r.cancel()
 	}
@@ -220,6 +227,29 @@ func (c *cancelWriteSink) Close() error {
 		}
 	})
 	return c.err
+}
+
+func joinTwoErrors(first, second error) error {
+	if first == nil {
+		return second
+	}
+	if second == nil {
+		return first
+	}
+	return multiError{first: first, second: second}
+}
+
+type multiError struct {
+	first  error
+	second error
+}
+
+func (e multiError) Error() string {
+	return e.first.Error() + "\n" + e.second.Error()
+}
+
+func (e multiError) Unwrap() []error {
+	return []error{e.first, e.second}
 }
 
 func (c *cancelWriteSink) Abort() error {

--- a/streaming_reader_test.go
+++ b/streaming_reader_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -122,6 +124,79 @@ func TestStreamThrough_CopyShortWriteWithWriterToAborts(t *testing.T) {
 	assert.False(t, sink.closed)
 }
 
+func TestStreamThrough_ConcurrentClosePublishesOnceAfterEOF(t *testing.T) {
+	sink := &countingWriteSink{}
+	var published atomic.Int32
+
+	stream := streamThrough(
+		io.NopCloser(bytes.NewReader([]byte("hello"))),
+		sink,
+		nil,
+		func() { published.Add(1) },
+	)
+
+	body, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(body))
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 32)
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- stream.Close()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 1, sink.closeCalls())
+	assert.Equal(t, 0, sink.abortCalls())
+	assert.Equal(t, int32(1), published.Load())
+	assert.Equal(t, []byte("hello"), sink.snapshot())
+}
+
+func TestStreamThrough_ConcurrentCloseBeforeEOFAbortsOnce(t *testing.T) {
+	sink := &countingWriteSink{}
+	var published atomic.Int32
+
+	stream := streamThrough(
+		io.NopCloser(bytes.NewReader([]byte("hello"))),
+		sink,
+		nil,
+		func() { published.Add(1) },
+	)
+
+	buf := make([]byte, 2)
+	n, err := stream.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 32)
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- stream.Close()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 0, sink.closeCalls())
+	assert.Equal(t, 1, sink.abortCalls())
+	assert.Equal(t, int32(0), published.Load())
+	assert.Equal(t, []byte("he"), sink.snapshot())
+}
+
 type recordingWriteSink struct {
 	buf        bytes.Buffer
 	closeErr   error
@@ -183,4 +258,49 @@ func (r *writerToSpyReadCloser) WriteTo(w io.Writer) (int64, error) {
 
 func (r *writerToSpyReadCloser) Close() error {
 	return nil
+}
+
+type countingWriteSink struct {
+	mu         sync.Mutex
+	buf        bytes.Buffer
+	closeCount int
+	abortCount int
+}
+
+func (s *countingWriteSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *countingWriteSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeCount++
+	return nil
+}
+
+func (s *countingWriteSink) Abort() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.abortCount++
+	return nil
+}
+
+func (s *countingWriteSink) closeCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closeCount
+}
+
+func (s *countingWriteSink) abortCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.abortCount
+}
+
+func (s *countingWriteSink) snapshot() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return bytes.Clone(s.buf.Bytes())
 }

--- a/tests/cache_regression_test.go
+++ b/tests/cache_regression_test.go
@@ -192,6 +192,127 @@ func TestScheduleRefresh_ContinuesAfterCallerContextCancel(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
+func TestScheduleRefresh_DoesNotOverwriteNewerTopEntry(t *testing.T) {
+	hot := newMockStore()
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	ctx := context.Background()
+	key := "refresh-does-not-clobber"
+
+	wc, err := cache.Set(ctx, key, &daramjwee.Metadata{CacheTag: "v0"})
+	require.NoError(t, err)
+	_, err = wc.Write([]byte("old-value"))
+	require.NoError(t, err)
+	require.NoError(t, wc.Close())
+
+	started := make(chan struct{}, 1)
+	blocker := make(chan struct{})
+	fetcher := blockingSuccessFetcher{
+		started:  started,
+		blocker:  blocker,
+		content:  "background-value",
+		cacheTag: "v1",
+	}
+
+	require.NoError(t, cache.ScheduleRefresh(ctx, key, fetcher))
+	<-started
+
+	newer, err := cache.Set(ctx, key, &daramjwee.Metadata{CacheTag: "user-v2"})
+	require.NoError(t, err)
+	_, err = newer.Write([]byte("user-value"))
+	require.NoError(t, err)
+	require.NoError(t, newer.Close())
+
+	close(blocker)
+
+	require.Eventually(t, func() bool {
+		reader, meta, err := hot.GetStream(context.Background(), key)
+		if err != nil {
+			return false
+		}
+		defer reader.Close()
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			return false
+		}
+		return string(body) == "user-value" && meta.CacheTag == "user-v2"
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestScheduleRefresh_CloseWindowDoesNotOverwriteNewerSet(t *testing.T) {
+	top := newNotifyingSlowSetStore(150 * time.Millisecond)
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	key := "refresh-close-window-no-clobber"
+	top.setData(key, "old-value", &daramjwee.Metadata{
+		CacheTag: "v0",
+		CachedAt: time.Now().Add(-time.Hour),
+	})
+
+	started := make(chan struct{}, 1)
+	blocker := make(chan struct{})
+	fetcher := blockingSuccessFetcher{
+		started:  started,
+		blocker:  blocker,
+		content:  "background-value",
+		cacheTag: "v1",
+	}
+
+	require.NoError(t, cache.ScheduleRefresh(context.Background(), key, fetcher))
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background refresh did not start")
+	}
+	close(blocker)
+
+	select {
+	case <-top.closeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background refresh did not reach top-tier close")
+	}
+
+	newer, err := cache.Set(context.Background(), key, &daramjwee.Metadata{CacheTag: "user-v2"})
+	require.NoError(t, err)
+	_, err = newer.Write([]byte("user-value"))
+	require.NoError(t, err)
+	require.NoError(t, newer.Close())
+
+	require.Eventually(t, func() bool {
+		reader, meta, err := top.GetStream(context.Background(), key)
+		if err != nil {
+			return false
+		}
+		defer reader.Close()
+		current, err := io.ReadAll(reader)
+		if err != nil {
+			return false
+		}
+		return string(current) == "user-value" && meta.CacheTag == "user-v2"
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
 type blockingFetcher struct {
 	started chan struct{}
 	blocker chan struct{}
@@ -209,6 +330,71 @@ func (f blockingFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metad
 	case <-f.blocker:
 		return nil, daramjwee.ErrCacheableNotFound
 	}
+}
+
+type blockingSuccessFetcher struct {
+	started  chan struct{}
+	blocker  chan struct{}
+	content  string
+	cacheTag string
+}
+
+func (f blockingSuccessFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	select {
+	case f.started <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-f.blocker:
+		return &daramjwee.FetchResult{
+			Body:     io.NopCloser(strings.NewReader(f.content)),
+			Metadata: &daramjwee.Metadata{CacheTag: f.cacheTag},
+		}, nil
+	}
+}
+
+type notifyingSlowSetStore struct {
+	*mockStore
+	closeStarted chan struct{}
+	delay        time.Duration
+}
+
+func newNotifyingSlowSetStore(delay time.Duration) *notifyingSlowSetStore {
+	return &notifyingSlowSetStore{
+		mockStore:    newMockStore(),
+		closeStarted: make(chan struct{}, 1),
+		delay:        delay,
+	}
+}
+
+func (s *notifyingSlowSetStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	sink, err := s.mockStore.BeginSet(ctx, key, metadata)
+	if err != nil {
+		return nil, err
+	}
+	return &notifyingSlowSetSink{
+		WriteSink:    sink,
+		closeStarted: s.closeStarted,
+		delay:        s.delay,
+	}, nil
+}
+
+type notifyingSlowSetSink struct {
+	daramjwee.WriteSink
+	closeStarted chan struct{}
+	delay        time.Duration
+}
+
+func (s *notifyingSlowSetSink) Close() error {
+	select {
+	case s.closeStarted <- struct{}{}:
+	default:
+	}
+	time.Sleep(s.delay)
+	return s.WriteSink.Close()
 }
 
 type failingRefreshFetcher struct {

--- a/tests/cache_regression_test.go
+++ b/tests/cache_regression_test.go
@@ -192,6 +192,95 @@ func TestScheduleRefresh_ContinuesAfterCallerContextCancel(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
+// Background refresh validation reuses the worker job context, so a fetch that
+// outlives OpTimeout but stays within WorkerTimeout must still publish.
+func TestScheduleRefresh_SlowFetchDoesNotInvalidateWithinWorkerTimeout(t *testing.T) {
+	hotInner := newMockStore()
+	hot := newContextAwareStatStore(hotInner)
+	key := "refresh-slow-fetch"
+	hotInner.setData(key, "old-value", &daramjwee.Metadata{
+		CacheTag: "v0",
+		CachedAt: time.Now().Add(-time.Hour),
+	})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(20*time.Millisecond),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(300*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	fetcher := &mockFetcher{
+		content:    "fresh-value",
+		etag:       "v1",
+		fetchDelay: 60 * time.Millisecond,
+	}
+
+	require.NoError(t, cache.ScheduleRefresh(context.Background(), key, fetcher))
+
+	require.Eventually(t, func() bool {
+		reader, meta, err := hot.GetStream(context.Background(), key)
+		if err != nil {
+			return false
+		}
+		defer reader.Close()
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			return false
+		}
+		return string(body) == "fresh-value" && meta.CacheTag == "v1"
+	}, time.Second, 10*time.Millisecond)
+}
+
+// Fanout validation shares the worker job context for the same reason: a slow
+// source copy should persist as long as the job itself has not timed out.
+func TestScheduleRefresh_FanoutSlowCopyDoesNotInvalidateWithinWorkerTimeout(t *testing.T) {
+	top := newContextAwareStatStore(newDelayedReadStore(newMockStore(), 60*time.Millisecond))
+	mid := newMockStore()
+	low := newMockStore()
+	key := "fanout-slow-copy"
+	low.setData(key, "lower-value", &daramjwee.Metadata{
+		CacheTag: "v1",
+		CachedAt: time.Now(),
+	})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, mid, low),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(20*time.Millisecond),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(300*time.Millisecond),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	require.Equal(t, "lower-value", string(body))
+	require.NoError(t, resp.Close())
+
+	require.Eventually(t, func() bool {
+		reader, meta, err := mid.GetStream(context.Background(), key)
+		if err != nil {
+			return false
+		}
+		defer reader.Close()
+		copied, err := io.ReadAll(reader)
+		if err != nil {
+			return false
+		}
+		return string(copied) == "lower-value" && meta.CacheTag == "v1"
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestScheduleRefresh_DoesNotOverwriteNewerTopEntry(t *testing.T) {
 	hot := newMockStore()
 
@@ -316,6 +405,74 @@ func TestScheduleRefresh_CloseWindowDoesNotOverwriteNewerSet(t *testing.T) {
 type blockingFetcher struct {
 	started chan struct{}
 	blocker chan struct{}
+}
+
+type delayedReadStore struct {
+	inner *mockStore
+	delay time.Duration
+}
+
+func newDelayedReadStore(inner *mockStore, delay time.Duration) *delayedReadStore {
+	return &delayedReadStore{inner: inner, delay: delay}
+}
+
+func (s *delayedReadStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	reader, meta, err := s.inner.GetStream(ctx, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &delayedReadCloser{ReadCloser: reader, delay: s.delay}, meta, nil
+}
+
+func (s *delayedReadStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return s.inner.BeginSet(ctx, key, metadata)
+}
+
+func (s *delayedReadStore) Delete(ctx context.Context, key string) error {
+	return s.inner.Delete(ctx, key)
+}
+
+func (s *delayedReadStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	return s.inner.Stat(ctx, key)
+}
+
+type delayedReadCloser struct {
+	io.ReadCloser
+	delay time.Duration
+}
+
+func (r *delayedReadCloser) Read(p []byte) (int, error) {
+	time.Sleep(r.delay)
+	return r.ReadCloser.Read(p)
+}
+
+type contextAwareStatStore struct {
+	inner daramjwee.Store
+}
+
+func newContextAwareStatStore(inner daramjwee.Store) *contextAwareStatStore {
+	return &contextAwareStatStore{inner: inner}
+}
+
+func (s *contextAwareStatStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	return s.inner.GetStream(ctx, key)
+}
+
+func (s *contextAwareStatStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return s.inner.BeginSet(ctx, key, metadata)
+}
+
+func (s *contextAwareStatStore) Delete(ctx context.Context, key string) error {
+	return s.inner.Delete(ctx, key)
+}
+
+func (s *contextAwareStatStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	return s.inner.Stat(ctx, key)
 }
 
 func (f blockingFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {

--- a/tests/pure_streaming_benchmark_test.go
+++ b/tests/pure_streaming_benchmark_test.go
@@ -58,6 +58,10 @@ func BenchmarkCacheGet_Miss_1MiB_PrebuiltFetcher_DirectSink(b *testing.B) {
 	benchmarkMissStreamThroughWithFixtures(b, bytes.Repeat([]byte("c"), benchmarkLargePayload), &benchmarkDirectSinkStore{}, benchmarkFetcherModePrebuilt)
 }
 
+func BenchmarkCacheGet_Miss_1MiB_PrebuiltFetcher_AsyncFanoutTwoTiers(b *testing.B) {
+	benchmarkMissStreamThroughWithFanout(b, benchmarkLargePayload, 2)
+}
+
 func BenchmarkCacheGet_MissPartialReadAbort(b *testing.B) {
 	hot := newMockStore()
 	payload := strings.Repeat("p", benchmarkLargePayload)
@@ -322,6 +326,44 @@ func benchmarkMissStreamThroughWithFixtures(b *testing.B, payload []byte, hot da
 	}
 }
 
+func benchmarkMissStreamThroughWithFanout(b *testing.B, payloadSize int, fanoutTiers int) {
+	hot := newMockStore()
+	payload := bytes.Repeat([]byte("f"), payloadSize)
+
+	tiers := make([]daramjwee.Store, 0, fanoutTiers+1)
+	tiers = append(tiers, hot)
+	for i := 0; i < fanoutTiers; i++ {
+		tiers = append(tiers, &benchmarkDirectSinkStore{id: i + 1})
+	}
+
+	cache := mustNewBenchmarkCache(
+		b,
+		daramjwee.WithTiers(tiers...),
+		daramjwee.WithWorkers(fanoutTiers),
+		daramjwee.WithWorkerQueue(fanoutTiers*4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	fetcher := &benchmarkBytesFetcher{body: payload, etag: "v1"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		key := benchmarkKey("miss-fanout", i)
+		stream, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, fetcher)
+		if err != nil {
+			b.Fatalf("get: %v", err)
+		}
+		if _, err := io.Copy(io.Discard, stream); err != nil {
+			b.Fatalf("copy: %v", err)
+		}
+		if err := stream.Close(); err != nil {
+			b.Fatalf("close: %v", err)
+		}
+	}
+}
+
 func mustNewBenchmarkCache(b *testing.B, opts ...daramjwee.Option) daramjwee.Cache {
 	b.Helper()
 
@@ -382,7 +424,9 @@ func (f *benchmarkBytesFetcher) Fetch(ctx context.Context, oldMetadata *daramjwe
 	}, nil
 }
 
-type benchmarkDirectSinkStore struct{}
+type benchmarkDirectSinkStore struct {
+	id int
+}
 
 func (s *benchmarkDirectSinkStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
 	return nil, nil, daramjwee.ErrNotFound

--- a/tests/pure_streaming_integration_test.go
+++ b/tests/pure_streaming_integration_test.go
@@ -162,6 +162,36 @@ func TestCache_PartialMissReadCloseDoesNotPublishToHot(t *testing.T) {
 	assert.ErrorIs(t, err, daramjwee.ErrNotFound)
 }
 
+func TestCache_MissContextCancellationMidStreamDoesNotPublishPartialEntry(t *testing.T) {
+	hot := newMockStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	fetcher := &contextBoundFetcher{
+		body:     bytes.Repeat([]byte("c"), 32*1024),
+		metadata: &daramjwee.Metadata{CacheTag: "v1"},
+	}
+
+	cache, err := daramjwee.New(nil, daramjwee.WithTiers(hot), daramjwee.WithOpTimeout(2*time.Second))
+	require.NoError(t, err)
+	defer cache.Close()
+
+	stream, err := cache.Get(ctx, "cancelled-miss-key", daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+
+	buf := make([]byte, 4096)
+	n, err := io.ReadFull(stream, buf)
+	require.NoError(t, err)
+	require.Equal(t, len(buf), n)
+
+	cancel()
+
+	_, err = io.ReadAll(stream)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NoError(t, stream.Close())
+
+	_, _, err = hot.GetStream(context.Background(), "cancelled-miss-key")
+	assert.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
 func TestCache_PartialColdHitReadCloseDoesNotPublishToHot(t *testing.T) {
 	hot := newMockStore()
 	cold := newMockStore()

--- a/tests/race_test.go
+++ b/tests/race_test.go
@@ -2,7 +2,9 @@ package daramjwee_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -205,6 +207,82 @@ func TestConcurrentMixedOperations(t *testing.T) {
 	}
 }
 
+func TestConcurrentStaleLowerTierHitsDoNotPublishPartialTopOnRefreshFailure(t *testing.T) {
+	top := newMockStore()
+	lower := newMockStore()
+	key := "stale-lower-refresh-failure"
+	lower.setData(key, "stale-value", &daramjwee.Metadata{
+		CacheTag: "v0",
+		CachedAt: time.Now().Add(-time.Hour),
+	})
+
+	cache, err := daramjwee.New(
+		log.NewNopLogger(),
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFreshness(time.Millisecond, 0),
+		daramjwee.WithWorkers(4),
+		daramjwee.WithWorkerQueue(64),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create cache: %v", err)
+	}
+	defer cache.Close()
+
+	fetcher := &concurrentFailingRefreshFetcher{
+		contentPrefix: []byte("new-"),
+		err:           errors.New("midstream refresh failure"),
+	}
+
+	const numGoroutines = 32
+	var wg sync.WaitGroup
+	readErrors := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, fetcher)
+			if err != nil {
+				readErrors <- err
+				return
+			}
+			defer resp.Close()
+
+			body, err := io.ReadAll(resp)
+			if err != nil {
+				readErrors <- err
+				return
+			}
+			if resp.Status != daramjwee.GetStatusOK {
+				readErrors <- fmt.Errorf("unexpected status: %s", resp.Status)
+				return
+			}
+			if string(body) != "stale-value" {
+				readErrors <- fmt.Errorf("unexpected body: %q", string(body))
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(readErrors)
+	for err := range readErrors {
+		t.Error(err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	_, _, err = top.GetStream(context.Background(), key)
+	if !errors.Is(err, daramjwee.ErrNotFound) {
+		t.Fatalf("expected top tier to remain empty after failed refreshes, got %v", err)
+	}
+	if fetcher.getFetchCount() == 0 {
+		t.Fatal("expected at least one background refresh attempt")
+	}
+}
+
 // BenchmarkConcurrentAccess benchmarks concurrent cache operations
 func BenchmarkConcurrentAccess(b *testing.B) {
 	baseCache, err := createTestCacheForRace()
@@ -237,4 +315,28 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 			i++
 		}
 	})
+}
+
+type concurrentFailingRefreshFetcher struct {
+	mu            sync.Mutex
+	fetchCount    int
+	contentPrefix []byte
+	err           error
+}
+
+func (f *concurrentFailingRefreshFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	f.mu.Lock()
+	f.fetchCount++
+	f.mu.Unlock()
+
+	return &daramjwee.FetchResult{
+		Body:     newFailingReadCloser(f.contentPrefix, f.err),
+		Metadata: &daramjwee.Metadata{CacheTag: "v1"},
+	}, nil
+}
+
+func (f *concurrentFailingRefreshFetcher) getFetchCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.fetchCount
 }

--- a/tests/race_test.go
+++ b/tests/race_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +28,13 @@ func createTestCacheForRace() (daramjwee.Cache, error) {
 		daramjwee.WithOpTimeout(10*time.Second),
 		daramjwee.WithFreshness(1*time.Minute, 0),
 	)
+}
+
+func isAllowedConcurrentSetError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "top-tier write invalidated")
 }
 
 // TestConcurrentAccess tests the actual production code for race conditions
@@ -70,7 +78,7 @@ func TestConcurrentAccess(t *testing.T) {
 					// Set
 					value := fmt.Sprintf("set-value-%d-%d", id, j)
 					err := stringCache.Set(ctx, key, value, &daramjwee.Metadata{CacheTag: "test"})
-					if err != nil {
+					if err != nil && !isAllowedConcurrentSetError(err) {
 						errors <- fmt.Errorf("goroutine %d: Set failed: %v", id, err)
 					}
 				}
@@ -175,7 +183,7 @@ func TestConcurrentMixedOperations(t *testing.T) {
 				case 1: // Set
 					value := fmt.Sprintf("set-%d-%d", id, j)
 					err := stringCache.Set(ctx, key, value, &daramjwee.Metadata{CacheTag: "test"})
-					if err != nil {
+					if err != nil && !isAllowedConcurrentSetError(err) {
 						errors <- fmt.Errorf("goroutine %d: Set failed: %v", id, err)
 					}
 

--- a/tests/tiering_integration_test.go
+++ b/tests/tiering_integration_test.go
@@ -2,6 +2,7 @@ package daramjwee_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -346,6 +347,57 @@ func TestCache_LowerTierConditionalHitPromotesFreshEntryToTop(t *testing.T) {
 	assert.Equal(t, "cached-value", string(body))
 	assert.Equal(t, "cache-v1", meta.CacheTag)
 	assert.Equal(t, cachedAt.UnixNano(), meta.CachedAt.UnixNano())
+}
+
+func TestCache_LowerTierConditionalStaleHitReturnsNotModifiedAndPromotesFallbackOnNotModified(t *testing.T) {
+	top := newMockStore()
+	lower := newMockStore()
+	oldCachedAt := time.Now().Add(-time.Hour)
+	lower.setData("conditional-stale-lower-key", "stale-value", &daramjwee.Metadata{
+		CacheTag: "cache-v1",
+		CachedAt: oldCachedAt,
+	})
+	fetcher := &mockFetcher{err: daramjwee.ErrNotModified}
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithFreshness(time.Second, time.Second),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "conditional-stale-lower-key", daramjwee.GetRequest{IfNoneMatch: "cache-v1"}, fetcher)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, daramjwee.GetStatusNotModified, resp.Status)
+	require.Nil(t, resp.Body)
+	assert.Equal(t, "cache-v1", resp.Metadata.CacheTag)
+
+	require.Eventually(t, func() bool {
+		reader, meta, err := top.GetStream(context.Background(), "conditional-stale-lower-key")
+		if err != nil {
+			return false
+		}
+		defer reader.Close()
+
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			return false
+		}
+		return string(body) == "stale-value" && meta.CacheTag == "cache-v1" && meta.CachedAt.After(oldCachedAt)
+	}, 2*time.Second, 10*time.Millisecond)
+
+	fetchCount := fetcher.getFetchCount()
+	resp, err = cache.Get(context.Background(), "conditional-stale-lower-key", daramjwee.GetRequest{IfNoneMatch: "cache-v1"}, fetcher)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, daramjwee.GetStatusNotModified, resp.Status)
+	require.Nil(t, resp.Body)
+
+	time.Sleep(150 * time.Millisecond)
+	assert.Equal(t, fetchCount, fetcher.getFetchCount())
 }
 
 func TestCache_LowerTierNegativeStaleHitNotModifiedPromotesNegativeToTop(t *testing.T) {
@@ -961,6 +1013,243 @@ func TestCache_DeleteRemovesFromAllOrderedTiers(t *testing.T) {
 	require.ErrorIs(t, err, daramjwee.ErrNotFound)
 }
 
+func TestCache_DeleteDoesNotAllowBackgroundPersistToResurrectLowerTier(t *testing.T) {
+	top := newMockStore()
+	lower := newBlockingCloseStore()
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	key := "delete-race-lower-resurrection"
+	fetcher := &mockFetcher{content: "fresh-value", etag: "v1"}
+
+	resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	require.Equal(t, "fresh-value", string(body))
+	require.NoError(t, resp.Close())
+
+	select {
+	case <-lower.closeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background persist did not reach lower-tier publish")
+	}
+
+	require.NoError(t, cache.Delete(context.Background(), key))
+	close(lower.unblockClose)
+
+	require.Eventually(t, func() bool {
+		_, _, topErr := top.GetStream(context.Background(), key)
+		_, _, lowerErr := lower.GetStream(context.Background(), key)
+		return errors.Is(topErr, daramjwee.ErrNotFound) && errors.Is(lowerErr, daramjwee.ErrNotFound)
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestCache_DeleteCleanupDoesNotRemoveRecreatedLowerTierValue(t *testing.T) {
+	top := newMockStore()
+	lower := newPostCloseBlockingStore()
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	key := "delete-cleanup-recreate"
+	fetcher := &mockFetcher{content: "fresh-value", etag: "v1"}
+
+	resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	_, err = io.ReadAll(resp)
+	require.NoError(t, err)
+	require.NoError(t, resp.Close())
+
+	select {
+	case <-lower.closeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background persist did not reach lower-tier publish")
+	}
+
+	require.NoError(t, cache.Delete(context.Background(), key))
+	close(lower.releaseWrite)
+	close(lower.releaseReturn)
+
+	select {
+	case <-lower.statBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup path did not reach lower-tier stat")
+	}
+
+	lower.setData(key, "recreated-value", &daramjwee.Metadata{
+		CacheTag: "v2",
+		CachedAt: time.Now(),
+	})
+	close(lower.blockStat)
+
+	require.Eventually(t, func() bool {
+		reader, meta, err := lower.GetStream(context.Background(), key)
+		if err != nil {
+			return false
+		}
+		defer reader.Close()
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			return false
+		}
+		return string(body) == "recreated-value" && meta.CacheTag == "v2"
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestCache_DeleteDoesNotAllowFallbackPromotionAfterNotModifiedRefresh(t *testing.T) {
+	top := newBlockingCloseStore()
+	lower := newMockStore()
+	key := "delete-race-fallback-promotion"
+	lower.setData(key, "stale-value", &daramjwee.Metadata{
+		CacheTag: "v0",
+		CachedAt: time.Now().Add(-time.Hour),
+	})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFreshness(time.Millisecond, 0),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	fetcher := &mockFetcher{err: daramjwee.ErrNotModified}
+
+	resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	require.Equal(t, "stale-value", string(body))
+	require.NoError(t, resp.Close())
+
+	select {
+	case <-top.closeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fallback promotion did not reach top-tier publish")
+	}
+
+	require.NoError(t, cache.Delete(context.Background(), key))
+	close(top.unblockClose)
+
+	require.Eventually(t, func() bool {
+		_, _, topErr := top.GetStream(context.Background(), key)
+		return errors.Is(topErr, daramjwee.ErrNotFound)
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestCache_DeleteDoesNotAllowTopMetadataRefreshAfterNotModified(t *testing.T) {
+	tier := newBlockingCloseStore()
+	key := "delete-race-top-refresh"
+	tier.setData(key, "stale-value", &daramjwee.Metadata{
+		CacheTag: "v0",
+		CachedAt: time.Now().Add(-time.Hour),
+	})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(tier),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFreshness(time.Millisecond, 0),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	fetcher := &mockFetcher{err: daramjwee.ErrNotModified}
+
+	resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{IfNoneMatch: `"v0"`}, fetcher)
+	require.NoError(t, err)
+	require.Equal(t, daramjwee.GetStatusNotModified, resp.Status)
+
+	select {
+	case <-tier.closeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("top-tier metadata refresh did not reach publish")
+	}
+
+	require.NoError(t, cache.Delete(context.Background(), key))
+	close(tier.unblockClose)
+
+	require.Eventually(t, func() bool {
+		_, _, err := tier.GetStream(context.Background(), key)
+		return errors.Is(err, daramjwee.ErrNotFound)
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestCache_DeleteDoesNotAllowNegativeRefreshAfterOwnershipCheck(t *testing.T) {
+	tier := newBlockingBeginSetStore()
+	key := "delete-race-negative-refresh-beginset"
+	tier.setData(key, "stale-value", &daramjwee.Metadata{
+		CacheTag: "v0",
+		CachedAt: time.Now().Add(-time.Hour),
+	})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(tier),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFreshness(time.Millisecond, 0),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	fetcher := &mockFetcher{err: daramjwee.ErrCacheableNotFound}
+
+	resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	require.Equal(t, "stale-value", string(body))
+	require.NoError(t, resp.Close())
+
+	select {
+	case <-tier.beginSetStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("negative refresh did not reach top-tier BeginSet")
+	}
+
+	require.NoError(t, cache.Delete(context.Background(), key))
+	close(tier.unblockBeginSet)
+	select {
+	case <-tier.beginSetDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("negative refresh did not finish BeginSet after delete")
+	}
+
+	require.Eventually(t, func() bool {
+		_, _, err := tier.GetStream(context.Background(), key)
+		return errors.Is(err, daramjwee.ErrNotFound)
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
 type slowSetStore struct {
 	*mockStore
 	delay time.Duration
@@ -988,5 +1277,141 @@ type slowSetSink struct {
 
 func (s *slowSetSink) Close() error {
 	time.Sleep(s.delay)
+	return s.WriteSink.Close()
+}
+
+type blockingCloseStore struct {
+	*mockStore
+	closeStarted chan struct{}
+	unblockClose chan struct{}
+}
+
+type blockingBeginSetStore struct {
+	*mockStore
+	beginSetStarted chan struct{}
+	beginSetDone    chan struct{}
+	unblockBeginSet chan struct{}
+}
+
+type postCloseBlockingStore struct {
+	*mockStore
+	closeStarted  chan struct{}
+	releaseWrite  chan struct{}
+	releaseReturn chan struct{}
+	blockStat     chan struct{}
+	statBlocked   chan struct{}
+}
+
+func newPostCloseBlockingStore() *postCloseBlockingStore {
+	return &postCloseBlockingStore{
+		mockStore:     newMockStore(),
+		closeStarted:  make(chan struct{}, 1),
+		releaseWrite:  make(chan struct{}),
+		releaseReturn: make(chan struct{}),
+		blockStat:     make(chan struct{}),
+		statBlocked:   make(chan struct{}, 1),
+	}
+}
+
+func (s *postCloseBlockingStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	sink, err := s.mockStore.BeginSet(ctx, key, metadata)
+	if err != nil {
+		return nil, err
+	}
+	return &postCloseBlockingSink{
+		WriteSink:     sink,
+		closeStarted:  s.closeStarted,
+		releaseWrite:  s.releaseWrite,
+		releaseReturn: s.releaseReturn,
+	}, nil
+}
+
+func (s *postCloseBlockingStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	if s.blockStat != nil {
+		select {
+		case s.statBlocked <- struct{}{}:
+		default:
+		}
+		<-s.blockStat
+		s.blockStat = nil
+	}
+	return s.mockStore.Stat(ctx, key)
+}
+
+type postCloseBlockingSink struct {
+	daramjwee.WriteSink
+	closeStarted  chan struct{}
+	releaseWrite  chan struct{}
+	releaseReturn chan struct{}
+}
+
+func (s *postCloseBlockingSink) Close() error {
+	select {
+	case s.closeStarted <- struct{}{}:
+	default:
+	}
+	<-s.releaseWrite
+	if err := s.WriteSink.Close(); err != nil {
+		return err
+	}
+	<-s.releaseReturn
+	return nil
+}
+
+func newBlockingCloseStore() *blockingCloseStore {
+	return &blockingCloseStore{
+		mockStore:    newMockStore(),
+		closeStarted: make(chan struct{}, 1),
+		unblockClose: make(chan struct{}),
+	}
+}
+
+func newBlockingBeginSetStore() *blockingBeginSetStore {
+	return &blockingBeginSetStore{
+		mockStore:       newMockStore(),
+		beginSetStarted: make(chan struct{}, 1),
+		beginSetDone:    make(chan struct{}, 1),
+		unblockBeginSet: make(chan struct{}),
+	}
+}
+
+func (s *blockingCloseStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	sink, err := s.mockStore.BeginSet(ctx, key, metadata)
+	if err != nil {
+		return nil, err
+	}
+	return &blockingCloseSink{
+		WriteSink:    sink,
+		closeStarted: s.closeStarted,
+		unblockClose: s.unblockClose,
+	}, nil
+}
+
+func (s *blockingBeginSetStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	select {
+	case s.beginSetStarted <- struct{}{}:
+	default:
+	}
+	<-s.unblockBeginSet
+	sink, err := s.mockStore.BeginSet(ctx, key, metadata)
+	select {
+	case s.beginSetDone <- struct{}{}:
+	default:
+	}
+	return sink, err
+}
+
+type blockingCloseSink struct {
+	daramjwee.WriteSink
+	closeStarted chan struct{}
+	unblockClose chan struct{}
+}
+
+func (s *blockingCloseSink) Close() error {
+	select {
+	case s.closeStarted <- struct{}{}:
+	default:
+	}
+	<-s.unblockClose
 	return s.WriteSink.Close()
 }


### PR DESCRIPTION
## What changed
- hardened top-tier refresh, negative refresh, and lower-tier fanout paths so stale background work cannot overwrite newer writes or resurrect deleted entries
- serialized top-tier commit arbitration with per-key generation checks while adding bounded cleanup for idle arbitration state
- tightened memstore and streaming close/abort concurrency handling and added broader regression, race, fuzz, and benchmark coverage
- restored safe read-before-write behavior for top-tier `304` refreshes so destructive `BeginSet` stores do not corrupt the source read

## Why
Recent review and race work surfaced several TOCTOU and concurrent publish hazards:
- stale refresh and fallback promotion could clobber newer top-tier writes
- delete could race with background negative refresh or lower-tier fanout and reintroduce data
- top-tier metadata refresh assumed non-destructive `BeginSet` semantics
- test coverage was missing for several of these timing windows

## Impact
- cache refresh and fanout behavior is more robust under concurrent set/delete/refresh activity
- race and fuzz coverage is materially stronger for cache tag matching, metadata round-trip, streaming close behavior, and multi-tier delete/persist windows
- benchmark coverage now includes refresh and async fanout cases used while iterating on the fixes

## Validation
- `go test ./...`
- `go test -race ./...`
- targeted regression runs for delete/refresh races and destructive `BeginSet` refresh behavior
- benchmark spot checks for refresh, stream-through, and miss/fanout paths
