### PR TITLE
Add optional packed whole-object read cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 *   **Background jobs now preserve request-scoped values without inheriting request cancellation**: refresh and persist work keep caller context values available to context-sensitive stores and fetchers, while still running under worker-managed deadlines.
 *   **Invalidated fanout cleanup regained best-effort semantics**: destination-tier cleanup after generation invalidation now runs under a fresh timeout context again, so worker shutdown or timeout races do not leave stale persisted objects behind.
 *   **Constructor and helper regressions are pinned by direct tests**: response/cancel wrappers, lower-tier promotion cleanup, objectstore init failures, and internal block/page/segment caches now have explicit regression coverage.
+*   **Objectstore can now reuse optional local whole-object files for packed remote reads**: when block cache is disabled, packed remote reads can populate a bounded ephemeral local file cache that only publishes after a full successful read and close.
 
 ### ✅ Verification
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ Recommended starting points:
   - Local ingest/catalog workspace for the backend.
 - `WithBlockCache(...)`
   - In-process payload block cache for packed remote reads.
+- `WithPackedWholeObjectCache(...)`
+  - Optional local file cache for packed remote reads when block cache is disabled.
+  - Publishes only after a full successful read+close and does not become a persistent local tier.
 - `WithCheckpointCache(...)`
   - In-process metadata cache for decoded shard checkpoints such as `latest.json`.
 - `WithCheckpointTTL(...)`

--- a/pkg/store/objectstore/README.md
+++ b/pkg/store/objectstore/README.md
@@ -140,6 +140,23 @@ Recommended starting values:
 - `32 MiB` when `FileStore` is already in front
 - `64 MiB ~ 128 MiB` when `objectstore` serves more remote hits directly
 
+### `WithPackedWholeObjectCache(capacityBytes int64)`
+
+Enables an optional local whole-object file cache for packed remote reads when block cache is disabled.
+
+Properties:
+
+- first read still streams directly from remote storage
+- the local cache entry is published only after the reader reaches EOF and `Close()` succeeds
+- partial reads or interrupted materialization are discarded
+- cached files are local-process best-effort reuse, not durable published entries
+- restart persistence is not guaranteed; old cache files are cleaned up on next initialization
+
+Recommended starting values:
+
+- `32 MiB ~ 128 MiB` when block cache is intentionally disabled but packed remote reuse still matters
+- keep this disabled when `FileStore` already provides the desired whole-object local tier
+
 ### `WithCheckpointCache(capacityBytes int64)`
 
 Enables an in-process cache for decoded shard checkpoints such as `checkpoints/<shard>/latest.json`.

--- a/pkg/store/objectstore/benchmark_test.go
+++ b/pkg/store/objectstore/benchmark_test.go
@@ -58,6 +58,23 @@ func BenchmarkStore_ReadRemotePackedWarmConcurrentSameKey(b *testing.B) {
 	benchmarkReadAllParallel(b, store, "bench-key")
 }
 
+func BenchmarkStore_ReadRemotePackedWholeObjectCacheCold(b *testing.B) {
+	store := benchmarkRemotePackedStoreWithWholeObjectCache(b)
+	benchmarkReadAll(b, store, "bench-key")
+}
+
+func BenchmarkStore_ReadRemotePackedWholeObjectCacheWarm(b *testing.B) {
+	store := benchmarkRemotePackedStoreWithWholeObjectCache(b)
+	warmWholeObjectCache(b, store)
+	benchmarkReadAll(b, store, "bench-key")
+}
+
+func BenchmarkStore_ReadRemotePackedWholeObjectCacheWarmConcurrentSameKey(b *testing.B) {
+	store := benchmarkRemotePackedStoreWithWholeObjectCache(b)
+	warmWholeObjectCache(b, store)
+	benchmarkReadAllParallel(b, store, "bench-key")
+}
+
 func benchmarkLocalPublishedStore(b *testing.B) *Store {
 	store := New(objstore.NewInMemBucket(), log.NewNopLogger(),
 		WithPackThreshold(1<<20),
@@ -116,6 +133,52 @@ func benchmarkRemotePackedStore(b *testing.B, enableCache bool) *Store {
 	remote := New(bucket, log.NewNopLogger(), remoteOpts...)
 	remote.autoFlush = false
 	return remote
+}
+
+func benchmarkRemotePackedStoreWithWholeObjectCache(b *testing.B) *Store {
+	bucket := objstore.NewInMemBucket()
+	store := New(bucket, log.NewNopLogger(),
+		WithPackThreshold(1<<20),
+		WithPageSize(32<<10),
+		WithDir(b.TempDir()),
+	)
+	store.autoFlush = false
+	writer, err := store.BeginSet(context.Background(), "bench-key", &daramjwee.Metadata{CacheTag: "bench"})
+	if err != nil {
+		panic(err)
+	}
+	if _, err := writer.Write(bytes.Repeat([]byte("0123456789abcdef"), 1<<16)); err != nil {
+		panic(err)
+	}
+	if err := writer.Close(); err != nil {
+		panic(err)
+	}
+	if err := store.flushPending(context.Background()); err != nil {
+		panic(err)
+	}
+
+	remote := New(bucket, log.NewNopLogger(),
+		WithPackThreshold(1<<20),
+		WithPageSize(32<<10),
+		WithDir(b.TempDir()),
+		WithPackedWholeObjectCache(8<<20),
+	)
+	remote.autoFlush = false
+	return remote
+}
+
+func warmWholeObjectCache(b *testing.B, store *Store) {
+	b.Helper()
+	stream, _, err := store.GetStream(context.Background(), "bench-key")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := io.Copy(io.Discard, stream); err != nil {
+		b.Fatal(err)
+	}
+	if err := stream.Close(); err != nil {
+		b.Fatal(err)
+	}
 }
 
 func benchmarkReadAll(b *testing.B, store *Store, key string) {

--- a/pkg/store/objectstore/blockcache_test.go
+++ b/pkg/store/objectstore/blockcache_test.go
@@ -2,7 +2,10 @@ package objectstore
 
 import (
 	"context"
+	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -183,6 +186,195 @@ func TestStore_RemotePackedReadWithoutBlockCacheDoesNotCoalesceConcurrentReaders
 	assert.Greater(t, bucket.rangeCalls(), 1)
 }
 
+func TestStore_RemotePackedReadWithLocalWholeObjectCacheReusesLocalFileAfterWarmup(t *testing.T) {
+	ctx := context.Background()
+	bucket := &countingRangeBucket{Bucket: objstore.NewInMemBucket()}
+	seedRemotePackedStore(t, ctx, bucket, "local-whole-object-cache", strings.Repeat("m", 256))
+
+	store := New(bucket, log.NewNopLogger(),
+		WithDir(t.TempDir()),
+		WithPackThreshold(1024),
+		WithPageSize(64),
+		WithPackedWholeObjectCache(1<<20),
+	)
+	store.autoFlush = false
+
+	body := readAllStoreKey(t, ctx, store, "local-whole-object-cache")
+	require.Equal(t, strings.Repeat("m", 256), body)
+	require.Equal(t, 1, bucket.rangeCalls())
+
+	body = readAllStoreKey(t, ctx, store, "local-whole-object-cache")
+	require.Equal(t, strings.Repeat("m", 256), body)
+	assert.Equal(t, 1, bucket.rangeCalls())
+}
+
+func TestStore_RemotePackedReadWithLocalWholeObjectCacheDiscardsPartialRead(t *testing.T) {
+	ctx := context.Background()
+	bucket := &countingRangeBucket{Bucket: objstore.NewInMemBucket()}
+	seedRemotePackedStore(t, ctx, bucket, "local-whole-object-partial", strings.Repeat("p", 256))
+
+	store := New(bucket, log.NewNopLogger(),
+		WithDir(t.TempDir()),
+		WithPackThreshold(1024),
+		WithPageSize(64),
+		WithPackedWholeObjectCache(1<<20),
+	)
+	store.autoFlush = false
+
+	stream, _, err := store.GetStream(ctx, "local-whole-object-partial")
+	require.NoError(t, err)
+	buf := make([]byte, 64)
+	n, err := stream.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 64, n)
+	require.NoError(t, stream.Close())
+	require.Equal(t, 1, bucket.rangeCalls())
+
+	body := readAllStoreKey(t, ctx, store, "local-whole-object-partial")
+	require.Equal(t, strings.Repeat("p", 256), body)
+	assert.Equal(t, 2, bucket.rangeCalls())
+}
+
+func TestStore_RemotePackedReadWithLocalWholeObjectCacheEvictsOldEntries(t *testing.T) {
+	ctx := context.Background()
+	bucket := &countingRangeBucket{Bucket: objstore.NewInMemBucket()}
+	seedRemotePackedStore(t, ctx, bucket, "local-whole-object-evict-a", strings.Repeat("a", 256))
+	seedRemotePackedStore(t, ctx, bucket, "local-whole-object-evict-b", strings.Repeat("b", 256))
+
+	store := New(bucket, log.NewNopLogger(),
+		WithDir(t.TempDir()),
+		WithPackThreshold(1024),
+		WithPageSize(64),
+		WithPackedWholeObjectCache(300),
+	)
+	store.autoFlush = false
+
+	readAllStoreKey(t, ctx, store, "local-whole-object-evict-a")
+	require.Equal(t, 1, bucket.rangeCalls())
+
+	readAllStoreKey(t, ctx, store, "local-whole-object-evict-b")
+	require.Equal(t, 2, bucket.rangeCalls())
+
+	readAllStoreKey(t, ctx, store, "local-whole-object-evict-a")
+	assert.Equal(t, 3, bucket.rangeCalls())
+}
+
+func TestStore_RemotePackedReadWithLocalWholeObjectCacheIsNoOpWhenBlockCacheEnabled(t *testing.T) {
+	ctx := context.Background()
+	bucket := &countingRangeBucket{Bucket: objstore.NewInMemBucket()}
+	seedRemotePackedStore(t, ctx, bucket, "whole-object-cache-noop", strings.Repeat("n", 256))
+
+	store := New(bucket, log.NewNopLogger(),
+		WithDir(t.TempDir()),
+		WithPackThreshold(1024),
+		WithPageSize(64),
+		WithBlockCache(1<<20),
+		WithPackedWholeObjectCache(1<<20),
+	)
+	store.autoFlush = false
+
+	readAllStoreKey(t, ctx, store, "whole-object-cache-noop")
+	firstReads := bucket.rangeCalls()
+	require.Greater(t, firstReads, 0)
+	require.Equal(t, 0, countReadCacheFiles(t, store))
+
+	readAllStoreKey(t, ctx, store, "whole-object-cache-noop")
+	assert.Equal(t, firstReads, bucket.rangeCalls())
+	assert.Equal(t, 0, countReadCacheFiles(t, store))
+}
+
+func TestStore_RemotePackedReadWithLocalWholeObjectCacheDiscardsTempFileOnReadError(t *testing.T) {
+	ctx := context.Background()
+	bucket := &faultyRangeBucket{
+		Bucket:    objstore.NewInMemBucket(),
+		failAfter: 64,
+		readErr:   errors.New("boom"),
+		failReads: 1,
+	}
+	seedRemotePackedStore(t, ctx, bucket, "local-whole-object-read-error", strings.Repeat("r", 256))
+
+	store := New(bucket, log.NewNopLogger(),
+		WithDir(t.TempDir()),
+		WithPackThreshold(1024),
+		WithPageSize(64),
+		WithPackedWholeObjectCache(1<<20),
+	)
+	store.autoFlush = false
+
+	stream, _, err := store.GetStream(ctx, "local-whole-object-read-error")
+	require.NoError(t, err)
+	_, err = io.ReadAll(stream)
+	require.EqualError(t, err, "boom")
+	require.NoError(t, stream.Close())
+	require.Equal(t, 0, countReadCacheFiles(t, store))
+
+	body := readAllStoreKey(t, ctx, store, "local-whole-object-read-error")
+	require.Equal(t, strings.Repeat("r", 256), body)
+	assert.Equal(t, 2, bucket.rangeCalls())
+	assert.Equal(t, 1, countReadCacheFiles(t, store))
+}
+
+func TestStore_RemotePackedReadWithLocalWholeObjectCacheDiscardsTempFileOnCloseError(t *testing.T) {
+	ctx := context.Background()
+	bucket := &faultyRangeBucket{
+		Bucket:    objstore.NewInMemBucket(),
+		closeErr:  errors.New("close boom"),
+		failClose: 1,
+	}
+	seedRemotePackedStore(t, ctx, bucket, "local-whole-object-close-error", strings.Repeat("c", 256))
+
+	store := New(bucket, log.NewNopLogger(),
+		WithDir(t.TempDir()),
+		WithPackThreshold(1024),
+		WithPageSize(64),
+		WithPackedWholeObjectCache(1<<20),
+	)
+	store.autoFlush = false
+
+	stream, _, err := store.GetStream(ctx, "local-whole-object-close-error")
+	require.NoError(t, err)
+	body, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("c", 256), string(body))
+	require.EqualError(t, stream.Close(), "close boom")
+	require.Equal(t, 0, countReadCacheFiles(t, store))
+
+	warmBody := readAllStoreKey(t, ctx, store, "local-whole-object-close-error")
+	require.Equal(t, strings.Repeat("c", 256), warmBody)
+	assert.Equal(t, 2, bucket.rangeCalls())
+	assert.Equal(t, 1, countReadCacheFiles(t, store))
+}
+
+func TestStore_RemotePackedReadWithLocalWholeObjectCacheCleansReadCacheOnRestart(t *testing.T) {
+	ctx := context.Background()
+	bucket := &countingRangeBucket{Bucket: objstore.NewInMemBucket()}
+	seedRemotePackedStore(t, ctx, bucket, "local-whole-object-restart", strings.Repeat("s", 256))
+
+	dir := t.TempDir()
+	store := New(bucket, log.NewNopLogger(),
+		WithDir(dir),
+		WithPackThreshold(1024),
+		WithPageSize(64),
+		WithPackedWholeObjectCache(1<<20),
+	)
+	store.autoFlush = false
+
+	readAllStoreKey(t, ctx, store, "local-whole-object-restart")
+	require.Equal(t, 1, countReadCacheFiles(t, store))
+
+	restarted := New(bucket, log.NewNopLogger(),
+		WithDir(dir),
+		WithPackThreshold(1024),
+		WithPageSize(64),
+		WithPackedWholeObjectCache(1<<20),
+	)
+	restarted.autoFlush = false
+
+	require.Equal(t, 0, countReadCacheFiles(t, restarted))
+	body := readAllStoreKey(t, ctx, restarted, "local-whole-object-restart")
+	require.Equal(t, strings.Repeat("s", 256), body)
+}
+
 func seedRemotePackedStore(t *testing.T, ctx context.Context, bucket objstore.Bucket, key, body string) {
 	t.Helper()
 	store := New(bucket, log.NewNopLogger(),
@@ -236,4 +428,97 @@ func (b *countingRangeBucket) rangeCalls() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.reads
+}
+
+type faultyRangeBucket struct {
+	objstore.Bucket
+	mu        sync.Mutex
+	reads     int
+	failReads int
+	failAfter int
+	readErr   error
+	failClose int
+	closeErr  error
+}
+
+func (b *faultyRangeBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	reader, err := b.Bucket.GetRange(ctx, name, off, length)
+	if err != nil {
+		return nil, err
+	}
+
+	b.mu.Lock()
+	b.reads++
+	failRead := b.failReads > 0
+	if b.failReads > 0 {
+		b.failReads--
+	}
+	failClose := b.failClose > 0
+	if b.failClose > 0 {
+		b.failClose--
+	}
+	readErr := b.readErr
+	failAfter := b.failAfter
+	closeErr := b.closeErr
+	b.mu.Unlock()
+
+	if failRead || failClose {
+		return &faultyReadCloser{
+			reader:    reader,
+			failRead:  failRead,
+			failAfter: failAfter,
+			readErr:   readErr,
+			failClose: failClose,
+			closeErr:  closeErr,
+		}, nil
+	}
+	return reader, nil
+}
+
+func (b *faultyRangeBucket) rangeCalls() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.reads
+}
+
+type faultyReadCloser struct {
+	reader    io.ReadCloser
+	read      int
+	failRead  bool
+	failAfter int
+	readErr   error
+	failClose bool
+	closeErr  error
+}
+
+func (r *faultyReadCloser) Read(p []byte) (int, error) {
+	if r.failRead && r.read >= r.failAfter {
+		return 0, r.readErr
+	}
+
+	if r.failRead {
+		remaining := r.failAfter - r.read
+		if remaining > 0 && remaining < len(p) {
+			p = p[:remaining]
+		}
+	}
+
+	n, err := r.reader.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *faultyReadCloser) Close() error {
+	closeErr := r.reader.Close()
+	if r.failClose {
+		return r.closeErr
+	}
+	return closeErr
+}
+
+func countReadCacheFiles(t *testing.T, store *Store) int {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(store.dataDir, "readcache"))
+	require.NoError(t, err)
+	return len(entries)
 }

--- a/pkg/store/objectstore/options.go
+++ b/pkg/store/objectstore/options.go
@@ -5,16 +5,17 @@ import "time"
 type Option func(*config)
 
 type config struct {
-	dir                  string
-	prefix               string
-	gcGrace              time.Duration
-	packThreshold        int64
-	pagedThreshold       int64
-	pageSize             int64
-	pageCacheBytes       int64
-	blockCacheBytes      int64
-	checkpointCacheBytes int64
-	checkpointTTL        time.Duration
+	dir                   string
+	prefix                string
+	gcGrace               time.Duration
+	packThreshold         int64
+	pagedThreshold        int64
+	pageSize              int64
+	pageCacheBytes        int64
+	blockCacheBytes       int64
+	packedWholeCacheBytes int64
+	checkpointCacheBytes  int64
+	checkpointTTL         time.Duration
 }
 
 // WithDir configures the local objectstore working directory used for
@@ -77,6 +78,15 @@ func WithPageCache(capacityBytes int64) Option {
 func WithBlockCache(capacityBytes int64) Option {
 	return func(cfg *config) {
 		cfg.blockCacheBytes = capacityBytes
+	}
+}
+
+// WithPackedWholeObjectCache enables an optional local whole-object file cache
+// for packed remote reads when block cache is disabled. A non-positive capacity
+// disables the cache.
+func WithPackedWholeObjectCache(capacityBytes int64) Option {
+	return func(cfg *config) {
+		cfg.packedWholeCacheBytes = capacityBytes
 	}
 }
 

--- a/pkg/store/objectstore/packed_whole_cache.go
+++ b/pkg/store/objectstore/packed_whole_cache.go
@@ -1,0 +1,259 @@
+package objectstore
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/zeebo/xxh3"
+)
+
+type packedWholeObjectCache struct {
+	logger   log.Logger
+	root     string
+	capacity int64
+
+	mu      sync.Mutex
+	entries map[string]*packedWholeObjectCacheEntry
+	lru     *list.List
+	bytes   int64
+}
+
+type packedWholeObjectCacheEntry struct {
+	key            string
+	path           string
+	size           int64
+	refs           int
+	evicted        bool
+	evictOnRelease bool
+	lruElement     *list.Element
+}
+
+func newPackedWholeObjectCache(root string, capacity int64, logger log.Logger) (*packedWholeObjectCache, error) {
+	if capacity <= 0 {
+		return nil, nil
+	}
+	if err := os.RemoveAll(root); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, err
+	}
+	return &packedWholeObjectCache{
+		logger:   logger,
+		root:     root,
+		capacity: capacity,
+		entries:  make(map[string]*packedWholeObjectCacheEntry),
+		lru:      list.New(),
+	}, nil
+}
+
+func (c *packedWholeObjectCache) open(entry checkpointEntry) (io.ReadCloser, bool, error) {
+	if c == nil {
+		return nil, false, nil
+	}
+
+	key := c.cacheKey(entry)
+
+	c.mu.Lock()
+	cacheEntry, ok := c.entries[key]
+	if !ok || cacheEntry.evicted {
+		c.mu.Unlock()
+		return nil, false, nil
+	}
+	cacheEntry.refs++
+	c.lru.MoveToBack(cacheEntry.lruElement)
+	path := cacheEntry.path
+	c.mu.Unlock()
+
+	file, err := os.Open(path)
+	if err == nil {
+		return &fileSectionReadCloser{
+			Reader: file,
+			closeFn: func() error {
+				err := file.Close()
+				c.release(key)
+				return err
+			},
+		}, true, nil
+	}
+
+	c.releaseBrokenOpen(key, err)
+	if os.IsNotExist(err) {
+		return nil, false, nil
+	}
+	return nil, false, err
+}
+
+func (c *packedWholeObjectCache) wrapRemoteReader(entry checkpointEntry, reader io.ReadCloser) (io.ReadCloser, error) {
+	if c == nil {
+		return reader, nil
+	}
+
+	file, err := os.CreateTemp(c.root, "packed-whole-*.data")
+	if err != nil {
+		return reader, nil
+	}
+
+	return &packedWholeObjectCachingReader{
+		reader:       reader,
+		file:         file,
+		cache:        c,
+		cacheKey:     c.cacheKey(entry),
+		size:         entry.Length,
+		tempPath:     file.Name(),
+		cacheEnabled: true,
+	}, nil
+}
+
+func (c *packedWholeObjectCache) cacheKey(entry checkpointEntry) string {
+	identity := fmt.Sprintf("%s:%d:%d:%s", entry.SegmentPath, entry.Offset, entry.Length, entry.Metadata.CacheTag)
+	return fmt.Sprintf("%016x", xxh3.HashString(identity))
+}
+
+func (c *packedWholeObjectCache) publish(key, path string, size int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, ok := c.entries[key]; ok {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			level.Warn(c.logger).Log("msg", "failed to discard duplicate packed whole-object cache file", "path", path, "err", err)
+		}
+		return
+	}
+
+	entry := &packedWholeObjectCacheEntry{
+		key:  key,
+		path: path,
+		size: size,
+	}
+	entry.lruElement = c.lru.PushBack(entry)
+	c.entries[key] = entry
+	c.bytes += size
+	c.evictLocked()
+}
+
+func (c *packedWholeObjectCache) evictLocked() {
+	for c.bytes > c.capacity {
+		elem := c.lru.Front()
+		if elem == nil {
+			return
+		}
+		entry := elem.Value.(*packedWholeObjectCacheEntry)
+		if entry.refs > 0 {
+			entry.evicted = true
+			entry.evictOnRelease = true
+			c.lru.Remove(elem)
+			entry.lruElement = nil
+			continue
+		}
+		c.deleteEntryLocked(entry)
+	}
+}
+
+func (c *packedWholeObjectCache) release(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return
+	}
+	if entry.refs > 0 {
+		entry.refs--
+	}
+	if entry.refs == 0 && entry.evictOnRelease {
+		c.deleteEntryLocked(entry)
+	}
+}
+
+func (c *packedWholeObjectCache) releaseBrokenOpen(key string, openErr error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return
+	}
+	if entry.refs > 0 {
+		entry.refs--
+	}
+	if os.IsNotExist(openErr) {
+		c.deleteEntryLocked(entry)
+	}
+}
+
+func (c *packedWholeObjectCache) deleteEntryLocked(entry *packedWholeObjectCacheEntry) {
+	if entry == nil {
+		return
+	}
+	delete(c.entries, entry.key)
+	if entry.lruElement != nil {
+		c.lru.Remove(entry.lruElement)
+		entry.lruElement = nil
+	}
+	c.bytes -= entry.size
+	if c.bytes < 0 {
+		c.bytes = 0
+	}
+	if err := os.Remove(entry.path); err != nil && !os.IsNotExist(err) {
+		level.Warn(c.logger).Log("msg", "failed to delete packed whole-object cache file", "path", entry.path, "err", err)
+	}
+}
+
+type packedWholeObjectCachingReader struct {
+	reader       io.ReadCloser
+	file         *os.File
+	cache        *packedWholeObjectCache
+	cacheKey     string
+	size         int64
+	read         int64
+	tempPath     string
+	cacheEnabled bool
+	eof          bool
+
+	once sync.Once
+	err  error
+}
+
+func (r *packedWholeObjectCachingReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		r.read += int64(n)
+		if r.cacheEnabled {
+			if _, writeErr := r.file.Write(p[:n]); writeErr != nil {
+				r.cacheEnabled = false
+			}
+		}
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		r.cacheEnabled = false
+	}
+	if errors.Is(err, io.EOF) && r.read == r.size {
+		r.eof = true
+	}
+	return n, err
+}
+
+func (r *packedWholeObjectCachingReader) Close() error {
+	r.once.Do(func() {
+		closeErr := r.reader.Close()
+		fileErr := r.file.Close()
+		if closeErr == nil && fileErr == nil && r.cacheEnabled && r.eof && r.read == r.size {
+			r.cache.publish(r.cacheKey, r.tempPath, r.size)
+		} else if err := os.Remove(r.tempPath); err != nil && !os.IsNotExist(err) {
+			level.Warn(r.cache.logger).Log("msg", "failed to remove discarded packed whole-object cache file", "path", r.tempPath, "err", err)
+		}
+
+		r.err = closeErr
+		if r.err == nil {
+			r.err = fileErr
+		}
+	})
+	return r.err
+}

--- a/pkg/store/objectstore/reader.go
+++ b/pkg/store/objectstore/reader.go
@@ -76,12 +76,21 @@ func (s *Store) loadRemoteEntry(ctx context.Context, key string) (*checkpointEnt
 func (s *Store) openRemoteEntry(ctx context.Context, entry checkpointEntry) (io.ReadCloser, error) {
 	if s.isPackedRemotePath(entry.SegmentPath) {
 		if s.blockCache == nil {
+			if reader, ok, err := s.packedWholeCache.open(entry); err != nil {
+				return nil, err
+			} else if ok {
+				return reader, nil
+			}
+
 			reader, err := s.bucket.GetRange(ctx, entry.SegmentPath, entry.Offset, entry.Length)
 			if err != nil {
 				if s.bucket.IsObjNotFoundErr(err) {
 					return nil, daramjwee.ErrNotFound
 				}
 				return nil, err
+			}
+			if s.packedWholeCache != nil {
+				return s.packedWholeCache.wrapRemoteReader(entry, reader)
 			}
 			return reader, nil
 		}

--- a/pkg/store/objectstore/store.go
+++ b/pkg/store/objectstore/store.go
@@ -60,6 +60,7 @@ type Store struct {
 	pageSize          int64
 	blockCache        *blockcache.Cache
 	pageCache         *pagecache.Cache
+	packedWholeCache  *packedWholeObjectCache
 	checkpointCache   *checkpointCache
 	catalog           *internalcatalog.Catalog
 	lockManager       *keyLockManager
@@ -136,6 +137,9 @@ func New(bucket objstore.Bucket, logger log.Logger, opts ...Option) *Store {
 		openSegmentWriter: func(root, shard, segmentID string) (segmentWriter, error) {
 			return segment.Open(root, shard, segmentID)
 		},
+	}
+	if store.initErr == nil {
+		store.packedWholeCache, store.initErr = newPackedWholeObjectCache(filepath.Join(dataDir, "readcache"), cfg.packedWholeCacheBytes, logger)
 	}
 	store.checkpointCache = newCheckpointCache(cfg.checkpointCacheBytes, cfg.checkpointTTL, func() time.Time {
 		return store.now()


### PR DESCRIPTION
## Summary
- add `objectstore.WithPackedWholeObjectCache(...)` as an opt-in ephemeral local file cache for packed remote reads when block cache is disabled
- publish cached files only after a full successful read and close, keeping this path separate from catalog/published local entries
- add regression coverage for warm reuse, partial reads, read/close failures, block-cache no-op behavior, restart cleanup, and eviction, plus benchmark/documentation updates

## Why
Issue #37 follows up the direct-range optimization for no-cache packed reads. This change adds an optional same-process whole-object reuse path without turning `objectstore` into a persistent local read tier.

## Validation
- `go test ./pkg/store/objectstore`
- `go test -race ./pkg/store/objectstore`
- `go test ./...`
- `go test ./pkg/store/objectstore -run '^$' -bench 'BenchmarkStore_ReadRemotePacked(WholeObjectCache(Cold|Warm|WarmConcurrentSameKey)|Cold|Warm|ColdConcurrentSameKey|WarmConcurrentSameKey)$' -benchmem -cpu=1 -benchtime=1s -count=1`

## Notes
- the synthetic in-memory benchmark does not show a speedup over the direct-range baseline, so this remains opt-in only
- this is intended for same-process reuse only and does not promise restart-persistent local tier semantics

Closes #37
