### PR TITLE
add cache group example and doc updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 *   **Background jobs now preserve request-scoped values without inheriting request cancellation**: refresh and persist work keep caller context values available to context-sensitive stores and fetchers, while still running under worker-managed deadlines.
 *   **Invalidated fanout cleanup regained best-effort semantics**: destination-tier cleanup after generation invalidation now runs under a fresh timeout context again, so worker shutdown or timeout races do not leave stale persisted objects behind.
 *   **Constructor and helper regressions are pinned by direct tests**: response/cancel wrappers, lower-tier promotion cleanup, objectstore init failures, and internal block/page/segment caches now have explicit regression coverage.
+*   **New runnable `CacheGroup` example**: added a local example under `examples/cache_group` showing shared-runtime construction, per-cache weights, and mixed tier layouts without requiring external services.
 
 ### ✅ Verification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@
 ### ⚠️ Breaking Changes & API Updates
 
 *   **`DaramjweeCache` runtime fields are no longer part of the public surface**: the concrete cache type remains exported, but `Tiers`, `Worker`, logger state, timeout fields, and freshness fields are now internal implementation details instead of exported struct fields.
+*   **Cache construction now has a standalone/group split**: `New(...)` creates a self-contained cache with its own background runtime, while `NewGroup(...)` creates a `CacheGroup` whose caches share one bounded background runtime.
+*   **Group and cache runtime options are separated**: group construction uses the `WithGroup...` option surface, while group-attached caches use `WithWeight(...)` and `WithQueueLimit(...)` for per-cache runtime tuning. Standalone caches continue to use `WithWorkers(...)`, `WithWorkerQueue(...)`, `WithWorkerTimeout(...)`, and `WithWorkerStrategy(...)`.
 *   **Unknown worker strategies now fail fast**: `WithWorkerStrategy(...)` accepts only `"pool"` and `"all"`, and invalid values now return a configuration error instead of silently falling back to `"pool"`.
 *   **Objectstore tier initialization is now validated during `daramjwee.New(...)`**: misconfigured `objectstore` tiers fail cache construction immediately instead of deferring the failure until first store operation.
 
 ### 🧰 Migration Notes
 
 *   Stop reading or mutating runtime fields on `*DaramjweeCache` directly. Treat `daramjwee.New(...)` as the construction boundary and keep concrete cache state internal to the package.
+*   Use `daramjwee.New(...)` for a self-contained cache, or `daramjwee.NewGroup(...)` when several caches should share one bounded background runtime.
+*   Keep the option surfaces separate: `WithGroupWorkers(...)`, `WithGroupWorkerTimeout(...)`, `WithGroupWorkerQueueDefault(...)`, and `WithGroupCloseTimeout(...)` configure the group itself, while `WithWeight(...)` and `WithQueueLimit(...)` configure caches created from that group.
 *   Audit any custom configuration that relied on unknown worker strategy strings being accepted. Use `WithWorkerStrategy("pool")` or `WithWorkerStrategy("all")` explicitly.
 *   If you build `objectstore` tiers dynamically, expect `daramjwee.New(...)` to return initialization errors earlier when the local directory or other objectstore prerequisites are invalid.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 *   **Invalidated fanout cleanup regained best-effort semantics**: destination-tier cleanup after generation invalidation now runs under a fresh timeout context again, so worker shutdown or timeout races do not leave stale persisted objects behind.
 *   **Constructor and helper regressions are pinned by direct tests**: response/cancel wrappers, lower-tier promotion cleanup, objectstore init failures, and internal block/page/segment caches now have explicit regression coverage.
 *   **New runnable `CacheGroup` example**: added a local example under `examples/cache_group` showing shared-runtime construction, per-cache weights, and mixed tier layouts without requiring external services.
+*   **New runnable local objectstore examples**: added `examples/file_objstore_gcs_vind` and `examples/file_objstore_s3_vind` to smoke-test the ordered `FileStore -> objectstore` flow against local GCS and S3-compatible emulators on the `vcluster` Docker driver, and clarified that the older GCS examples target real cloud buckets.
 
 ### ✅ Verification
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A pragmatic and lightweight hybrid caching middleware for Go.
       * **`FileStore`**: Guarantees atomic writes by default using a "write-to-temp-then-rename" pattern to prevent data corruption. It also offers a copy-based alternative (`WithCopyWrite`) for compatibility with network filesystems, though this option is **not atomic and may leave orphan files on failure**, and it is not supported as a top-tier (tier 0) store due to limitations with the stream-through publish contract.
       * **`MemStore`**: A thread-safe, high-throughput in-memory store with fully integrated capacity-based eviction logic. Its performance is optimized using `sync.Pool` to reduce memory allocations under high concurrency.
       * **`objectstore`**: A first-party `Store` for `thanos-io/objstore` providers (S3, GCS, Azure Blob Storage). It is designed for cost-efficient durable caching, especially when object count and large-object read cost matter, while still fitting into the same ordered-tier cache model as the other backends. Its local `dataDir` is an ingest/catalog workspace, not a persistent local read-cache tier. If you want durable remote backing plus local file-cache hits, place `FileStore` ahead of `objectstore` in `WithTiers(...)`. In distributed deployments, concurrent writes to the same key are still last-writer-wins unless you coordinate writers externally.
+        Local emulator demos for the objectstore path now live under [`examples/file_objstore_gcs_vind`](./examples/file_objstore_gcs_vind) and [`examples/file_objstore_s3_vind`](./examples/file_objstore_s3_vind), while the older GCS examples remain real-cloud configuration examples.
 
   * **Advanced Eviction Policies (`EvictionPolicy`):**
 
@@ -290,6 +291,7 @@ defer group.Close()
 ```
 
 See [`examples/cache_group`](./examples/cache_group) for a runnable local demo.
+See [`examples/file_objstore_gcs_vind`](./examples/file_objstore_gcs_vind) and [`examples/file_objstore_s3_vind`](./examples/file_objstore_s3_vind) for runnable local objectstore demos on emulator-backed buckets.
 
 ## objectstore Configuration
 

--- a/README.md
+++ b/README.md
@@ -276,8 +276,6 @@ group, err := daramjwee.NewGroup(
 if err != nil {
     panic(err)
 }
-defer group.Close()
-
 users, err := group.NewCache(
     "users",
     daramjwee.WithTiers(memTier, fileTier),
@@ -288,6 +286,7 @@ if err != nil {
     panic(err)
 }
 defer users.Close()
+defer group.Close()
 ```
 
 See [`examples/cache_group`](./examples/cache_group) for a runnable local demo.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ worker lifecycle, shutdown behavior, and queue limits independently.
 background runtime for multiple caches. Call `group.NewCache(...)` to create
 cache instances that share that runtime while keeping their tier chains and
 cache-local policy separate. Each grouped cache still closes independently, and
-`group.Close()` shuts down the shared runtime after closing the created caches.
+`group.Close()` first shuts down the shared runtime under the group close
+timeout and then closes the created caches.
 
 Group construction uses the `WithGroup...` option surface:
 
@@ -263,6 +264,33 @@ Per-cache runtime tuning inside a group uses the regular cache options
 created from a `CacheGroup`; standalone `New(...)` construction keeps using the
 original cache-level worker options such as `WithWorkers(...)`,
 `WithWorkerQueue(...)`, `WithWorkerTimeout(...)`, and `WithWorkerStrategy(...)`.
+
+Minimal example:
+
+```go
+group, err := daramjwee.NewGroup(
+    logger,
+    daramjwee.WithGroupWorkers(2),
+    daramjwee.WithGroupWorkerQueueDefault(8),
+)
+if err != nil {
+    panic(err)
+}
+defer group.Close()
+
+users, err := group.NewCache(
+    "users",
+    daramjwee.WithTiers(memTier, fileTier),
+    daramjwee.WithWeight(4),
+    daramjwee.WithQueueLimit(16),
+)
+if err != nil {
+    panic(err)
+}
+defer users.Close()
+```
+
+See [`examples/cache_group`](./examples/cache_group) for a runnable local demo.
 
 ## objectstore Configuration
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,31 @@ need the old fire-one-goroutine-per-job behavior, set
 `"all"`; unknown strategy values now fail cache construction instead of silently
 falling back to `"pool"`.
 
+## Cache Groups
+
+`New(...)` constructs a self-contained cache instance with its own background
+runtime. That is the right choice when you want one cache to manage its own
+worker lifecycle, shutdown behavior, and queue limits independently.
+
+`NewGroup(...)` constructs a `CacheGroup` that owns one bounded shared
+background runtime for multiple caches. Call `group.NewCache(...)` to create
+cache instances that share that runtime while keeping their tier chains and
+cache-local policy separate. Each grouped cache still closes independently, and
+`group.Close()` shuts down the shared runtime after closing the created caches.
+
+Group construction uses the `WithGroup...` option surface:
+
+* `WithGroupWorkers(...)`
+* `WithGroupWorkerTimeout(...)`
+* `WithGroupWorkerQueueDefault(...)`
+* `WithGroupCloseTimeout(...)`
+
+Per-cache runtime tuning inside a group uses the regular cache options
+`WithWeight(...)` and `WithQueueLimit(...)`. Those options only apply to caches
+created from a `CacheGroup`; standalone `New(...)` construction keeps using the
+original cache-level worker options such as `WithWorkers(...)`,
+`WithWorkerQueue(...)`, `WithWorkerTimeout(...)`, and `WithWorkerStrategy(...)`.
+
 ## objectstore Configuration
 
 `objectstore` exposes its behavior entirely through constructor options. There are two separate configuration layers:

--- a/background_runtime.go
+++ b/background_runtime.go
@@ -1,0 +1,45 @@
+package daramjwee
+
+import (
+	"time"
+
+	"github.com/mrchypark/daramjwee/internal/worker"
+)
+
+type cacheConstructionMode int
+
+const (
+	cacheConstructionStandalone cacheConstructionMode = iota
+	cacheConstructionGroup
+)
+
+type JobKind int
+
+const (
+	JobKindRefresh JobKind = iota
+	JobKindPersist
+)
+
+func (k JobKind) String() string {
+	switch k {
+	case JobKindRefresh:
+		return "refresh"
+	case JobKindPersist:
+		return "persist"
+	default:
+		return "unknown"
+	}
+}
+
+type CacheRuntimeConfig struct {
+	Weight     int
+	QueueLimit int
+}
+
+type backgroundRuntime interface {
+	Register(cacheID string, cfg CacheRuntimeConfig) error
+	Submit(cacheID string, kind JobKind, job worker.Job) bool
+	CloseCache(cacheID string, timeout time.Duration) error
+	RemoveCache(cacheID string)
+	Shutdown(timeout time.Duration) error
+}

--- a/background_runtime_group.go
+++ b/background_runtime_group.go
@@ -60,12 +60,9 @@ type queuedBackgroundJob struct {
 	job     worker.Job
 }
 
-func newGroupRuntime(logger log.Logger, workers, queueLimit int, timeout time.Duration) (*groupRuntime, error) {
+func newGroupRuntime(logger log.Logger, workers int, timeout time.Duration) (*groupRuntime, error) {
 	if workers <= 0 {
 		workers = 1
-	}
-	if queueLimit <= 0 {
-		queueLimit = 1
 	}
 	if timeout <= 0 {
 		timeout = 30 * time.Second
@@ -300,13 +297,21 @@ func (r *groupRuntime) workerLoop(workerID int) {
 		}
 		ctx, cancel := context.WithTimeout(state.ctx, r.timeout)
 		level.Debug(r.logger).Log("msg", "starting background job", "cache_id", cacheID, "job_kind", job.kind.String())
-		job.job(ctx)
-		cancel()
-		r.mu.Lock()
-		state.active--
-		r.notifyCacheActivityLocked(state)
-		r.mu.Unlock()
-		level.Debug(r.logger).Log("msg", "finished background job", "cache_id", cacheID, "job_kind", job.kind.String())
+		func() {
+			defer func() {
+				cancel()
+				if rec := recover(); rec != nil {
+					level.Error(r.logger).Log("msg", "background job panicked", "cache_id", cacheID, "job_kind", job.kind.String(), "panic", rec)
+				} else {
+					level.Debug(r.logger).Log("msg", "finished background job", "cache_id", cacheID, "job_kind", job.kind.String())
+				}
+				r.mu.Lock()
+				state.active--
+				r.notifyCacheActivityLocked(state)
+				r.mu.Unlock()
+			}()
+			job.job(ctx)
+		}()
 	}
 }
 

--- a/background_runtime_group.go
+++ b/background_runtime_group.go
@@ -1,0 +1,397 @@
+package daramjwee
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/mrchypark/daramjwee/internal/worker"
+)
+
+type rejectReason string
+
+const (
+	rejectReasonGroupClosing rejectReason = "group_closing"
+	rejectReasonCacheClosed  rejectReason = "cache_closed"
+	rejectReasonQueueFull    rejectReason = "queue_full"
+)
+
+func (r rejectReason) String() string { return string(r) }
+
+type groupRuntime struct {
+	logger log.Logger
+
+	mu             sync.Mutex
+	cond           *sync.Cond
+	beforeJobStart func(cacheID string, kind JobKind)
+	caches         map[string]*groupRuntimeCacheState
+	order          []string
+	nextIdx        int
+	closing        bool
+
+	wg      sync.WaitGroup
+	timeout time.Duration
+
+	acceptedByKind  map[JobKind]int
+	rejectedByKind  map[JobKind]int
+	rejectedByCause map[rejectReason]int
+}
+
+type groupRuntimeCacheState struct {
+	cacheID    string
+	weight     int
+	credit     int
+	queueLimit int
+	queue      chan queuedBackgroundJob
+	ctx        context.Context
+	cancel     context.CancelFunc
+	active     int
+	closed     bool
+}
+
+type queuedBackgroundJob struct {
+	cacheID string
+	kind    JobKind
+	job     worker.Job
+}
+
+func newGroupRuntime(logger log.Logger, workers, queueLimit int, timeout time.Duration) (*groupRuntime, error) {
+	if workers <= 0 {
+		workers = 1
+	}
+	if queueLimit <= 0 {
+		queueLimit = 1
+	}
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	rt := &groupRuntime{
+		logger:          logger,
+		caches:          make(map[string]*groupRuntimeCacheState),
+		timeout:         timeout,
+		acceptedByKind:  make(map[JobKind]int),
+		rejectedByKind:  make(map[JobKind]int),
+		rejectedByCause: make(map[rejectReason]int),
+	}
+	rt.cond = sync.NewCond(&rt.mu)
+
+	rt.wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go rt.workerLoop(i)
+	}
+	return rt, nil
+}
+
+func (r *groupRuntime) Register(cacheID string, cfg CacheRuntimeConfig) error {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closing {
+		return &ConfigError{"cache group is closed"}
+	}
+	if cacheID == "" {
+		return &ConfigError{"cache name cannot be empty"}
+	}
+	if _, exists := r.caches[cacheID]; exists {
+		return &ConfigError{fmt.Sprintf("duplicate cache name %q", cacheID)}
+	}
+
+	cacheCtx, cancel := context.WithCancel(context.Background())
+	queueLimit := maxInt(cfg.QueueLimit, 1)
+	r.caches[cacheID] = &groupRuntimeCacheState{
+		cacheID:    cacheID,
+		weight:     maxInt(cfg.Weight, 1),
+		queueLimit: queueLimit,
+		queue:      make(chan queuedBackgroundJob, queueLimit),
+		ctx:        cacheCtx,
+		cancel:     cancel,
+	}
+	r.order = append(r.order, cacheID)
+	r.cond.Broadcast()
+	return nil
+}
+
+func (r *groupRuntime) Submit(cacheID string, kind JobKind, job worker.Job) bool {
+	if r == nil {
+		return false
+	}
+
+	r.mu.Lock()
+	state, ok := r.caches[cacheID]
+	if !ok {
+		r.noteRejectLocked(cacheID, kind, rejectReasonCacheClosed, 0, 0)
+		r.mu.Unlock()
+		return false
+	}
+	if r.closing {
+		r.noteRejectLocked(cacheID, kind, rejectReasonGroupClosing, len(state.queue), state.queueLimit)
+		r.mu.Unlock()
+		return false
+	}
+	if state.closed {
+		r.noteRejectLocked(cacheID, kind, rejectReasonCacheClosed, len(state.queue), state.queueLimit)
+		r.mu.Unlock()
+		return false
+	}
+	depth := len(state.queue)
+	if depth >= state.queueLimit {
+		r.noteRejectLocked(cacheID, kind, rejectReasonQueueFull, depth, state.queueLimit)
+		r.mu.Unlock()
+		return false
+	}
+	state.queue <- queuedBackgroundJob{cacheID: cacheID, kind: kind, job: job}
+	r.acceptedByKind[kind]++
+	level.Debug(r.logger).Log(
+		"msg", "queued background job",
+		"cache_id", cacheID,
+		"job_kind", kind.String(),
+		"queue_depth", len(state.queue),
+		"queue_limit", state.queueLimit,
+	)
+	r.cond.Signal()
+	r.mu.Unlock()
+	return true
+}
+
+func (r *groupRuntime) RemoveCache(cacheID string) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.caches[cacheID]; ok {
+		delete(r.caches, cacheID)
+		for i, id := range r.order {
+			if id == cacheID {
+				r.order = append(r.order[:i], r.order[i+1:]...)
+				if r.nextIdx >= len(r.order) {
+					r.nextIdx = 0
+				}
+				break
+			}
+		}
+		r.cond.Broadcast()
+	}
+}
+
+func (r *groupRuntime) noteRejectLocked(cacheID string, kind JobKind, reason rejectReason, depth, limit int) {
+	r.rejectedByKind[kind]++
+	r.rejectedByCause[reason]++
+	level.Warn(r.logger).Log(
+		"msg", "rejected background job",
+		"cache_id", cacheID,
+		"job_kind", kind.String(),
+		"queue_depth", depth,
+		"queue_limit", limit,
+		"reject_reason", reason.String(),
+	)
+}
+
+func (r *groupRuntime) CloseCache(cacheID string, timeout time.Duration) error {
+	if r == nil {
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = r.timeout
+	}
+
+	r.mu.Lock()
+	state, ok := r.caches[cacheID]
+	if !ok {
+		r.mu.Unlock()
+		return nil
+	}
+	if state.closed {
+		done := make(chan struct{})
+		go func() {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			for state.active > 0 {
+				r.cond.Wait()
+			}
+			close(done)
+		}()
+		r.mu.Unlock()
+		select {
+		case <-done:
+			return nil
+		case <-time.After(timeout):
+			level.Warn(r.logger).Log("msg", "cache close timed out", "cache_id", cacheID, "timeout", timeout)
+			return worker.ErrShutdownTimeout
+		}
+	}
+
+	state.closed = true
+	state.cancel()
+	dropped := len(state.queue)
+	for len(state.queue) > 0 {
+		<-state.queue
+	}
+	r.cond.Broadcast()
+	done := make(chan struct{})
+	go func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		for state.active > 0 {
+			r.cond.Wait()
+		}
+		close(done)
+	}()
+	r.mu.Unlock()
+
+	level.Info(r.logger).Log("msg", "closing cache runtime", "cache_id", cacheID, "dropped_jobs", dropped, "timeout", timeout)
+	select {
+	case <-done:
+		return nil
+	case <-time.After(timeout):
+		level.Warn(r.logger).Log("msg", "cache close timed out", "cache_id", cacheID, "timeout", timeout)
+		return worker.ErrShutdownTimeout
+	}
+}
+
+func (r *groupRuntime) Shutdown(timeout time.Duration) error {
+	if r == nil {
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = r.timeout
+	}
+
+	r.mu.Lock()
+	if r.closing {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closing = true
+	for cacheID, state := range r.caches {
+		if !state.closed {
+			state.closed = true
+			state.cancel()
+		}
+		dropped := len(state.queue)
+		for len(state.queue) > 0 {
+			<-state.queue
+		}
+		level.Info(r.logger).Log("msg", "closing cache runtime", "cache_id", cacheID, "dropped_jobs", dropped, "timeout", timeout)
+	}
+	r.cond.Broadcast()
+	r.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-time.After(timeout):
+		level.Warn(r.logger).Log("msg", "group runtime shutdown timed out", "timeout", timeout)
+		return worker.ErrShutdownTimeout
+	}
+}
+
+func (r *groupRuntime) workerLoop(workerID int) {
+	defer r.wg.Done()
+	for {
+		cacheID, job, state, ok := r.nextJob()
+		if !ok {
+			return
+		}
+
+		r.mu.Lock()
+		closed := state.closed
+		r.mu.Unlock()
+		if closed {
+			r.mu.Lock()
+			state.active--
+			if state.active == 0 {
+				r.cond.Broadcast()
+			}
+			r.mu.Unlock()
+			level.Debug(r.logger).Log("msg", "dropping dequeued job for closed cache", "cache_id", cacheID, "job_kind", job.kind.String())
+			continue
+		}
+
+		if hook := r.beforeJobStart; hook != nil {
+			hook(cacheID, job.kind)
+		}
+		ctx, cancel := context.WithTimeout(state.ctx, r.timeout)
+		level.Debug(r.logger).Log("msg", "starting background job", "cache_id", cacheID, "job_kind", job.kind.String())
+		job.job(ctx)
+		cancel()
+		r.mu.Lock()
+		state.active--
+		if state.active == 0 {
+			r.cond.Broadcast()
+		}
+		r.mu.Unlock()
+		level.Debug(r.logger).Log("msg", "finished background job", "cache_id", cacheID, "job_kind", job.kind.String())
+	}
+}
+
+func (r *groupRuntime) nextJob() (string, queuedBackgroundJob, *groupRuntimeCacheState, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for {
+		if r.closing && r.allQueuesEmptyLocked() {
+			return "", queuedBackgroundJob{}, nil, false
+		}
+
+		cacheID, job, state, ok := r.pickNextLocked()
+		if ok {
+			return cacheID, job, state, true
+		}
+
+		r.cond.Wait()
+	}
+}
+
+func (r *groupRuntime) allQueuesEmptyLocked() bool {
+	for _, cacheID := range r.order {
+		state := r.caches[cacheID]
+		if state != nil && !state.closed && len(state.queue) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *groupRuntime) pickNextLocked() (string, queuedBackgroundJob, *groupRuntimeCacheState, bool) {
+	if len(r.order) == 0 {
+		return "", queuedBackgroundJob{}, nil, false
+	}
+
+	total := len(r.order)
+	for checked := 0; checked < total; checked++ {
+		idx := (r.nextIdx + checked) % total
+		cacheID := r.order[idx]
+		state := r.caches[cacheID]
+		if state == nil || state.closed || len(state.queue) == 0 {
+			continue
+		}
+		if state.credit <= 0 {
+			state.credit = state.weight
+		}
+		job := <-state.queue
+		state.credit--
+		if state.credit <= 0 {
+			r.nextIdx = (idx + 1) % total
+		} else {
+			r.nextIdx = idx
+		}
+		state.active++
+		return cacheID, job, state, true
+	}
+	return "", queuedBackgroundJob{}, nil, false
+}

--- a/background_runtime_group.go
+++ b/background_runtime_group.go
@@ -60,7 +60,7 @@ type queuedBackgroundJob struct {
 	job     worker.Job
 }
 
-func newGroupRuntime(logger log.Logger, workers int, timeout time.Duration) (*groupRuntime, error) {
+func newGroupRuntime(logger log.Logger, workers int, timeout time.Duration) *groupRuntime {
 	if workers <= 0 {
 		workers = 1
 	}
@@ -82,7 +82,7 @@ func newGroupRuntime(logger log.Logger, workers int, timeout time.Duration) (*gr
 	for i := 0; i < workers; i++ {
 		go rt.workerLoop(i)
 	}
-	return rt, nil
+	return rt
 }
 
 func (r *groupRuntime) Register(cacheID string, cfg CacheRuntimeConfig) error {

--- a/background_runtime_group.go
+++ b/background_runtime_group.go
@@ -50,6 +50,8 @@ type groupRuntimeCacheState struct {
 	cancel     context.CancelFunc
 	active     int
 	closed     bool
+	closeDone  chan struct{}
+	closeSent  bool
 }
 
 type queuedBackgroundJob struct {
@@ -210,23 +212,9 @@ func (r *groupRuntime) CloseCache(cacheID string, timeout time.Duration) error {
 		return nil
 	}
 	if state.closed {
-		done := make(chan struct{})
-		go func() {
-			r.mu.Lock()
-			defer r.mu.Unlock()
-			for state.active > 0 {
-				r.cond.Wait()
-			}
-			close(done)
-		}()
+		done := r.cacheCloseDoneLocked(state)
 		r.mu.Unlock()
-		select {
-		case <-done:
-			return nil
-		case <-time.After(timeout):
-			level.Warn(r.logger).Log("msg", "cache close timed out", "cache_id", cacheID, "timeout", timeout)
-			return worker.ErrShutdownTimeout
-		}
+		return r.waitForCacheClose(cacheID, done, timeout)
 	}
 
 	state.closed = true
@@ -236,25 +224,11 @@ func (r *groupRuntime) CloseCache(cacheID string, timeout time.Duration) error {
 		<-state.queue
 	}
 	r.cond.Broadcast()
-	done := make(chan struct{})
-	go func() {
-		r.mu.Lock()
-		defer r.mu.Unlock()
-		for state.active > 0 {
-			r.cond.Wait()
-		}
-		close(done)
-	}()
+	done := r.cacheCloseDoneLocked(state)
 	r.mu.Unlock()
 
 	level.Info(r.logger).Log("msg", "closing cache runtime", "cache_id", cacheID, "dropped_jobs", dropped, "timeout", timeout)
-	select {
-	case <-done:
-		return nil
-	case <-time.After(timeout):
-		level.Warn(r.logger).Log("msg", "cache close timed out", "cache_id", cacheID, "timeout", timeout)
-		return worker.ErrShutdownTimeout
-	}
+	return r.waitForCacheClose(cacheID, done, timeout)
 }
 
 func (r *groupRuntime) Shutdown(timeout time.Duration) error {
@@ -280,6 +254,7 @@ func (r *groupRuntime) Shutdown(timeout time.Duration) error {
 		for len(state.queue) > 0 {
 			<-state.queue
 		}
+		r.cacheCloseDoneLocked(state)
 		level.Info(r.logger).Log("msg", "closing cache runtime", "cache_id", cacheID, "dropped_jobs", dropped, "timeout", timeout)
 	}
 	r.cond.Broadcast()
@@ -314,9 +289,7 @@ func (r *groupRuntime) workerLoop(workerID int) {
 		if closed {
 			r.mu.Lock()
 			state.active--
-			if state.active == 0 {
-				r.cond.Broadcast()
-			}
+			r.notifyCacheActivityLocked(state)
 			r.mu.Unlock()
 			level.Debug(r.logger).Log("msg", "dropping dequeued job for closed cache", "cache_id", cacheID, "job_kind", job.kind.String())
 			continue
@@ -331,9 +304,7 @@ func (r *groupRuntime) workerLoop(workerID int) {
 		cancel()
 		r.mu.Lock()
 		state.active--
-		if state.active == 0 {
-			r.cond.Broadcast()
-		}
+		r.notifyCacheActivityLocked(state)
 		r.mu.Unlock()
 		level.Debug(r.logger).Log("msg", "finished background job", "cache_id", cacheID, "job_kind", job.kind.String())
 	}
@@ -383,7 +354,12 @@ func (r *groupRuntime) pickNextLocked() (string, queuedBackgroundJob, *groupRunt
 		if state.credit <= 0 {
 			state.credit = state.weight
 		}
-		job := <-state.queue
+		var job queuedBackgroundJob
+		select {
+		case job = <-state.queue:
+		default:
+			continue
+		}
 		state.credit--
 		if state.credit <= 0 {
 			r.nextIdx = (idx + 1) % total
@@ -394,4 +370,34 @@ func (r *groupRuntime) pickNextLocked() (string, queuedBackgroundJob, *groupRunt
 		return cacheID, job, state, true
 	}
 	return "", queuedBackgroundJob{}, nil, false
+}
+
+func (r *groupRuntime) cacheCloseDoneLocked(state *groupRuntimeCacheState) chan struct{} {
+	if state.closeDone == nil {
+		state.closeDone = make(chan struct{})
+	}
+	if state.closed && state.active == 0 && !state.closeSent {
+		close(state.closeDone)
+		state.closeSent = true
+	}
+	return state.closeDone
+}
+
+func (r *groupRuntime) notifyCacheActivityLocked(state *groupRuntimeCacheState) {
+	if state.closed && state.active == 0 {
+		r.cacheCloseDoneLocked(state)
+	}
+	if state.active == 0 {
+		r.cond.Broadcast()
+	}
+}
+
+func (r *groupRuntime) waitForCacheClose(cacheID string, done <-chan struct{}, timeout time.Duration) error {
+	select {
+	case <-done:
+		return nil
+	case <-time.After(timeout):
+		level.Warn(r.logger).Log("msg", "cache close timed out", "cache_id", cacheID, "timeout", timeout)
+		return worker.ErrShutdownTimeout
+	}
 }

--- a/background_runtime_group.go
+++ b/background_runtime_group.go
@@ -145,7 +145,13 @@ func (r *groupRuntime) Submit(cacheID string, kind JobKind, job worker.Job) bool
 		r.mu.Unlock()
 		return false
 	}
-	state.queue <- queuedBackgroundJob{cacheID: cacheID, kind: kind, job: job}
+	select {
+	case state.queue <- queuedBackgroundJob{cacheID: cacheID, kind: kind, job: job}:
+	default:
+		r.noteRejectLocked(cacheID, kind, rejectReasonQueueFull, len(state.queue), state.queueLimit)
+		r.mu.Unlock()
+		return false
+	}
 	r.acceptedByKind[kind]++
 	level.Debug(r.logger).Log(
 		"msg", "queued background job",
@@ -171,7 +177,9 @@ func (r *groupRuntime) RemoveCache(cacheID string) {
 		for i, id := range r.order {
 			if id == cacheID {
 				r.order = append(r.order[:i], r.order[i+1:]...)
-				if r.nextIdx >= len(r.order) {
+				if i < r.nextIdx {
+					r.nextIdx--
+				} else if r.nextIdx >= len(r.order) {
 					r.nextIdx = 0
 				}
 				break

--- a/background_runtime_standalone.go
+++ b/background_runtime_standalone.go
@@ -1,0 +1,45 @@
+package daramjwee
+
+import (
+	"sync"
+	"time"
+
+	"github.com/mrchypark/daramjwee/internal/worker"
+)
+
+type standaloneRuntime struct {
+	manager *worker.Manager
+	once    sync.Once
+}
+
+func newStandaloneRuntime(manager *worker.Manager) backgroundRuntime {
+	return &standaloneRuntime{manager: manager}
+}
+
+func (r *standaloneRuntime) Register(string, CacheRuntimeConfig) error {
+	return nil
+}
+
+func (r *standaloneRuntime) Submit(_ string, _ JobKind, job worker.Job) bool {
+	if r == nil || r.manager == nil {
+		return false
+	}
+	return r.manager.Submit(job)
+}
+
+func (r *standaloneRuntime) CloseCache(_ string, timeout time.Duration) error {
+	return r.Shutdown(timeout)
+}
+
+func (r *standaloneRuntime) RemoveCache(_ string) {}
+
+func (r *standaloneRuntime) Shutdown(timeout time.Duration) error {
+	if r == nil || r.manager == nil {
+		return nil
+	}
+	var shutdownErr error
+	r.once.Do(func() {
+		shutdownErr = r.manager.Shutdown(timeout)
+	})
+	return shutdownErr
+}

--- a/background_runtime_test.go
+++ b/background_runtime_test.go
@@ -3,6 +3,7 @@ package daramjwee
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -132,6 +133,54 @@ func TestGroupRuntime_CloseCacheWaitsForDequeuedJobReservation(t *testing.T) {
 
 	close(releaseJob)
 	require.NoError(t, <-closeDone)
+
+	require.NoError(t, rt.Shutdown(time.Second))
+}
+
+func TestGroupRuntime_CloseCache_IdempotentWhileJobActive(t *testing.T) {
+	rt, err := newGroupRuntime(log.NewNopLogger(), 1, 4, time.Second)
+	require.NoError(t, err)
+
+	const cacheID = "cache-repeat-close"
+	require.NoError(t, rt.Register(cacheID, CacheRuntimeConfig{Weight: 1, QueueLimit: 4}))
+
+	jobReady := make(chan struct{})
+	releaseJob := make(chan struct{})
+	rt.beforeJobStart = func(id string, kind JobKind) {
+		if id == cacheID && kind == JobKindRefresh {
+			select {
+			case <-jobReady:
+			default:
+				close(jobReady)
+			}
+			<-releaseJob
+		}
+	}
+
+	require.True(t, rt.Submit(cacheID, JobKindRefresh, func(ctx context.Context) {}))
+	<-jobReady
+
+	var firstReturned atomic.Bool
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- rt.CloseCache(cacheID, time.Second)
+		firstReturned.Store(true)
+	}()
+
+	require.Never(t, firstReturned.Load, 100*time.Millisecond, 10*time.Millisecond)
+
+	var secondReturned atomic.Bool
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- rt.CloseCache(cacheID, time.Second)
+		secondReturned.Store(true)
+	}()
+
+	require.Never(t, secondReturned.Load, 100*time.Millisecond, 10*time.Millisecond)
+
+	close(releaseJob)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
 
 	require.NoError(t, rt.Shutdown(time.Second))
 }

--- a/background_runtime_test.go
+++ b/background_runtime_test.go
@@ -36,8 +36,7 @@ func TestStandaloneRuntime_CloseCacheWaitsForJobCompletion(t *testing.T) {
 }
 
 func TestGroupRuntime_QueueIsolationAndLimitEnforcement(t *testing.T) {
-	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
-	require.NoError(t, err)
+	rt := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 
 	require.NoError(t, rt.Register("cache-a", CacheRuntimeConfig{Weight: 1, QueueLimit: 1}))
 	require.NoError(t, rt.Register("cache-b", CacheRuntimeConfig{Weight: 1, QueueLimit: 1}))
@@ -61,8 +60,7 @@ func TestGroupRuntime_QueueIsolationAndLimitEnforcement(t *testing.T) {
 }
 
 func TestGroupRuntime_WeightedDequeueProgress(t *testing.T) {
-	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
-	require.NoError(t, err)
+	rt := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 
 	require.NoError(t, rt.Register("cache-a", CacheRuntimeConfig{Weight: 2, QueueLimit: 8}))
 	require.NoError(t, rt.Register("cache-b", CacheRuntimeConfig{Weight: 1, QueueLimit: 8}))
@@ -98,8 +96,7 @@ func TestGroupRuntime_WeightedDequeueProgress(t *testing.T) {
 }
 
 func TestGroupRuntime_CloseCacheWaitsForDequeuedJobReservation(t *testing.T) {
-	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
-	require.NoError(t, err)
+	rt := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 
 	const cacheID = "cache-race"
 	require.NoError(t, rt.Register(cacheID, CacheRuntimeConfig{Weight: 1, QueueLimit: 4}))
@@ -138,8 +135,7 @@ func TestGroupRuntime_CloseCacheWaitsForDequeuedJobReservation(t *testing.T) {
 }
 
 func TestGroupRuntime_CloseCache_IdempotentWhileJobActive(t *testing.T) {
-	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
-	require.NoError(t, err)
+	rt := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 
 	const cacheID = "cache-repeat-close"
 	require.NoError(t, rt.Register(cacheID, CacheRuntimeConfig{Weight: 1, QueueLimit: 4}))
@@ -186,8 +182,7 @@ func TestGroupRuntime_CloseCache_IdempotentWhileJobActive(t *testing.T) {
 }
 
 func TestGroupRuntime_RecoversPanickingJobAndContinues(t *testing.T) {
-	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
-	require.NoError(t, err)
+	rt := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 
 	const cacheID = "cache-panic"
 	require.NoError(t, rt.Register(cacheID, CacheRuntimeConfig{Weight: 1, QueueLimit: 4}))

--- a/background_runtime_test.go
+++ b/background_runtime_test.go
@@ -208,3 +208,22 @@ func TestGroupRuntime_RecoversPanickingJobAndContinues(t *testing.T) {
 	require.NoError(t, rt.CloseCache(cacheID, time.Second))
 	require.NoError(t, rt.Shutdown(time.Second))
 }
+
+func TestGroupRuntime_RemoveCache_AdjustsNextIndex(t *testing.T) {
+	rt := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
+
+	require.NoError(t, rt.Register("cache-a", CacheRuntimeConfig{Weight: 1, QueueLimit: 4}))
+	require.NoError(t, rt.Register("cache-b", CacheRuntimeConfig{Weight: 1, QueueLimit: 4}))
+	require.NoError(t, rt.Register("cache-c", CacheRuntimeConfig{Weight: 1, QueueLimit: 4}))
+
+	rt.mu.Lock()
+	rt.nextIdx = 2
+	rt.mu.Unlock()
+
+	rt.RemoveCache("cache-a")
+
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	require.Equal(t, []string{"cache-b", "cache-c"}, rt.order)
+	require.Equal(t, 1, rt.nextIdx)
+}

--- a/background_runtime_test.go
+++ b/background_runtime_test.go
@@ -1,0 +1,137 @@
+package daramjwee
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee/internal/worker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStandaloneRuntime_CloseCacheWaitsForJobCompletion(t *testing.T) {
+	manager, err := worker.NewManager("pool", log.NewNopLogger(), 1, 1, time.Second)
+	require.NoError(t, err)
+
+	rt := newStandaloneRuntime(manager)
+	jobStarted := make(chan struct{})
+	releaseJob := make(chan struct{})
+
+	require.True(t, rt.Submit("cache", JobKindRefresh, func(ctx context.Context) {
+		close(jobStarted)
+		<-releaseJob
+	}))
+	<-jobStarted
+
+	done := make(chan error, 1)
+	go func() {
+		done <- rt.CloseCache("cache", 2*time.Second)
+	}()
+
+	close(releaseJob)
+	require.NoError(t, <-done)
+}
+
+func TestGroupRuntime_QueueIsolationAndLimitEnforcement(t *testing.T) {
+	rt, err := newGroupRuntime(log.NewNopLogger(), 1, 4, time.Second)
+	require.NoError(t, err)
+
+	require.NoError(t, rt.Register("cache-a", CacheRuntimeConfig{Weight: 1, QueueLimit: 1}))
+	require.NoError(t, rt.Register("cache-b", CacheRuntimeConfig{Weight: 1, QueueLimit: 1}))
+
+	blockA := make(chan struct{})
+	releaseA := make(chan struct{})
+	require.True(t, rt.Submit("cache-a", JobKindPersist, func(ctx context.Context) {
+		close(blockA)
+		<-releaseA
+	}))
+	<-blockA
+	require.True(t, rt.Submit("cache-a", JobKindPersist, func(ctx context.Context) {}))
+	require.False(t, rt.Submit("cache-a", JobKindPersist, func(ctx context.Context) {}))
+
+	require.True(t, rt.Submit("cache-b", JobKindPersist, func(ctx context.Context) {}))
+	close(releaseA)
+
+	require.NoError(t, rt.CloseCache("cache-a", time.Second))
+	require.False(t, rt.Submit("cache-a", JobKindPersist, func(ctx context.Context) {}))
+	require.NoError(t, rt.Shutdown(time.Second))
+}
+
+func TestGroupRuntime_WeightedDequeueProgress(t *testing.T) {
+	rt, err := newGroupRuntime(log.NewNopLogger(), 1, 8, time.Second)
+	require.NoError(t, err)
+
+	require.NoError(t, rt.Register("cache-a", CacheRuntimeConfig{Weight: 2, QueueLimit: 8}))
+	require.NoError(t, rt.Register("cache-b", CacheRuntimeConfig{Weight: 1, QueueLimit: 8}))
+
+	var mu sync.Mutex
+	order := make([]string, 0, 3)
+	done := make(chan struct{})
+	record := func(name string) worker.Job {
+		return func(ctx context.Context) {
+			mu.Lock()
+			order = append(order, name)
+			if len(order) == 3 {
+				close(done)
+			}
+			mu.Unlock()
+		}
+	}
+
+	require.True(t, rt.Submit("cache-a", JobKindPersist, record("A")))
+	require.True(t, rt.Submit("cache-a", JobKindPersist, record("A")))
+	require.True(t, rt.Submit("cache-b", JobKindPersist, record("B")))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for weighted dequeue order")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"A", "A", "B"}, order)
+	require.NoError(t, rt.Shutdown(time.Second))
+}
+
+func TestGroupRuntime_CloseCacheWaitsForDequeuedJobReservation(t *testing.T) {
+	rt, err := newGroupRuntime(log.NewNopLogger(), 1, 4, time.Second)
+	require.NoError(t, err)
+
+	const cacheID = "cache-race"
+	require.NoError(t, rt.Register(cacheID, CacheRuntimeConfig{Weight: 1, QueueLimit: 4}))
+
+	jobReady := make(chan struct{})
+	releaseJob := make(chan struct{})
+	rt.beforeJobStart = func(id string, kind JobKind) {
+		if id == cacheID && kind == JobKindRefresh {
+			select {
+			case <-jobReady:
+			default:
+				close(jobReady)
+			}
+			<-releaseJob
+		}
+	}
+
+	require.True(t, rt.Submit(cacheID, JobKindRefresh, func(ctx context.Context) {}))
+	<-jobReady
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- rt.CloseCache(cacheID, time.Second)
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("cache close returned before reserved job was released: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseJob)
+	require.NoError(t, <-closeDone)
+
+	require.NoError(t, rt.Shutdown(time.Second))
+}

--- a/background_runtime_test.go
+++ b/background_runtime_test.go
@@ -36,7 +36,7 @@ func TestStandaloneRuntime_CloseCacheWaitsForJobCompletion(t *testing.T) {
 }
 
 func TestGroupRuntime_QueueIsolationAndLimitEnforcement(t *testing.T) {
-	rt, err := newGroupRuntime(log.NewNopLogger(), 1, 4, time.Second)
+	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 	require.NoError(t, err)
 
 	require.NoError(t, rt.Register("cache-a", CacheRuntimeConfig{Weight: 1, QueueLimit: 1}))
@@ -61,7 +61,7 @@ func TestGroupRuntime_QueueIsolationAndLimitEnforcement(t *testing.T) {
 }
 
 func TestGroupRuntime_WeightedDequeueProgress(t *testing.T) {
-	rt, err := newGroupRuntime(log.NewNopLogger(), 1, 8, time.Second)
+	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 	require.NoError(t, err)
 
 	require.NoError(t, rt.Register("cache-a", CacheRuntimeConfig{Weight: 2, QueueLimit: 8}))
@@ -98,7 +98,7 @@ func TestGroupRuntime_WeightedDequeueProgress(t *testing.T) {
 }
 
 func TestGroupRuntime_CloseCacheWaitsForDequeuedJobReservation(t *testing.T) {
-	rt, err := newGroupRuntime(log.NewNopLogger(), 1, 4, time.Second)
+	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 	require.NoError(t, err)
 
 	const cacheID = "cache-race"
@@ -138,7 +138,7 @@ func TestGroupRuntime_CloseCacheWaitsForDequeuedJobReservation(t *testing.T) {
 }
 
 func TestGroupRuntime_CloseCache_IdempotentWhileJobActive(t *testing.T) {
-	rt, err := newGroupRuntime(log.NewNopLogger(), 1, 4, time.Second)
+	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 	require.NoError(t, err)
 
 	const cacheID = "cache-repeat-close"
@@ -182,5 +182,34 @@ func TestGroupRuntime_CloseCache_IdempotentWhileJobActive(t *testing.T) {
 	require.NoError(t, <-firstDone)
 	require.NoError(t, <-secondDone)
 
+	require.NoError(t, rt.Shutdown(time.Second))
+}
+
+func TestGroupRuntime_RecoversPanickingJobAndContinues(t *testing.T) {
+	rt, err := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
+	require.NoError(t, err)
+
+	const cacheID = "cache-panic"
+	require.NoError(t, rt.Register(cacheID, CacheRuntimeConfig{Weight: 1, QueueLimit: 4}))
+
+	require.True(t, rt.Submit(cacheID, JobKindRefresh, func(ctx context.Context) {
+		panic("boom")
+	}))
+
+	secondDone := make(chan struct{})
+	require.True(t, rt.Submit(cacheID, JobKindRefresh, func(ctx context.Context) {
+		close(secondDone)
+	}))
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-secondDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, rt.CloseCache(cacheID, time.Second))
 	require.NoError(t, rt.Shutdown(time.Second))
 }

--- a/cache.go
+++ b/cache.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/mrchypark/daramjwee/internal/worker"
 )
 
 var ErrCacheClosed = errors.New("daramjwee: cache is closed")
@@ -33,7 +32,10 @@ func (e lowerTierPromotionInvalidatedError) Is(target error) bool {
 type DaramjweeCache struct {
 	tiers                  []Store
 	logger                 log.Logger
-	worker                 *worker.Manager
+	runtime                backgroundRuntime
+	cacheID                string
+	runtimeWeight          int
+	runtimeQueueLimit      int
 	opTimeout              time.Duration
 	closeTimeout           time.Duration
 	positiveFreshness      time.Duration
@@ -43,6 +45,7 @@ type DaramjweeCache struct {
 	isClosed               atomic.Bool
 	topWrites              topWriteManager
 	fanoutWrites           fanoutWriteManager
+	closeHook              func()
 }
 
 var _ Cache = (*DaramjweeCache)(nil)
@@ -170,12 +173,23 @@ func (c *DaramjweeCache) Close() {
 		return
 	}
 
-	if c.worker != nil {
+	closedCleanly := false
+	if c.runtime != nil {
 		c.infoLog("msg", "shutting down daramjwee cache")
-		if err := c.worker.Shutdown(c.closeTimeout); err != nil {
+		if err := c.runtime.CloseCache(c.cacheID, c.closeTimeout); err != nil {
 			c.errorLog("msg", "graceful shutdown failed", "err", err)
 		} else {
 			c.infoLog("msg", "daramjwee cache shutdown complete")
+			closedCleanly = true
+		}
+		if closedCleanly {
+			c.runtime.RemoveCache(c.cacheID)
+		}
+	}
+
+	if closedCleanly {
+		if hook := c.closeHook; hook != nil {
+			hook()
 		}
 	}
 }

--- a/cache.go
+++ b/cache.go
@@ -173,24 +173,18 @@ func (c *DaramjweeCache) Close() {
 		return
 	}
 
-	closedCleanly := false
 	if c.runtime != nil {
 		c.infoLog("msg", "shutting down daramjwee cache")
 		if err := c.runtime.CloseCache(c.cacheID, c.closeTimeout); err != nil {
 			c.errorLog("msg", "graceful shutdown failed", "err", err)
 		} else {
 			c.infoLog("msg", "daramjwee cache shutdown complete")
-			closedCleanly = true
 		}
-		if closedCleanly {
-			c.runtime.RemoveCache(c.cacheID)
-		}
+		c.runtime.RemoveCache(c.cacheID)
 	}
 
-	if closedCleanly {
-		if hook := c.closeHook; hook != nil {
-			hook()
-		}
+	if hook := c.closeHook; hook != nil {
+		hook()
 	}
 }
 

--- a/cache_close_test.go
+++ b/cache_close_test.go
@@ -1,0 +1,57 @@
+package daramjwee
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee/internal/worker"
+	"github.com/stretchr/testify/require"
+)
+
+type cacheCloseStubRuntime struct {
+	closeErr      error
+	closeCalls    int
+	removeCalls   int
+	lastCacheID   string
+	lastCloseWait time.Duration
+}
+
+func (s *cacheCloseStubRuntime) Register(cacheID string, cfg CacheRuntimeConfig) error { return nil }
+func (s *cacheCloseStubRuntime) Submit(cacheID string, kind JobKind, job worker.Job) bool {
+	return true
+}
+func (s *cacheCloseStubRuntime) CloseCache(cacheID string, timeout time.Duration) error {
+	s.closeCalls++
+	s.lastCacheID = cacheID
+	s.lastCloseWait = timeout
+	return s.closeErr
+}
+func (s *cacheCloseStubRuntime) RemoveCache(cacheID string) {
+	s.removeCalls++
+	s.lastCacheID = cacheID
+}
+func (s *cacheCloseStubRuntime) Shutdown(timeout time.Duration) error { return nil }
+
+func TestDaramjweeCache_Close_RemovesRuntimeStateAfterTimeout(t *testing.T) {
+	rt := &cacheCloseStubRuntime{closeErr: worker.ErrShutdownTimeout}
+	hookCalls := 0
+
+	cache := &DaramjweeCache{
+		logger:       log.NewNopLogger(),
+		runtime:      rt,
+		cacheID:      "cache-a",
+		closeTimeout: 250 * time.Millisecond,
+		closeHook: func() {
+			hookCalls++
+		},
+	}
+
+	cache.Close()
+
+	require.Equal(t, 1, rt.closeCalls)
+	require.Equal(t, 1, rt.removeCalls)
+	require.Equal(t, "cache-a", rt.lastCacheID)
+	require.Equal(t, 250*time.Millisecond, rt.lastCloseWait)
+	require.Equal(t, 1, hookCalls)
+}

--- a/cache_persist.go
+++ b/cache_persist.go
@@ -42,7 +42,7 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 	if !hasRealStore(srcStore) || len(destinations) == 0 {
 		return
 	}
-	if c.worker == nil {
+	if c.runtime == nil {
 		c.warnLog("msg", "worker is not configured, cannot schedule persistence", "key", key)
 		return
 	}
@@ -95,7 +95,7 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 			c.infoLog("msg", "background set successful", "key", key, "dest_tier", destTierIndex)
 		}
 
-		if !c.worker.Submit(job) {
+		if !c.runtime.Submit(c.cacheID, JobKindPersist, job) {
 			c.warnLog("msg", "background set rejected", "key", key, "dest_tier", destTierIndex)
 		}
 	}

--- a/cache_persist_test.go
+++ b/cache_persist_test.go
@@ -140,7 +140,8 @@ func TestSchedulePersistFromTop_InvalidationCleanupUsesFreshContext(t *testing.T
 
 	cache := &DaramjweeCache{
 		tiers:        []Store{src},
-		worker:       workerManager,
+		runtime:      newStandaloneRuntime(workerManager),
+		cacheID:      "persist-cleanup",
 		logger:       log.NewNopLogger(),
 		opTimeout:    time.Second,
 		closeTimeout: time.Second,

--- a/cache_refresh.go
+++ b/cache_refresh.go
@@ -25,7 +25,7 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 	default:
 	}
 
-	if c.worker == nil {
+	if c.runtime == nil {
 		return errors.New("worker is not configured, cannot schedule refresh")
 	}
 
@@ -98,7 +98,7 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 		}
 	}
 
-	if !c.worker.Submit(job) {
+	if !c.runtime.Submit(c.cacheID, JobKindRefresh, job) {
 		return ErrBackgroundJobRejected
 	}
 	return nil

--- a/constructor_validation_external_test.go
+++ b/constructor_validation_external_test.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
@@ -79,6 +81,84 @@ func TestNew_ExposesDaramjweeCacheWithoutExportingRuntimeFields(t *testing.T) {
 	}
 }
 
+func TestNewGroup_ConstructorSurface(t *testing.T) {
+	group, err := daramjwee.NewGroup(nil,
+		daramjwee.WithGroupWorkers(2),
+		daramjwee.WithGroupWorkerTimeout(5*time.Second),
+		daramjwee.WithGroupWorkerQueueDefault(8),
+		daramjwee.WithGroupCloseTimeout(10*time.Second),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	t.Cleanup(group.Close)
+
+	cache, err := group.NewCache("shared", daramjwee.WithTiers(&optionsCompatibleStore{}), daramjwee.WithWeight(3), daramjwee.WithQueueLimit(11))
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+	t.Cleanup(cache.Close)
+
+	defaultQueueCache, err := group.NewCache("shared-default", daramjwee.WithTiers(&optionsCompatibleStore{}), daramjwee.WithWeight(2))
+	require.NoError(t, err)
+	require.NotNil(t, defaultQueueCache)
+	require.Equal(t, 8, int(reflect.ValueOf(defaultQueueCache).Elem().FieldByName("runtimeQueueLimit").Int()))
+	t.Cleanup(defaultQueueCache.Close)
+}
+
+func TestNewGroup_RejectsEmptyAndDuplicateNames(t *testing.T) {
+	group, err := daramjwee.NewGroup(nil, daramjwee.WithGroupWorkers(1))
+	require.NoError(t, err)
+	t.Cleanup(group.Close)
+
+	_, err = group.NewCache("", daramjwee.WithTiers(&optionsCompatibleStore{}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cache name cannot be empty")
+
+	_, err = group.NewCache("dup", daramjwee.WithTiers(&optionsCompatibleStore{}))
+	require.NoError(t, err)
+
+	_, err = group.NewCache("dup", daramjwee.WithTiers(&optionsCompatibleStore{}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate cache name")
+}
+
+func TestNewGroup_NewCacheRejectsStandaloneWorkerOptions(t *testing.T) {
+	group, err := daramjwee.NewGroup(nil, daramjwee.WithGroupWorkers(1))
+	require.NoError(t, err)
+	t.Cleanup(group.Close)
+
+	testCases := []struct {
+		name string
+		opt  daramjwee.Option
+		msg  string
+	}{
+		{name: "WithWorkers", opt: daramjwee.WithWorkers(2), msg: "standalone worker option"},
+		{name: "WithWorkerQueue", opt: daramjwee.WithWorkerQueue(8), msg: "standalone worker option"},
+		{name: "WithWorkerTimeout", opt: daramjwee.WithWorkerTimeout(5 * time.Second), msg: "standalone worker option"},
+		{name: "WithWorkerStrategy", opt: daramjwee.WithWorkerStrategy("pool"), msg: "standalone worker option"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := group.NewCache("bad", daramjwee.WithTiers(&optionsCompatibleStore{}), tc.opt)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.msg)
+		})
+	}
+}
+
+func TestNewGroup_CloseClosesCreatedCaches(t *testing.T) {
+	group, err := daramjwee.NewGroup(nil, daramjwee.WithGroupWorkers(1), daramjwee.WithGroupCloseTimeout(2*time.Second))
+	require.NoError(t, err)
+
+	cache, err := group.NewCache("closable", daramjwee.WithTiers(&optionsCompatibleStore{}))
+	require.NoError(t, err)
+
+	group.Close()
+
+	_, err = cache.Get(context.Background(), "k", daramjwee.GetRequest{}, optionsCompatibleNoopFetcher{})
+	require.ErrorIs(t, err, daramjwee.ErrCacheClosed)
+}
+
 type optionsCompatibleStore struct{}
 
 func (optionsCompatibleStore) GetStream(_ context.Context, _ string) (io.ReadCloser, *daramjwee.Metadata, error) {
@@ -102,3 +182,12 @@ type noopWriteSink struct{}
 func (noopWriteSink) Write(p []byte) (int, error) { return len(p), nil }
 func (noopWriteSink) Close() error                { return nil }
 func (noopWriteSink) Abort() error                { return nil }
+
+type optionsCompatibleNoopFetcher struct{}
+
+func (optionsCompatibleNoopFetcher) Fetch(context.Context, *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	return &daramjwee.FetchResult{
+		Body:     io.NopCloser(strings.NewReader("noop")),
+		Metadata: &daramjwee.Metadata{CacheTag: "noop"},
+	}, nil
+}

--- a/daramjwee.go
+++ b/daramjwee.go
@@ -281,57 +281,125 @@ func New(logger log.Logger, opts ...Option) (Cache, error) {
 		logger = log.NewNopLogger()
 	}
 
+	cfg, err := buildCacheConfig(cacheConstructionStandalone, nil, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	manager, err := worker.NewManager(cfg.WorkerStrategy, logger, cfg.Workers, cfg.WorkerQueue, cfg.WorkerTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	runtime := newStandaloneRuntime(manager)
+	cacheID := "standalone"
+	return newCacheFromConfig(logger, runtime, cacheID, cfg)
+}
+
+func buildCacheConfig(mode cacheConstructionMode, groupCfg *GroupConfig, opts ...Option) (Config, error) {
 	cfg := Config{
-		WorkerStrategy:    "pool",
 		OpTimeout:         30 * time.Second,
-		Workers:           1,
-		WorkerQueue:       500,
-		WorkerTimeout:     30 * time.Second,
-		CloseTimeout:      30 * time.Second,
 		PositiveFreshness: 0,
 		NegativeFreshness: 0,
 	}
 
 	for _, opt := range opts {
 		if err := opt(&cfg); err != nil {
-			return nil, err
+			return Config{}, err
+		}
+	}
+
+	switch mode {
+	case cacheConstructionStandalone:
+		if cfg.Weight > 0 || cfg.QueueLimit > 0 {
+			return Config{}, &ConfigError{"group-attached cache option cannot be used with New"}
+		}
+		if cfg.WorkerStrategy == "" {
+			cfg.WorkerStrategy = "pool"
+		}
+		if cfg.Workers == 0 {
+			cfg.Workers = 1
+		}
+		if cfg.WorkerQueue == 0 {
+			cfg.WorkerQueue = 500
+		}
+		if cfg.WorkerTimeout == 0 {
+			cfg.WorkerTimeout = 30 * time.Second
+		}
+		if cfg.CloseTimeout == 0 {
+			cfg.CloseTimeout = 30 * time.Second
+		}
+	case cacheConstructionGroup:
+		if groupCfg != nil {
+			if cfg.WorkerStrategy != "" {
+				return Config{}, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
+			}
+			if cfg.Workers != 0 {
+				return Config{}, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
+			}
+			if cfg.WorkerQueue != 0 {
+				return Config{}, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
+			}
+			if cfg.WorkerTimeout != 0 {
+				return Config{}, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
+			}
+			if cfg.Workers == 0 {
+				cfg.Workers = groupCfg.Workers
+			}
+			if cfg.WorkerQueue == 0 {
+				cfg.WorkerQueue = groupCfg.WorkerQueueDefault
+			}
+			if cfg.WorkerTimeout == 0 {
+				cfg.WorkerTimeout = groupCfg.WorkerTimeout
+			}
+			if cfg.QueueLimit == 0 {
+				cfg.QueueLimit = groupCfg.WorkerQueueDefault
+			}
+		}
+		if cfg.CloseTimeout == 0 {
+			cfg.CloseTimeout = 30 * time.Second
+		}
+		if cfg.OpTimeout == 0 {
+			cfg.OpTimeout = 30 * time.Second
 		}
 	}
 
 	if len(cfg.Tiers) == 0 {
-		return nil, &ConfigError{"at least one tier is required"}
+		return Config{}, &ConfigError{"at least one tier is required"}
 	}
 
 	seen := make([]Store, 0, len(cfg.Tiers))
 	for idx, tier := range cfg.Tiers {
 		if isNilStore(tier) {
-			return nil, &ConfigError{"tier cannot be nil"}
+			return Config{}, &ConfigError{"tier cannot be nil"}
 		}
 		if containsSameStore(seen, tier) {
-			return nil, &ConfigError{"duplicate tier store instance"}
+			return Config{}, &ConfigError{"duplicate tier store instance"}
 		}
 		if validator, ok := tier.(TierValidator); ok {
 			if err := validator.ValidateTier(idx); err != nil {
-				return nil, &ConfigError{fmt.Sprintf("tier %d %s", idx, err.Error())}
+				return Config{}, &ConfigError{fmt.Sprintf("tier %d %s", idx, err.Error())}
 			}
 		}
 		seen = append(seen, tier)
 	}
 	for idx := range cfg.TierFreshnessOverrides {
 		if idx < 0 || idx >= len(cfg.Tiers) {
-			return nil, &ConfigError{fmt.Sprintf("tier freshness override index %d is out of range", idx)}
+			return Config{}, &ConfigError{fmt.Sprintf("tier freshness override index %d is out of range", idx)}
 		}
 	}
 
-	workerManager, err := worker.NewManager(cfg.WorkerStrategy, logger, cfg.Workers, cfg.WorkerQueue, cfg.WorkerTimeout)
-	if err != nil {
-		return nil, err
-	}
+	return cfg, nil
+}
 
-	c := &DaramjweeCache{
+func newCacheFromConfig(logger log.Logger, runtime backgroundRuntime, cacheID string, cfg Config) (Cache, error) {
+	cache := &DaramjweeCache{
 		logger:                 logger,
+		runtime:                runtime,
+		cacheID:                cacheID,
 		tiers:                  append([]Store(nil), cfg.Tiers...),
-		worker:                 workerManager,
+		runtimeWeight:          cfg.Weight,
+		runtimeQueueLimit:      cfg.QueueLimit,
 		opTimeout:              cfg.OpTimeout,
 		closeTimeout:           cfg.CloseTimeout,
 		positiveFreshness:      cfg.PositiveFreshness,
@@ -340,8 +408,21 @@ func New(logger log.Logger, opts ...Option) (Cache, error) {
 		loggingDisabled:        isNoopLogger(logger),
 	}
 
-	level.Info(logger).Log("msg", "daramjwee cache initialized", "op_timeout", c.opTimeout)
-	return c, nil
+	if runtime != nil {
+		if err := runtime.Register(cacheID, CacheRuntimeConfig{Weight: maxInt(cfg.Weight, 1), QueueLimit: maxInt(cfg.QueueLimit, 1)}); err != nil {
+			return nil, err
+		}
+	}
+
+	level.Info(logger).Log("msg", "daramjwee cache initialized", "op_timeout", cache.opTimeout)
+	return cache, nil
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func containsSameStore(stores []Store, candidate Store) bool {

--- a/docs/plans/2026-04-10-cache-group-design.md
+++ b/docs/plans/2026-04-10-cache-group-design.md
@@ -175,9 +175,9 @@ For group-attached caches, `WithCloseTimeout(...)` is a per-cache quiescence tim
 
 Move shared runtime knobs to group configuration:
 
-- `WithWorkers(...)`
-- `WithWorkerTimeout(...)`
-- `WithWorkerQueueDefault(...)`
+- `WithGroupWorkers(...)`
+- `WithGroupWorkerTimeout(...)`
+- `WithGroupWorkerQueueDefault(...)`
 - `WithGroupCloseTimeout(...)`
 
 If `WithQueueLimit(...)` is omitted for a cache, the group default applies.
@@ -212,7 +212,7 @@ type CacheRuntimeConfig struct {
 type backgroundRuntime interface {
 	Register(cacheID string, cfg CacheRuntimeConfig) error
 	Submit(cacheID string, kind JobKind, job worker.Job) bool
-	Unregister(cacheID string)
+	CloseCache(cacheID string, timeout time.Duration) error
 	Shutdown(timeout time.Duration) error
 }
 ```
@@ -221,7 +221,7 @@ type backgroundRuntime interface {
 
 - register itself with a cache ID and runtime config
 - submit background jobs with its cache ID
-- unregister on close
+- close its own runtime handle on close
 
 The runtime should not need to know tier details or fetch semantics.
 

--- a/docs/plans/2026-04-10-cache-group-design.md
+++ b/docs/plans/2026-04-10-cache-group-design.md
@@ -1,0 +1,406 @@
+# Daramjwee CacheGroup Design
+
+**Date:** 2026-04-10
+
+## Goal
+
+Add a `CacheGroup` runtime container that allows multiple caches with different tier layouts to share one background worker runtime without collapsing cache-local policy boundaries.
+
+The target use case is:
+
+- cache A: `mem -> file`
+- cache B: `mem -> objectstore`
+- cache C: `file -> objectstore`
+
+Those caches should remain independently configured, but their background refresh and persist work should run through one shared worker system with basic fairness controls.
+
+## Problem
+
+Current `DaramjweeCache` instances are self-contained.
+
+- each cache owns its own worker manager
+- each cache owns its own worker queue semantics
+- `Close()` shuts down that cache's workers directly
+- refresh and persist submission paths are hard-coupled to the cache-local worker manager
+
+That model is simple for a single cache, but it becomes wasteful and operationally awkward when an application needs several caches with different tier chains:
+
+- each cache brings its own worker pool and queue
+- one busy cache cannot be coordinated with another
+- there is no group-level fairness or capacity control
+- later features such as predictive warming would have no shared runtime surface to build on
+
+## Design Principles
+
+### 1. Keep Cache Policy Local
+
+`Cache` remains the owner of:
+
+- tier chain
+- freshness policy
+- fanout behavior
+- write coordination
+- fetch contract
+
+`CacheGroup` must not become a policy layer that understands tier topology, freshness semantics, or origin rules.
+
+### 2. Move Runtime Ownership Up
+
+`CacheGroup` owns:
+
+- shared worker pool
+- shared scheduling runtime
+- per-cache queue registration
+- basic fairness
+- shared shutdown
+
+This keeps the boundary crisp:
+
+```text
+CacheGroup = shared runtime owner
+Cache      = cache policy owner
+```
+
+### 3. Preserve Existing Single-Cache Behavior
+
+The existing `New(...)` constructor should keep creating a self-contained cache with private worker ownership.
+
+Shared-runtime behavior must be opt-in through a new group construction path rather than silently changing the semantics of `New(...)`.
+
+### 4. Preserve Cache-Local Close Semantics
+
+Regardless of ownership model, `Cache.Close()` must still mean:
+
+- this cache stops accepting new background work
+- queued background work for this cache will not run
+- in-flight background work for this cache is driven to quiescence before `Close()` returns or times out
+
+Callers should not need to know whether a cache is self-contained or group-attached in order to rely on `Cache.Close()` as the cache-local shutdown boundary.
+
+### 5. Keep v1 Small
+
+The first version should solve only:
+
+- shared runtime ownership
+- per-cache bounded fairness
+- lifecycle separation
+
+It should not try to solve predictive warming, dependency graphs, or distributed scheduling yet.
+
+## Rejected Approaches
+
+### Global Queue Only
+
+Rejected because a single FIFO queue does not provide meaningful isolation between caches. One cache can still saturate the shared runtime and starve others.
+
+### Group-Owned Cache Policy
+
+Rejected because it would make `CacheGroup` understand tier ordering, freshness, fanout, and cache-local coordination semantics. That would blur boundaries and make the design hard to evolve.
+
+### Full Per-Cache Worker Stacks
+
+Rejected for v1 because it recreates most of the current complexity while adding a coordinating layer on top. It improves isolation but does not meaningfully simplify runtime ownership.
+
+## Chosen Design
+
+Use a shared bounded worker pool with per-cache bounded queues.
+
+- `CacheGroup` owns one runtime and one worker pool.
+- Each cache registered with the group gets its own queue and weight.
+- The group scheduler selects work from cache queues using a simple weighted round-robin style policy.
+- `Cache` continues to generate refresh and persist jobs, but job submission goes through the group runtime instead of a cache-private worker manager.
+
+This is the smallest design that preserves both:
+
+- different tier chains per cache
+- basic anti-starvation control
+
+## Public API Direction
+
+The existing `Cache` interface remains unchanged.
+
+```go
+type Cache interface {
+	Get(ctx context.Context, key string, req GetRequest, fetcher Fetcher) (*GetResponse, error)
+	Set(ctx context.Context, key string, metadata *Metadata) (WriteSink, error)
+	Delete(ctx context.Context, key string) error
+	ScheduleRefresh(ctx context.Context, key string, fetcher Fetcher) error
+	Close()
+}
+```
+
+Add a new group-level construction surface:
+
+```go
+type CacheGroup interface {
+	NewCache(name string, opts ...Option) (Cache, error)
+	Close()
+}
+
+func New(logger log.Logger, opts ...Option) (Cache, error)
+func NewGroup(logger log.Logger, opts ...GroupOption) (CacheGroup, error)
+```
+
+Rationale:
+
+- `New(...)` remains backward-compatible and self-contained
+- `NewGroup(...)` makes shared runtime ownership explicit
+- `Cache.Close()` keeps the same cache-local quiescence contract in both ownership models
+- only the underlying runtime owner changes
+
+## Configuration Model
+
+Separate cache-local options from group-runtime options.
+
+### Cache Options
+
+These remain cache-local and continue to use the existing `Option` namespace:
+
+- `WithTiers(...)`
+- `WithFreshness(...)`
+- `WithTierFreshness(...)`
+- `WithOpTimeout(...)`
+- `WithCloseTimeout(...)`
+
+Add cache-runtime knobs at cache creation time:
+
+- `WithWeight(int)`
+- `WithQueueLimit(int)`
+
+Those settings describe how this cache participates in the shared runtime. They do not change cache semantics.
+
+For group-attached caches, `WithCloseTimeout(...)` is a per-cache quiescence timeout used by `Cache.Close()`. It does not control shared runtime shutdown.
+
+### Group Options
+
+Move shared runtime knobs to group configuration:
+
+- `WithWorkers(...)`
+- `WithWorkerTimeout(...)`
+- `WithWorkerQueueDefault(...)`
+- `WithGroupCloseTimeout(...)`
+
+If `WithQueueLimit(...)` is omitted for a cache, the group default applies.
+
+### Option Validation Rules
+
+The constructors must reject invalid mixes explicitly with `ConfigError`. No option may be silently ignored.
+
+- `New(...)` accepts existing standalone worker options and rejects `WithWeight(...)` / `WithQueueLimit(...)`.
+- `NewGroup(...)` accepts only `GroupOption`.
+- `CacheGroup.NewCache(...)` accepts cache-local `Option` values and rejects standalone worker ownership options such as `WithWorkers(...)`, `WithWorkerQueue(...)`, `WithWorkerTimeout(...)`, and `WithWorkerStrategy(...)`.
+
+This keeps migration incremental without allowing reused option slices to misconfigure shared caches accidentally.
+
+## Internal Runtime Shape
+
+The internal runtime boundary should be narrow.
+
+```go
+type JobKind int
+
+const (
+	JobKindRefresh JobKind = iota
+	JobKindPersist
+)
+
+type CacheRuntimeConfig struct {
+	Weight     int
+	QueueLimit int
+}
+
+type backgroundRuntime interface {
+	Register(cacheID string, cfg CacheRuntimeConfig) error
+	Submit(cacheID string, kind JobKind, job worker.Job) bool
+	Unregister(cacheID string)
+	Shutdown(timeout time.Duration) error
+}
+```
+
+`Cache` should only need to:
+
+- register itself with a cache ID and runtime config
+- submit background jobs with its cache ID
+- unregister on close
+
+The runtime should not need to know tier details or fetch semantics.
+
+## Fairness Model
+
+v1 fairness should stay simple.
+
+- one shared worker pool
+- one bounded queue per cache
+- one scheduler that iterates non-empty cache queues
+- each cache receives dequeue opportunities according to its configured weight
+
+This gives useful operational behavior without turning the runtime into a complex scheduler.
+
+### What Fairness Means In v1
+
+Fairness is queue-selection fairness, not execution-time fairness.
+
+That distinction matters because jobs are not equal:
+
+- a refresh job may be short
+- a persist job may stream or copy much more data
+
+So v1 only guarantees:
+
+- one cache cannot fill another cache's queue
+- one cache cannot monopolize dequeue opportunities forever
+
+It does not guarantee equal CPU time, wall time, or bytes processed.
+
+That limitation should be documented rather than hidden behind misleading "weighted fairness" language.
+
+## Lifecycle Semantics
+
+This is the most important compatibility boundary.
+
+### `New(...)`
+
+- creates a self-contained cache
+- private runtime ownership
+- `Cache.Close()` shuts down that cache's own runtime
+
+### `NewGroup(...).NewCache(...)`
+
+- creates a cache attached to a shared runtime
+- `Cache.Close()` shuts down that cache's runtime handle inside the group
+- `CacheGroup.Close()` shuts down the shared runtime
+
+### Pending Jobs
+
+After a cache is closed:
+
+- new submissions from that cache are rejected
+- queued jobs for that cache are dropped before execution
+- execution re-checks whether the cache is closed before running the job body
+
+This avoids "ghost job" behavior where a cache is closed but old queued closures still mutate it later.
+
+### In-Flight Jobs
+
+The runtime should create a cancelable child context per registered cache.
+
+- jobs submitted for cache A run with cache A's runtime context
+- `Cache.Close()` cancels that cache context, rejects future submissions, drops queued work, and waits up to that cache's `WithCloseTimeout(...)` for already-running jobs to observe cancellation and finish cleanup
+- `CacheGroup.Close()` marks the group as closing, stops new dequeue work, cancels all cache contexts plus the group root context, and waits up to `WithGroupCloseTimeout(...)` for in-flight jobs to finish cleanup
+
+If the timeout expires, shutdown completes as a best-effort close and logs the timeout condition. The intent is not to force-kill goroutines, but to make job cancellation and drain behavior explicit.
+
+### Runtime Strategy
+
+Shared groups are pool-based only in v1.
+
+- `New(...)` may continue supporting existing standalone worker strategies
+- `NewGroup(...)` uses a bounded shared pool runtime
+- queue fairness claims in this document apply only to that bounded shared pool runtime
+
+The unbounded `"all"` strategy is not part of `CacheGroup` v1 because it cannot provide meaningful queue-based fairness.
+
+## Error Semantics
+
+The public API can continue returning `ErrBackgroundJobRejected` for submission failures.
+
+Internally, rejection reasons should be separated:
+
+- group shutting down
+- cache already closed
+- cache queue full
+
+That split keeps the public surface stable while preserving useful operational signals.
+
+## Observability
+
+Shared runtime without cache identity will be hard to operate.
+
+At minimum, logs and metrics should carry:
+
+- `cache_id`
+- `job_kind`
+- queue depth per cache
+- rejected job count
+- rejection reason
+
+This is especially important once more than one cache shares the runtime.
+
+## Migration Strategy
+
+The migration should be additive.
+
+1. Keep `New(...)` behavior unchanged.
+2. Introduce `CacheGroup` and a shared runtime implementation.
+3. Route refresh and persist job submission through an internal runtime interface.
+4. Make group-attached caches use the shared runtime.
+5. Keep all tier traversal, freshness, fanout, and write coordination logic inside `Cache`.
+
+This avoids a broad refactor of cache semantics while still making runtime ownership pluggable.
+
+## Testing
+
+Add focused coverage for the new ownership and fairness boundaries.
+
+### Constructor and Lifecycle
+
+- `New(...)` still creates a self-contained cache
+- `NewGroup(...).NewCache(...)` creates a shared-runtime cache
+- closing one shared cache does not stop the group runtime
+- closing the group stops all future submissions
+- invalid option combinations are rejected explicitly
+
+### Queue Isolation
+
+- one cache filling its queue does not consume another cache's queue capacity
+- queue full for cache A does not prevent cache B submission
+
+### Scheduling Behavior
+
+- weighted round-robin eventually services multiple active caches
+- a non-empty lower-weight cache still makes progress while a higher-weight cache is busy
+
+### Closed-Cache Safety
+
+- queued work for a closed cache does not execute
+- execution re-checks the cache closed state before running job bodies
+- in-flight work observes cache or group cancellation and exits through normal cleanup paths
+
+### Shutdown Ordering
+
+- cache close then group close
+- group close then cache close
+- concurrent close vs submit
+- idempotent repeated close calls
+- timeout-expiry behavior for cache close and group close
+
+### Backward Compatibility
+
+- existing single-cache worker tests still pass through `New(...)`
+- public `Cache` interface consumers do not need code changes
+
+## v1 Non-Goals
+
+The first version should explicitly exclude:
+
+- predictive warming
+- request tree or request DAG modeling
+- cross-cache dependency graphs
+- dynamic weight auto-tuning
+- byte-based or time-based fairness
+- cross-cache deduplication of jobs
+- group-level freshness or tier policy
+- changes to the public `Cache` interface
+- bringing the standalone `"all"` worker strategy into shared groups
+- distributed scheduling across processes or nodes
+
+## Follow-Up Work
+
+Once `CacheGroup` exists as a clean shared runtime owner, later work can attach to it more safely:
+
+- predictive warm planner
+- request-graph driven background jobs
+- cache-class defaults
+- richer runtime metrics
+
+Those should remain follow-up layers on top of the runtime, not reasons to let `CacheGroup` absorb cache-local policy.

--- a/docs/plans/2026-04-10-cache-group-implementation.md
+++ b/docs/plans/2026-04-10-cache-group-implementation.md
@@ -1,0 +1,476 @@
+# CacheGroup Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `CacheGroup` as a shared background-runtime owner for multiple caches with different tier chains while preserving cache-local policy and close semantics.
+
+**Architecture:** Keep `Cache` responsible for tiers, freshness, fanout, and fetch behavior. Add a narrow background runtime abstraction, implement a bounded shared group runtime with per-cache queues and weighted dequeue fairness, and make both standalone caches and group-attached caches satisfy the same cache-local shutdown contract.
+
+**Tech Stack:** Go, `go test`, `testify`, `go-kit/log`, existing `internal/worker` package
+
+---
+
+## File Map
+
+### New Files
+
+- `group.go`
+  - public `CacheGroup` interface
+  - `NewGroup(...)`
+  - group constructor wiring
+- `group_options.go`
+  - `GroupConfig`
+  - `GroupOption`
+  - group-only option helpers such as `WithGroupWorkers(...)`, `WithGroupWorkerQueueDefault(...)`, and `WithGroupCloseTimeout(...)`
+- `background_runtime.go`
+  - `backgroundRuntime` interface
+  - `JobKind`
+  - `CacheRuntimeConfig`
+  - shared runtime helper types
+- `background_runtime_standalone.go`
+  - standalone runtime wrapper used by `New(...)`
+- `background_runtime_group.go`
+  - bounded shared group runtime
+  - per-cache queue registration
+  - weighted dequeue scheduler
+- `background_runtime_test.go`
+  - root-package tests for runtime registration, queue limits, fairness, and shutdown
+- `tests/cache_group_integration_test.go`
+  - external API coverage for `NewGroup(...)`, shared-runtime caches, and group lifecycle
+- `tests/cache_group_close_test.go`
+  - external coverage for cache-local close semantics, queued-job dropping, and in-flight cancellation
+
+### Existing Files To Modify
+
+- `daramjwee.go`
+  - keep `New(...)` behavior intact
+  - create standalone runtime instead of constructing a worker manager directly in the cache
+  - add or move public `CacheGroup` declarations if kept here instead of `group.go`
+- `cache.go`
+  - replace direct worker ownership with runtime ownership
+  - add per-cache runtime identity and close behavior
+  - preserve cache-local quiescence contract
+- `cache_refresh.go`
+  - submit refresh work through `backgroundRuntime`
+- `cache_persist.go`
+  - submit persist work through `backgroundRuntime`
+- `options.go`
+  - reject group-only options in standalone cache construction
+  - add cache-runtime options `WithWeight(...)` and `WithQueueLimit(...)`
+  - keep existing option validation clear and explicit
+- `options_test.go`
+  - extend constructor validation for standalone vs group-attached option mixes
+- `constructor_validation_external_test.go`
+  - external constructor compatibility coverage for `New(...)` and `NewGroup(...)`
+- `README.md`
+  - document `NewGroup(...)`
+  - clarify standalone vs shared runtime ownership
+- `CHANGELOG.md`
+  - document the new `CacheGroup` API and option split
+
+### Existing Files To Reuse As References
+
+- `internal/worker/worker.go`
+  - existing worker-manager boundary to reuse for standalone runtime
+- `internal/worker/pool_strategy.go`
+  - bounded worker behavior that group runtime should mirror at a higher level
+- `tests/cache_regression_test.go`
+  - existing refresh/persist semantics and queue pressure patterns
+- `tests/cache_worker_stress_test.go`
+  - existing close-under-pressure behavior to preserve for standalone caches
+
+## Chunk 1: Runtime and API Boundary
+
+### Task 1: Lock Down Constructor and Option Rules First
+
+**Files:**
+- Modify: `options_test.go`
+- Modify: `constructor_validation_external_test.go`
+- Test: `options_test.go`
+- Test: `constructor_validation_external_test.go`
+
+- [ ] **Step 1: Write failing standalone/group option typing and validation tests**
+
+```go
+func TestNew_RejectsGroupRuntimeOptions(t *testing.T) {
+    _, err := New(nil, WithTiers(&optionsTestMockStore{id: 1}), WithWeight(2))
+    require.Error(t, err)
+    require.Contains(t, err.Error(), "group-attached cache option")
+}
+
+func TestNewGroup_UsesGroupOptionSurface(t *testing.T) {
+    _, err := NewGroup(nil, WithGroupWorkers(1), WithGroupWorkerQueueDefault(8))
+    require.NoError(t, err)
+}
+
+func TestNewCache_RejectsStandaloneWorkerOptions(t *testing.T) {
+    group, err := NewGroup(nil, WithGroupWorkers(1))
+    require.NoError(t, err)
+    defer group.Close()
+
+    _, err = group.NewCache("bad", WithTiers(&optionsTestMockStore{id: 1}), WithWorkers(2))
+    require.Error(t, err)
+    require.Contains(t, err.Error(), "standalone worker option")
+}
+```
+
+- [ ] **Step 2: Run targeted tests to verify failure**
+
+Run: `go test ./... -run 'Test(New_|Option).*'`
+Expected: FAIL because `NewGroup`, `WithGroupWorkers`, `WithWeight`, and group/cache option separation do not exist yet
+
+- [ ] **Step 3: Add minimal option and constructor surface**
+
+```go
+type GroupOption func(*GroupConfig) error
+
+func WithGroupWorkers(count int) GroupOption {
+    ...
+}
+
+func WithWeight(weight int) Option {
+    return func(cfg *Config) error {
+        if weight <= 0 {
+            return &ConfigError{"cache weight must be positive"}
+        }
+        cfg.RuntimeWeight = weight
+        return nil
+    }
+}
+```
+
+- [ ] **Step 4: Implement explicit invalid-mix validation where the type system cannot enforce it**
+
+```go
+if cfg.RuntimeWeight != 0 {
+    return nil, &ConfigError{"WithWeight is only valid for group-attached caches"}
+}
+```
+
+- [ ] **Step 5: Re-run targeted tests**
+
+Run: `go test ./... -run 'Test(New_|Option).*'`
+Expected: PASS for new validation coverage and existing option tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add options.go group_options.go options_test.go constructor_validation_external_test.go daramjwee.go
+git commit -m "refactor: split cache and group option validation"
+```
+
+### Task 2: Introduce the Background Runtime Abstraction
+
+**Files:**
+- Create: `background_runtime.go`
+- Create: `background_runtime_standalone.go`
+- Modify: `cache.go`
+- Modify: `daramjwee.go`
+- Test: `background_runtime_test.go`
+
+- [ ] **Step 1: Write failing runtime-shape tests**
+
+```go
+func TestStandaloneRuntime_CloseWaitsForRunningJobs(t *testing.T) {
+    rt := newStandaloneRuntime(...)
+    // submit blocking job, close, unblock, assert close returns
+}
+```
+
+- [ ] **Step 2: Run the runtime test to verify failure**
+
+Run: `go test ./... -run 'TestStandaloneRuntime_'`
+Expected: FAIL because the runtime abstraction does not exist
+
+- [ ] **Step 3: Add the narrow runtime interface and job kinds**
+
+```go
+type backgroundRuntime interface {
+    Register(cacheID string, cfg CacheRuntimeConfig) error
+    Submit(cacheID string, kind JobKind, job worker.Job) bool
+    CloseCache(cacheID string, timeout time.Duration) error
+    Shutdown(timeout time.Duration) error
+}
+```
+
+- [ ] **Step 4: Wrap the existing worker manager as a standalone runtime**
+
+```go
+type standaloneRuntime struct {
+    manager *worker.Manager
+    ...
+}
+```
+
+- [ ] **Step 5: Replace direct `worker.Manager` ownership in `DaramjweeCache`**
+- [ ] **Step 5: Add runtime ownership to `DaramjweeCache` without deleting `c.worker` yet**
+
+```go
+type DaramjweeCache struct {
+    worker  *worker.Manager // temporary bridge until refresh/persist switch to runtime
+    runtime backgroundRuntime
+    cacheID string
+    ...
+}
+```
+
+- [ ] **Step 6: Re-run runtime and cache constructor tests**
+
+Run: `go test ./... -run 'Test(StandaloneRuntime_|New_)'`
+Expected: PASS with a compiling tree and no standalone behavior change
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add background_runtime.go background_runtime_standalone.go cache.go daramjwee.go background_runtime_test.go
+git commit -m "refactor: introduce background runtime abstraction"
+```
+
+### Task 3: Implement the Shared Group Runtime and Public Group API
+
+**Files:**
+- Create: `group.go`
+- Create: `background_runtime_group.go`
+- Modify: `daramjwee.go`
+- Test: `background_runtime_test.go`
+- Test: `tests/cache_group_integration_test.go`
+
+- [ ] **Step 1: Write failing tests for group registration and queue isolation**
+
+```go
+func TestGroupRuntime_QueueIsolation(t *testing.T) {
+    group, err := NewGroup(nil, WithGroupWorkers(1), WithGroupWorkerQueueDefault(1))
+    require.NoError(t, err)
+    ...
+}
+```
+
+- [ ] **Step 2: Run targeted group tests to verify failure**
+
+Run: `go test ./... -run 'Test(GroupRuntime_|CacheGroup_)'`
+Expected: FAIL because `NewGroup(...)`, `WithGroupWorkers(...)`, and the group runtime do not exist
+
+- [ ] **Step 3: Add `CacheGroup` and `NewGroup(...)`**
+
+```go
+type CacheGroup interface {
+    NewCache(name string, opts ...Option) (Cache, error)
+    Close()
+}
+```
+
+- [ ] **Step 4: Implement bounded per-cache queues plus weighted dequeue**
+
+```go
+type groupRuntime struct {
+    workers int
+    caches  map[string]*registeredCache
+    ...
+}
+```
+
+- [ ] **Step 5: Ensure group runtime is pool-only and uses only group-prefixed runtime options**
+
+```go
+if cfg.GroupWorkerStrategy != "" {
+    return nil, &ConfigError{"group runtime uses a bounded shared pool only"}
+}
+```
+
+- [ ] **Step 6: Re-run group runtime and API tests**
+
+Run: `go test ./... -run 'Test(GroupRuntime_|CacheGroup_|NewGroup_)'`
+Expected: PASS for registration, queue isolation, and constructor validation
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add group.go group_options.go background_runtime_group.go background_runtime_test.go tests/cache_group_integration_test.go
+git commit -m "feat: add shared cache group runtime"
+```
+
+## Chunk 2: Cache Integration, Lifecycle, and Docs
+
+### Task 4: Switch Refresh and Persist Paths to the Runtime and Remove the Worker Bridge
+
+**Files:**
+- Modify: `cache_refresh.go`
+- Modify: `cache_persist.go`
+- Modify: `cache.go`
+- Test: `tests/cache_regression_test.go`
+- Test: `tests/cache_group_integration_test.go`
+
+- [ ] **Step 1: Add failing external tests for shared-cache refresh and persist**
+
+```go
+func TestCacheGroup_ScheduleRefresh_PersistsAcrossSharedRuntime(t *testing.T) {
+    // build group, create hot+cold cache, schedule refresh, verify top and lower-tier behavior
+}
+```
+
+- [ ] **Step 2: Run the targeted integration tests to verify failure**
+
+Run: `go test ./... -run 'Test(CacheGroup_|ScheduleRefresh_)'`
+Expected: FAIL because refresh/persist paths still submit directly through cache-local worker ownership
+
+- [ ] **Step 3: Replace direct submission in refresh flow**
+
+```go
+if !c.runtime.Submit(c.cacheID, JobKindRefresh, job) {
+    return ErrBackgroundJobRejected
+}
+```
+
+- [ ] **Step 4: Replace direct submission in persist flow**
+
+```go
+if !c.runtime.Submit(c.cacheID, JobKindPersist, job) {
+    c.warnLog("msg", "background set rejected", "key", key, "dest_tier", destTierIndex)
+}
+```
+
+- [ ] **Step 5: Re-run regression and shared-runtime integration tests**
+
+Run: `go test ./... -run 'Test(CacheGroup_|ScheduleRefresh_|Cache_CloseDuringRefreshQueuePressureStress)'`
+Expected: PASS for both standalone and group-attached caches
+
+- [ ] **Step 6: Remove the temporary `c.worker` bridge once callers are switched**
+
+```go
+type DaramjweeCache struct {
+    runtime backgroundRuntime
+    cacheID string
+    ...
+}
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cache_refresh.go cache_persist.go cache.go tests/cache_group_integration_test.go tests/cache_regression_test.go
+git commit -m "refactor: route background cache jobs through runtime"
+```
+
+### Task 5: Implement Cache-Local Close Quiescence on Top of Shared Runtime
+
+**Files:**
+- Modify: `cache.go`
+- Modify: `background_runtime_group.go`
+- Modify: `background_runtime_standalone.go`
+- Test: `tests/cache_group_close_test.go`
+- Test: `tests/cache_worker_stress_test.go`
+- Test: `background_runtime_test.go`
+
+- [ ] **Step 1: Write failing close semantics tests first**
+
+```go
+func TestCacheGroup_CloseCache_DropsQueuedWorkAndWaitsForRunningJobs(t *testing.T) {}
+func TestCacheGroup_Close_StopsFutureDequeuesAndTimesOutBestEffort(t *testing.T) {}
+func TestCacheGroup_CloseOrdering_CacheThenGroupIsSafe(t *testing.T) {}
+func TestCacheGroup_CloseOrdering_GroupThenCacheIsSafe(t *testing.T) {}
+func TestCacheGroup_Close_IsIdempotent(t *testing.T) {}
+func TestCacheGroup_CloseCache_IsIdempotent(t *testing.T) {}
+func TestCacheGroup_Close_ConcurrentSubmitIsSafe(t *testing.T) {}
+func TestCacheGroup_CloseCache_DequeueRaceRechecksClosedState(t *testing.T) {}
+func TestCacheGroup_Close_CancelsRunningJobContext(t *testing.T) {}
+```
+
+- [ ] **Step 2: Run the targeted close tests to verify failure**
+
+Run: `go test ./... -run 'Test(CacheGroup_Close|Cache_CloseDuringRefreshQueuePressureStress|StandaloneRuntime_Close)'`
+Expected: FAIL because shared runtime cache-close quiescence does not exist yet
+
+- [ ] **Step 3: Add per-cache cancellation and close waiting**
+
+```go
+func (r *groupRuntime) CloseCache(cacheID string, timeout time.Duration) error {
+    // mark closed, cancel cache context, drop queued jobs, wait for in-flight jobs
+}
+```
+
+- [ ] **Step 4: Add group shutdown behavior**
+
+```go
+func (g *cacheGroup) Close() {
+    _ = g.runtime.Shutdown(g.closeTimeout)
+}
+```
+
+- [ ] **Step 5: Re-run close, stress, and regression coverage**
+
+Run: `go test ./... -run 'Test(CacheGroup_Close|Cache_CloseDuringRefreshQueuePressureStress|ScheduleRefresh_|StandaloneRuntime_Close)'`
+Expected: PASS for clean shutdown, ordering, idempotency, concurrent close-vs-submit, and timeout-path behavior
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cache.go background_runtime_group.go background_runtime_standalone.go tests/cache_group_close_test.go tests/cache_worker_stress_test.go background_runtime_test.go
+git commit -m "feat: preserve cache-local close semantics in shared runtime"
+```
+
+### Task 6: Finish Documentation and Compatibility Coverage
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Modify: `options_test.go`
+- Test: `tests/cache_group_integration_test.go`
+
+- [ ] **Step 1: Add failing doc-adjacent tests if constructor examples changed**
+
+```go
+func TestNewGroup_StandaloneWorkerOptionsRejected(t *testing.T) {
+    ...
+}
+```
+
+- [ ] **Step 2: Update README and changelog**
+
+```md
+- `New(...)` still creates a self-contained cache.
+- `NewGroup(...)` creates multiple caches that share one bounded background runtime.
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `go test ./...`
+Expected: PASS
+
+- [ ] **Step 4: Spot-check package docs and examples**
+
+Run: `rg -n "WithWorkerStrategy|NewGroup|WithWeight|WithQueueLimit" README.md CHANGELOG.md examples tests`
+Expected: only valid standalone references to `WithWorkerStrategy("all")`; group docs should describe pool-only shared runtime
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md CHANGELOG.md options_test.go tests/cache_group_integration_test.go docs/plans/2026-04-10-cache-group-design.md
+git commit -m "docs: document cache group runtime behavior"
+```
+
+## Execution Notes
+
+- Keep `Cache` interface unchanged in v1.
+- Do not bring the standalone `"all"` worker strategy into `CacheGroup`.
+- Prefer additive files over overloading `cache.go` further.
+- Preserve the observable `Cache.Close()` contract for both standalone and group-attached caches.
+- Keep predictive warming out of this implementation slice.
+
+## Verification Checklist
+
+- `New(...)` remains backward-compatible for existing callers
+- `NewGroup(...)` can create multiple caches with different tier chains
+- one cache queue filling up does not block submissions to another cache
+- `Cache.Close()` on a group-attached cache drops queued jobs for that cache and waits for in-flight work up to timeout
+- `CacheGroup.Close()` shuts down the shared runtime without leaving accepted jobs running indefinitely
+- cache close then group close is safe
+- group close then cache close is safe
+- repeated close calls are idempotent
+- concurrent close vs submit does not race into invalid state
+- a job that has been dequeued but not yet started re-checks closed state before executing
+- an in-flight job observes cache/group cancellation through its context and exits via cleanup
+- existing standalone worker regression and stress tests still pass
+
+## Handoff
+
+Plan complete and saved to `docs/plans/2026-04-10-cache-group-implementation.md`. Ready to execute?

--- a/examples/cache_group/README.md
+++ b/examples/cache_group/README.md
@@ -1,0 +1,30 @@
+# CacheGroup Example
+
+This example shows how to create multiple caches that share one bounded
+background runtime through `daramjwee.NewGroup(...)`.
+
+It demonstrates:
+
+- one shared `CacheGroup`
+- two caches with different tier layouts
+- group-level runtime options via `WithGroup...`
+- per-cache runtime tuning via `WithWeight(...)` and `WithQueueLimit(...)`
+
+## Run
+
+From this directory:
+
+```bash
+go run .
+```
+
+Expected flow:
+
+1. create one shared runtime with `WithGroupWorkers(2)`
+2. create a `users` cache with `mem -> file`
+3. create a `reports` cache with `file` only
+4. fetch one value through each cache
+5. schedule background refresh on both caches
+
+The example uses only local temporary directories and does not require any
+external service.

--- a/examples/cache_group/main.go
+++ b/examples/cache_group/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee"
+	"github.com/mrchypark/daramjwee/pkg/policy"
+	"github.com/mrchypark/daramjwee/pkg/store/filestore"
+	"github.com/mrchypark/daramjwee/pkg/store/memstore"
+)
+
+type simpleFetcher struct {
+	label string
+	data  string
+	tag   string
+}
+
+func (f simpleFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	oldTag := "none"
+	if oldMetadata != nil && oldMetadata.CacheTag != "" {
+		oldTag = oldMetadata.CacheTag
+	}
+	fmt.Printf("[%s origin] fetch (old=%s)\n", f.label, oldTag)
+	return &daramjwee.FetchResult{
+		Body:     io.NopCloser(strings.NewReader(f.data)),
+		Metadata: &daramjwee.Metadata{CacheTag: f.tag},
+	}, nil
+}
+
+func main() {
+	ctx := context.Background()
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+
+	baseDir, err := os.MkdirTemp("", "daramjwee-cache-group-example-")
+	if err != nil {
+		fmt.Printf("failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(baseDir)
+
+	userTier0 := memstore.New(512*1024, policy.NewLRU())
+	userTier1, err := filestore.New(baseDir+"/users", logger)
+	if err != nil {
+		fmt.Printf("failed to create user file tier: %v\n", err)
+		os.Exit(1)
+	}
+
+	reportTier0, err := filestore.New(baseDir+"/reports", logger)
+	if err != nil {
+		fmt.Printf("failed to create report file tier: %v\n", err)
+		os.Exit(1)
+	}
+
+	group, err := daramjwee.NewGroup(
+		logger,
+		daramjwee.WithGroupWorkers(2),
+		daramjwee.WithGroupWorkerQueueDefault(8),
+		daramjwee.WithGroupWorkerTimeout(5*time.Second),
+		daramjwee.WithGroupCloseTimeout(5*time.Second),
+	)
+	if err != nil {
+		fmt.Printf("failed to create cache group: %v\n", err)
+		os.Exit(1)
+	}
+	defer group.Close()
+
+	userCache, err := group.NewCache(
+		"users",
+		daramjwee.WithTiers(userTier0, userTier1),
+		daramjwee.WithFreshness(time.Minute, 10*time.Second),
+		daramjwee.WithWeight(4),
+		daramjwee.WithQueueLimit(8),
+	)
+	if err != nil {
+		fmt.Printf("failed to create user cache: %v\n", err)
+		os.Exit(1)
+	}
+	defer userCache.Close()
+
+	reportCache, err := group.NewCache(
+		"reports",
+		daramjwee.WithTiers(reportTier0),
+		daramjwee.WithFreshness(2*time.Minute, 30*time.Second),
+		daramjwee.WithWeight(1),
+	)
+	if err != nil {
+		fmt.Printf("failed to create report cache: %v\n", err)
+		os.Exit(1)
+	}
+	defer reportCache.Close()
+
+	userFetcher := simpleFetcher{
+		label: "users",
+		data:  `{"id":1,"name":"Ada Lovelace"}`,
+		tag:   "user-v1",
+	}
+	reportFetcher := simpleFetcher{
+		label: "reports",
+		data:  "daily-report-v1",
+		tag:   "report-v1",
+	}
+
+	fmt.Println("=== CacheGroup Demo ===")
+	fmt.Println("shared runtime: workers=2 queue_default=8")
+	fmt.Println("user cache: mem -> file, weight=4, queue=8")
+	fmt.Println("report cache: file only, weight=1, queue=default")
+
+	userResp, err := userCache.Get(ctx, "user:1", daramjwee.GetRequest{}, userFetcher)
+	if err != nil {
+		fmt.Printf("user cache get failed: %v\n", err)
+		os.Exit(1)
+	}
+	userBody, err := io.ReadAll(userResp)
+	_ = userResp.Close()
+	if err != nil {
+		fmt.Printf("user cache read failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("user payload: %s\n", string(userBody))
+
+	reportResp, err := reportCache.Get(ctx, "report:daily", daramjwee.GetRequest{}, reportFetcher)
+	if err != nil {
+		fmt.Printf("report cache get failed: %v\n", err)
+		os.Exit(1)
+	}
+	reportBody, err := io.ReadAll(reportResp)
+	_ = reportResp.Close()
+	if err != nil {
+		fmt.Printf("report cache read failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("report payload: %s\n", string(reportBody))
+
+	if err := userCache.ScheduleRefresh(ctx, "user:1", userFetcher); err != nil {
+		fmt.Printf("user refresh schedule failed: %v\n", err)
+		os.Exit(1)
+	}
+	if err := reportCache.ScheduleRefresh(ctx, "report:daily", reportFetcher); err != nil {
+		fmt.Printf("report refresh schedule failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("scheduled background refresh on both caches")
+
+	time.Sleep(200 * time.Millisecond)
+	fmt.Println("cache group example complete")
+}

--- a/examples/cache_group/main.go
+++ b/examples/cache_group/main.go
@@ -68,7 +68,6 @@ func main() {
 		fmt.Printf("failed to create cache group: %v\n", err)
 		os.Exit(1)
 	}
-	defer group.Close()
 
 	userCache, err := group.NewCache(
 		"users",
@@ -94,6 +93,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer reportCache.Close()
+	defer group.Close()
 
 	userFetcher := simpleFetcher{
 		label: "users",

--- a/examples/file_objstore/README.md
+++ b/examples/file_objstore/README.md
@@ -1,6 +1,7 @@
 # Ordered `FileStore -> objectstore` Example
 
-This example shows a practical ordered-tier deployment:
+This example shows a practical ordered-tier deployment against a real Google
+Cloud Storage bucket:
 
 - **tier 0**: `FileStore`
 - **tier 1**: `objectstore` backed by Google Cloud Storage
@@ -10,6 +11,9 @@ It demonstrates the main intended split of responsibilities:
 - `FileStore` is the user-visible local filesystem cache tier.
 - `objectstore` is the larger remote backing tier.
 - `objectstore.WithDir(...)` is a local workspace for ingest/catalog state, not a replacement for `FileStore`.
+
+If you want a fully local emulator-backed smoke test instead of real GCS,
+use [`examples/file_objstore_gcs_vind`](../file_objstore_gcs_vind).
 
 ## Why this layout is useful
 
@@ -38,10 +42,10 @@ go run .
 The example expects a `config.yaml` in this directory.
 
 Use real GCS credentials if you want to verify lower-tier recovery in step 5.
-With placeholder values, the example may fail during GCS client initialization
-or continue only until tier-1 access is attempted. In that case, the logs will
-show GCS access failures and origin fallback instead of a true `objectstore`
-hit.
+Placeholder values are only documentation scaffolding. Depending on which
+fields are invalid, the example can fail immediately during GCS client
+construction or later when tier-1 access is attempted. They are not expected to
+exercise the full scenario successfully.
 
 ## Configuration
 

--- a/examples/file_objstore/README.md
+++ b/examples/file_objstore/README.md
@@ -37,6 +37,12 @@ go run .
 
 The example expects a `config.yaml` in this directory.
 
+Use real GCS credentials if you want to verify lower-tier recovery in step 5.
+With placeholder values, the example may fail during GCS client initialization
+or continue only until tier-1 access is attempted. In that case, the logs will
+show GCS access failures and origin fallback instead of a true `objectstore`
+hit.
+
 ## Configuration
 
 This example uses the generic `thanos-io/objstore/client` format:

--- a/examples/file_objstore_gcs_vind/README.md
+++ b/examples/file_objstore_gcs_vind/README.md
@@ -1,0 +1,83 @@
+# Local `FileStore -> objectstore(GCS)` Example via `vcluster` Docker Driver
+
+This example runs the existing ordered-tier `FileStore -> objectstore` scenario
+against a local GCS emulator instead of real Google Cloud Storage.
+
+- runtime: `vcluster` with the Docker driver
+- emulator: `gcsemulator`
+- cache shape: tier 0 `FileStore`, tier 1 `objectstore` backed by a GCS bucket
+
+Use this when you want a fully local smoke test of the GCS-backed objectstore
+path. If you want a real cloud bucket example instead, use
+[`examples/file_objstore`](../file_objstore) or
+[`examples/file_objstore_provider`](../file_objstore_provider).
+
+## Prerequisites
+
+- `docker`
+- `go`
+- `kubectl`
+- `vcluster`
+
+## Quick Run
+
+```bash
+./run.sh
+```
+
+## Verification Run
+
+```bash
+./verify.sh
+```
+
+The example is self-checking. It fails if any of these transitions do not
+happen:
+
+- the first request populates tier 0 with at least one local file
+- the first request persists at least two remote objects into the GCS emulator
+- deleting tier 0 removes the local files while tier 1 still keeps remote data
+- the final request promotes data back into tier 0 after the wipe
+
+The script will:
+
+1. create or reuse a local `vcluster` on the Docker driver
+2. deploy `gcsemulator`
+3. port-forward the emulator to `127.0.0.1:4443`
+4. run `go run .` with the right environment variables
+
+## Manual Run
+
+Create or reuse a local cluster and export a kubeconfig:
+
+```bash
+vcluster create daramjwee-local --namespace daramjwee-local --driver docker --connect=false --background-proxy=false
+vcluster connect daramjwee-local --namespace daramjwee-local --driver docker --print >/tmp/daramjwee-gcs.kubeconfig
+```
+
+Deploy and port-forward the emulator:
+
+```bash
+kubectl --kubeconfig /tmp/daramjwee-gcs.kubeconfig apply -f manifests
+kubectl --kubeconfig /tmp/daramjwee-gcs.kubeconfig rollout status deployment/gcsemulator --timeout=180s
+kubectl --kubeconfig /tmp/daramjwee-gcs.kubeconfig port-forward service/gcsemulator 4443:9000
+```
+
+In another shell, run the example:
+
+```bash
+export DARAMJWEE_GCS_EMULATOR_HOST=127.0.0.1:4443
+export DARAMJWEE_GCS_BUCKET=daramjwee-gcs-local
+go run .
+```
+
+## Environment
+
+- `DARAMJWEE_GCS_EMULATOR_HOST`
+  Default: `127.0.0.1:4443`
+- `DARAMJWEE_GCS_BUCKET`
+  Default: `daramjwee-gcs-local`
+
+The example uses `STORAGE_EMULATOR_HOST` internally so the Google Cloud Storage
+client and the Thanos GCS provider both target the local emulator without a
+real service account.

--- a/examples/file_objstore_gcs_vind/main.go
+++ b/examples/file_objstore_gcs_vind/main.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"reflect"
+	"time"
+	"unsafe"
+
+	"cloud.google.com/go/storage"
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee/examples/internal/objectstoredemo"
+	"github.com/thanos-io/objstore/providers/gcs"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+type exampleConfig struct {
+	bucket       string
+	emulatorHost string
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller, "example", "file_objstore_gcs_vind")
+
+	cfg, err := loadExampleConfig(os.Getenv)
+	if err != nil {
+		fatal(logger, "load example config", err)
+	}
+
+	restoreEnv := setEmulatorEnv(cfg.emulatorHost)
+	defer restoreEnv()
+
+	if err := ensureBucketReady(ctx, cfg); err != nil {
+		fatal(logger, "prepare gcsemulator bucket", err)
+	}
+
+	bucketCfg, err := buildBucketConfig(cfg)
+	if err != nil {
+		fatal(logger, "build GCS objectstore config", err)
+	}
+	bucket, err := gcs.NewBucketWithConfig(ctx, logger, bucketCfg, "daramjwee", func(rt http.RoundTripper) http.RoundTripper {
+		return &loggingRoundTripper{next: rt}
+	})
+	if err != nil {
+		fatal(logger, "create GCS objectstore bucket", err)
+	}
+	defer bucket.Close()
+
+	prefix := fmt.Sprintf("examples/%s/%d", objectstoredemo.SanitizePrefix("file-objstore-gcs-vind"), time.Now().UnixNano())
+	summary, err := objectstoredemo.RunOrderedTierScenario(ctx, logger, bucket, prefix, "gcsemulator")
+	if err != nil {
+		fatal(logger, "run ordered-tier scenario", err)
+	}
+	_ = logger.Log("level", "info", "msg", "verification summary", "tier0_dir", summary.Tier0Dir, "tier1_workspace", summary.Tier1Workspace)
+}
+
+func loadExampleConfig(getenv func(string) string) (exampleConfig, error) {
+	cfg := exampleConfig{
+		bucket:       getenvDefault(getenv, "DARAMJWEE_GCS_BUCKET", "daramjwee-gcs-local"),
+		emulatorHost: getenvDefault(getenv, "DARAMJWEE_GCS_EMULATOR_HOST", "127.0.0.1:4443"),
+	}
+	if cfg.bucket == "" {
+		return exampleConfig{}, errors.New("DARAMJWEE_GCS_BUCKET must not be empty")
+	}
+	if cfg.emulatorHost == "" {
+		return exampleConfig{}, errors.New("DARAMJWEE_GCS_EMULATOR_HOST must not be empty")
+	}
+	return cfg, nil
+}
+
+func buildBucketConfig(cfg exampleConfig) (gcs.Config, error) {
+	conf := gcs.Config{
+		Bucket:  cfg.bucket,
+		UseGRPC: false,
+	}
+	// The Thanos GCS provider keeps emulator anonymous mode behind a private field.
+	// This example opts into that mode explicitly so fake-gcs-server can run without ADC.
+	if err := setPrivateBool(&conf, "noAuth", true); err != nil {
+		return gcs.Config{}, err
+	}
+	return conf, nil
+}
+
+func ensureBucketReady(ctx context.Context, cfg exampleConfig) error {
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		if err := ensureBucket(ctx, cfg.bucket); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for fake-gcs-server bucket readiness: %w", lastErr)
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func ensureBucket(ctx context.Context, bucketName string) error {
+	client, err := storage.NewClient(ctx, option.WithoutAuthentication())
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	handle := client.Bucket(bucketName)
+	if _, err := handle.Attrs(ctx); err == nil {
+		return nil
+	} else {
+		var gErr *googleapi.Error
+		if !errors.As(err, &gErr) || gErr.Code != http.StatusNotFound {
+			return err
+		}
+	}
+
+	if err := handle.Create(ctx, "daramjwee-local", nil); err != nil {
+		var gErr *googleapi.Error
+		if errors.As(err, &gErr) && gErr.Code == http.StatusConflict {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func setEmulatorEnv(host string) func() {
+	prevStorage, hadStorage := os.LookupEnv("STORAGE_EMULATOR_HOST")
+	prevGCS, hadGCS := os.LookupEnv("GCS_EMULATOR_HOST")
+	_ = os.Setenv("STORAGE_EMULATOR_HOST", host)
+	_ = os.Setenv("GCS_EMULATOR_HOST", host)
+
+	return func() {
+		restoreEnv("STORAGE_EMULATOR_HOST", prevStorage, hadStorage)
+		restoreEnv("GCS_EMULATOR_HOST", prevGCS, hadGCS)
+	}
+}
+
+func restoreEnv(key string, value string, hadValue bool) {
+	if hadValue {
+		_ = os.Setenv(key, value)
+		return
+	}
+	_ = os.Unsetenv(key)
+}
+
+func setPrivateBool(target interface{}, fieldName string, value bool) error {
+	field := reflect.ValueOf(target).Elem().FieldByName(fieldName)
+	if !field.IsValid() {
+		return fmt.Errorf("field %q not found on %T", fieldName, target)
+	}
+	if field.Kind() != reflect.Bool {
+		return fmt.Errorf("field %q on %T is %s, want bool", fieldName, target, field.Kind())
+	}
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().SetBool(value)
+	return nil
+}
+
+func getenvDefault(getenv func(string) string, key string, fallback string) string {
+	if value := getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func fatal(logger log.Logger, msg string, err error) {
+	_ = logger.Log("level", "error", "msg", msg, "err", err)
+	os.Exit(1)
+}
+
+type loggingRoundTripper struct {
+	next http.RoundTripper
+}
+
+func (l *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller, "transport", "gcs")
+	_ = logger.Log("level", "debug", "msg", "request start", "method", req.Method, "url", req.URL.String())
+	start := time.Now()
+	resp, err := l.next.RoundTrip(req)
+	if err != nil {
+		_ = logger.Log("level", "error", "msg", "request failed", "err", err, "duration", time.Since(start))
+		return nil, err
+	}
+	_ = logger.Log("level", "debug", "msg", "request complete", "status", resp.Status, "duration", time.Since(start))
+	return resp, nil
+}

--- a/examples/file_objstore_gcs_vind/main_test.go
+++ b/examples/file_objstore_gcs_vind/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/thanos-io/objstore/providers/gcs"
+)
+
+func TestLoadExampleConfigDefaults(t *testing.T) {
+	cfg, err := loadExampleConfig(func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("loadExampleConfig returned error: %v", err)
+	}
+
+	if cfg.bucket != "daramjwee-gcs-local" {
+		t.Fatalf("expected default bucket, got %q", cfg.bucket)
+	}
+	if cfg.emulatorHost != "127.0.0.1:4443" {
+		t.Fatalf("expected default emulator host, got %q", cfg.emulatorHost)
+	}
+}
+
+func TestBuildBucketConfig(t *testing.T) {
+	cfg := exampleConfig{
+		bucket:       "bucket-a",
+		emulatorHost: "127.0.0.1:5555",
+	}
+
+	conf, err := buildBucketConfig(cfg)
+	if err != nil {
+		t.Fatalf("buildBucketConfig returned error: %v", err)
+	}
+	if conf.Bucket != "bucket-a" {
+		t.Fatalf("expected bucket in config, got %q", conf.Bucket)
+	}
+	if conf.UseGRPC {
+		t.Fatalf("expected HTTP client mode for fake-gcs-server")
+	}
+	if !readNoAuthField(conf) {
+		t.Fatalf("expected private noAuth field to be enabled for emulator mode")
+	}
+}
+
+func readNoAuthField(conf gcs.Config) bool {
+	value := reflect.ValueOf(&conf).Elem()
+	field := value.FieldByName("noAuth")
+	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Bool()
+}
+
+func TestBuildBucketConfigLeavesNoAuthReadable(t *testing.T) {
+	conf, err := buildBucketConfig(exampleConfig{bucket: "bucket-b", emulatorHost: "127.0.0.1:4443"})
+	if err != nil {
+		t.Fatalf("buildBucketConfig returned error: %v", err)
+	}
+	if !readNoAuthField(conf) {
+		t.Fatalf("expected noAuth to remain enabled")
+	}
+}

--- a/examples/file_objstore_gcs_vind/manifests/fake-gcs-server.yaml
+++ b/examples/file_objstore_gcs_vind/manifests/fake-gcs-server.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcsemulator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gcsemulator
+  template:
+    metadata:
+      labels:
+        app: gcsemulator
+    spec:
+      containers:
+        - name: gcsemulator
+          image: fullstorydev/gcsemulator@sha256:739edad40c5b977c7d9b41573eb6dfa8c376a5351bb197a52a5c24a9f517a70b
+          args:
+            - -host
+            - 0.0.0.0
+            - -port
+            - "9000"
+          ports:
+            - name: http
+              containerPort: 9000
+          readinessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 1
+            periodSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gcsemulator
+spec:
+  selector:
+    app: gcsemulator
+  ports:
+    - name: http
+      port: 9000
+      targetPort: 9000

--- a/examples/file_objstore_gcs_vind/run.sh
+++ b/examples/file_objstore_gcs_vind/run.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER_NAME="${DARAMJWEE_VCLUSTER_NAME:-daramjwee-local}"
+CLUSTER_NAMESPACE="${DARAMJWEE_VCLUSTER_NAMESPACE:-${CLUSTER_NAME}}"
+LOCAL_PORT="${DARAMJWEE_GCS_LOCAL_PORT:-4443}"
+SERVICE_NAME="gcsemulator"
+KUBECONFIG_PATH="$(mktemp -t daramjwee-gcs-kubeconfig-XXXXXX)"
+PORT_FORWARD_LOG="$(mktemp -t daramjwee-gcs-portforward-XXXXXX.log)"
+PORT_FORWARD_PID=""
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+wait_for_port_forward() {
+  local pid="$1"
+  local log_file="$2"
+  local port="$3"
+  for _ in $(seq 1 60); do
+    if ! kill -0 "${pid}" >/dev/null 2>&1; then
+      echo "kubectl port-forward exited before becoming ready" >&2
+      cat "${log_file}" >&2 || true
+      return 1
+    fi
+    if grep -q "Forwarding from 127.0.0.1:${port}" "${log_file}" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timed out waiting for kubectl port-forward on 127.0.0.1:${port}" >&2
+  cat "${log_file}" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${PORT_FORWARD_PID}" ]] && kill -0 "${PORT_FORWARD_PID}" >/dev/null 2>&1; then
+    kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+    wait "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+  fi
+  rm -f "${KUBECONFIG_PATH}" "${PORT_FORWARD_LOG}"
+}
+trap cleanup EXIT
+
+require_cmd docker
+require_cmd go
+require_cmd kubectl
+require_cmd vcluster
+
+if ! vcluster connect "${CLUSTER_NAME}" --namespace "${CLUSTER_NAMESPACE}" --driver docker --print >"${KUBECONFIG_PATH}" 2>/dev/null; then
+  vcluster create "${CLUSTER_NAME}" \
+    --namespace "${CLUSTER_NAMESPACE}" \
+    --driver docker \
+    --connect=false \
+    --background-proxy=false \
+    --create-namespace
+  vcluster connect "${CLUSTER_NAME}" --namespace "${CLUSTER_NAMESPACE}" --driver docker --print >"${KUBECONFIG_PATH}"
+fi
+
+kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f "${SCRIPT_DIR}/manifests"
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deployment/"${SERVICE_NAME}" --timeout=180s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" port-forward service/"${SERVICE_NAME}" "${LOCAL_PORT}:9000" >"${PORT_FORWARD_LOG}" 2>&1 &
+PORT_FORWARD_PID=$!
+wait_for_port_forward "${PORT_FORWARD_PID}" "${PORT_FORWARD_LOG}" "${LOCAL_PORT}"
+
+export DARAMJWEE_GCS_EMULATOR_HOST="127.0.0.1:${LOCAL_PORT}"
+export DARAMJWEE_GCS_BUCKET="${DARAMJWEE_GCS_BUCKET:-daramjwee-gcs-local}"
+
+cd "${SCRIPT_DIR}"
+go run .

--- a/examples/file_objstore_gcs_vind/verify.sh
+++ b/examples/file_objstore_gcs_vind/verify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+echo "Verifying local FileStore -> objectstore(GCS) transitions..."
+./run.sh

--- a/examples/file_objstore_provider/README.md
+++ b/examples/file_objstore_provider/README.md
@@ -33,6 +33,12 @@ The example uses a `config.yaml` file to configure the connection to Google Clou
 
 Run the example from this directory and replace the placeholder values with your own GCS bucket and service account JSON.
 
+Use real GCS credentials if you want to verify the lower-tier recovery path.
+With placeholder values, the example may fail during GCS client initialization
+or continue only until tier-1 access is attempted. In that case, the logs will
+show GCS access failures and origin fallback instead of a true remote-cache
+hit.
+
 ```yaml
 bucket: "<YOUR_GCS_BUCKET>"
 service_account: |-

--- a/examples/file_objstore_provider/README.md
+++ b/examples/file_objstore_provider/README.md
@@ -1,6 +1,7 @@
 # Daramjwee Google Cloud Storage Objectstore Example
 
-This example demonstrates how to configure `daramjwee` with ordered tiers:
+This example demonstrates how to configure `daramjwee` with ordered tiers
+against a real Google Cloud Storage bucket:
 
 - **Tier 0**: `fileStore`, using the local filesystem for fast access.
 - **Tier 1**: `objectstore`, using Google Cloud Storage as a larger backing tier.
@@ -12,6 +13,9 @@ It also illustrates an important `objectstore` rule:
 - `FileStore` is the actual local filesystem cache tier.
 - `objectstore.WithDir(...)` is only the backend's local workspace for ingest/catalog state.
 - If tier 0 is wiped, tier 1 can still serve remote-flushed entries and repopulate tier 0 on demand.
+
+If you want a fully local emulator-backed smoke test instead of real GCS,
+use [`examples/file_objstore_gcs_vind`](../file_objstore_gcs_vind).
 
 ## Run
 
@@ -34,10 +38,10 @@ The example uses a `config.yaml` file to configure the connection to Google Clou
 Run the example from this directory and replace the placeholder values with your own GCS bucket and service account JSON.
 
 Use real GCS credentials if you want to verify the lower-tier recovery path.
-With placeholder values, the example may fail during GCS client initialization
-or continue only until tier-1 access is attempted. In that case, the logs will
-show GCS access failures and origin fallback instead of a true remote-cache
-hit.
+Placeholder values are only documentation scaffolding. Depending on which
+fields are invalid, the example can fail immediately during GCS client
+construction or later when tier-1 access is attempted. They are not expected to
+exercise the full scenario successfully.
 
 ```yaml
 bucket: "<YOUR_GCS_BUCKET>"

--- a/examples/file_objstore_s3_vind/README.md
+++ b/examples/file_objstore_s3_vind/README.md
@@ -1,0 +1,85 @@
+# Local `FileStore -> objectstore(S3)` Example via `vcluster` Docker Driver
+
+This example runs the ordered-tier `FileStore -> objectstore` scenario against a
+local S3-compatible emulator instead of a real remote bucket.
+
+- runtime: `vcluster` with the Docker driver
+- emulator: `RustFS`
+- cache shape: tier 0 `FileStore`, tier 1 `objectstore` backed by an S3 bucket
+
+Use this for a fully local smoke test of the S3-backed objectstore path.
+
+## Prerequisites
+
+- `docker`
+- `go`
+- `kubectl`
+- `vcluster`
+
+## Quick Run
+
+```bash
+./run.sh
+```
+
+## Verification Run
+
+```bash
+./verify.sh
+```
+
+The example is self-checking. It fails if any of these transitions do not
+happen:
+
+- the first request populates tier 0 with at least one local file
+- the first request persists at least two remote objects into the S3 emulator
+- deleting tier 0 removes the local files while tier 1 still keeps remote data
+- the final request promotes data back into tier 0 after the wipe
+
+The script will:
+
+1. create or reuse a local `vcluster` on the Docker driver
+2. deploy `RustFS`
+3. port-forward the S3 endpoint to `127.0.0.1:9000`
+4. run `go run .` with the right environment variables
+
+## Manual Run
+
+Create or reuse a local cluster and export a kubeconfig:
+
+```bash
+vcluster create daramjwee-local --namespace daramjwee-local --driver docker --connect=false --background-proxy=false
+vcluster connect daramjwee-local --namespace daramjwee-local --driver docker --print >/tmp/daramjwee-s3.kubeconfig
+```
+
+Deploy and port-forward the emulator:
+
+```bash
+kubectl --kubeconfig /tmp/daramjwee-s3.kubeconfig apply -f manifests
+kubectl --kubeconfig /tmp/daramjwee-s3.kubeconfig rollout status deployment/rustfs --timeout=180s
+kubectl --kubeconfig /tmp/daramjwee-s3.kubeconfig port-forward service/rustfs 9000:9000
+```
+
+In another shell, run the example:
+
+```bash
+export DARAMJWEE_S3_ENDPOINT=127.0.0.1:9000
+export DARAMJWEE_S3_BUCKET=daramjwee-s3-local
+export DARAMJWEE_S3_REGION=us-east-1
+export DARAMJWEE_S3_ACCESS_KEY=rustfsadmin
+export DARAMJWEE_S3_SECRET_KEY=ChangeMe123!
+go run .
+```
+
+## Environment
+
+- `DARAMJWEE_S3_ENDPOINT`
+  Default: `127.0.0.1:9000`
+- `DARAMJWEE_S3_BUCKET`
+  Default: `daramjwee-s3-local`
+- `DARAMJWEE_S3_REGION`
+  Default: `us-east-1`
+- `DARAMJWEE_S3_ACCESS_KEY`
+  Default: `rustfsadmin`
+- `DARAMJWEE_S3_SECRET_KEY`
+  Default: `ChangeMe123!`

--- a/examples/file_objstore_s3_vind/main.go
+++ b/examples/file_objstore_s3_vind/main.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/mrchypark/daramjwee/examples/internal/objectstoredemo"
+	"github.com/thanos-io/objstore/providers/s3"
+)
+
+type exampleConfig struct {
+	bucket    string
+	endpoint  string
+	region    string
+	accessKey string
+	secretKey string
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller, "example", "file_objstore_s3_vind")
+
+	cfg, err := loadExampleConfig(os.Getenv)
+	if err != nil {
+		fatal(logger, "load example config", err)
+	}
+
+	if err := ensureBucketReady(ctx, cfg); err != nil {
+		fatal(logger, "prepare RustFS bucket", err)
+	}
+
+	bucket, err := s3.NewBucket(logger, buildBucketConfig(cfg), "daramjwee", func(rt http.RoundTripper) http.RoundTripper {
+		return &loggingRoundTripper{next: rt}
+	})
+	if err != nil {
+		fatal(logger, "create S3 objectstore bucket", err)
+	}
+	defer bucket.Close()
+
+	prefix := fmt.Sprintf("examples/%s/%d", objectstoredemo.SanitizePrefix("file-objstore-s3-vind"), time.Now().UnixNano())
+	summary, err := objectstoredemo.RunOrderedTierScenario(ctx, logger, bucket, prefix, "rustfs")
+	if err != nil {
+		fatal(logger, "run ordered-tier scenario", err)
+	}
+	_ = logger.Log("level", "info", "msg", "verification summary", "tier0_dir", summary.Tier0Dir, "tier1_workspace", summary.Tier1Workspace)
+}
+
+func loadExampleConfig(getenv func(string) string) (exampleConfig, error) {
+	cfg := exampleConfig{
+		bucket:    getenvDefault(getenv, "DARAMJWEE_S3_BUCKET", "daramjwee-s3-local"),
+		endpoint:  getenvDefault(getenv, "DARAMJWEE_S3_ENDPOINT", "127.0.0.1:9000"),
+		region:    getenvDefault(getenv, "DARAMJWEE_S3_REGION", "us-east-1"),
+		accessKey: getenvDefault(getenv, "DARAMJWEE_S3_ACCESS_KEY", "rustfsadmin"),
+		secretKey: getenvDefault(getenv, "DARAMJWEE_S3_SECRET_KEY", "ChangeMe123!"),
+	}
+
+	if cfg.bucket == "" || cfg.endpoint == "" || cfg.region == "" || cfg.accessKey == "" || cfg.secretKey == "" {
+		return exampleConfig{}, errors.New("S3 example config values must not be empty")
+	}
+
+	return cfg, nil
+}
+
+func buildBucketConfig(cfg exampleConfig) []byte {
+	return []byte(fmt.Sprintf(
+		"bucket: %s\nendpoint: %s\nregion: %s\naccess_key: %s\nsecret_key: %s\ninsecure: true\nbucket_lookup_type: path\nsend_content_md5: false\n",
+		cfg.bucket,
+		cfg.endpoint,
+		cfg.region,
+		cfg.accessKey,
+		cfg.secretKey,
+	))
+}
+
+func ensureBucketReady(ctx context.Context, cfg exampleConfig) error {
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		if err := ensureBucket(ctx, cfg); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for RustFS bucket readiness: %w", lastErr)
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func ensureBucket(ctx context.Context, cfg exampleConfig) error {
+	client, err := minio.New(cfg.endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(cfg.accessKey, cfg.secretKey, ""),
+		Secure: false,
+		Region: cfg.region,
+	})
+	if err != nil {
+		return err
+	}
+
+	exists, err := client.BucketExists(ctx, cfg.bucket)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	if err := client.MakeBucket(ctx, cfg.bucket, minio.MakeBucketOptions{Region: cfg.region}); err != nil {
+		exists, existsErr := client.BucketExists(ctx, cfg.bucket)
+		if existsErr == nil && exists {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func getenvDefault(getenv func(string) string, key string, fallback string) string {
+	if value := getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func fatal(logger log.Logger, msg string, err error) {
+	_ = logger.Log("level", "error", "msg", msg, "err", err)
+	os.Exit(1)
+}
+
+type loggingRoundTripper struct {
+	next http.RoundTripper
+}
+
+func (l *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller, "transport", "s3")
+	_ = logger.Log("level", "debug", "msg", "request start", "method", req.Method, "url", req.URL.String())
+	start := time.Now()
+	resp, err := l.next.RoundTrip(req)
+	if err != nil {
+		_ = logger.Log("level", "error", "msg", "request failed", "err", err, "duration", time.Since(start))
+		return nil, err
+	}
+	_ = logger.Log("level", "debug", "msg", "request complete", "status", resp.Status, "duration", time.Since(start))
+	return resp, nil
+}

--- a/examples/file_objstore_s3_vind/main_test.go
+++ b/examples/file_objstore_s3_vind/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadExampleConfigDefaults(t *testing.T) {
+	cfg, err := loadExampleConfig(func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("loadExampleConfig returned error: %v", err)
+	}
+
+	if cfg.bucket != "daramjwee-s3-local" {
+		t.Fatalf("expected default bucket, got %q", cfg.bucket)
+	}
+	if cfg.endpoint != "127.0.0.1:9000" {
+		t.Fatalf("expected default endpoint, got %q", cfg.endpoint)
+	}
+	if cfg.accessKey != "rustfsadmin" {
+		t.Fatalf("expected default access key, got %q", cfg.accessKey)
+	}
+	if cfg.secretKey != "ChangeMe123!" {
+		t.Fatalf("expected default secret key, got %q", cfg.secretKey)
+	}
+}
+
+func TestBuildBucketConfig(t *testing.T) {
+	cfg := exampleConfig{
+		bucket:    "bucket-a",
+		endpoint:  "127.0.0.1:9999",
+		region:    "ap-northeast-2",
+		accessKey: "key-a",
+		secretKey: "secret-a",
+	}
+
+	conf := string(buildBucketConfig(cfg))
+	for _, want := range []string{
+		"bucket: bucket-a",
+		"endpoint: 127.0.0.1:9999",
+		"access_key: key-a",
+		"secret_key: secret-a",
+		"bucket_lookup_type: path",
+		"insecure: true",
+	} {
+		if !strings.Contains(conf, want) {
+			t.Fatalf("expected config to contain %q, got %q", want, conf)
+		}
+	}
+}

--- a/examples/file_objstore_s3_vind/manifests/rustfs.yaml
+++ b/examples/file_objstore_s3_vind/manifests/rustfs.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rustfs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rustfs
+  template:
+    metadata:
+      labels:
+        app: rustfs
+    spec:
+      containers:
+        - name: rustfs
+          image: rustfs/rustfs@sha256:f1b59053332cdaa00c6a0d08b43f02fb2d12bf2749098b6d9d5eed693b39b695
+          args:
+            - server
+            - /data
+          env:
+            - name: RUSTFS_ACCESS_KEY
+              value: rustfsadmin
+            - name: RUSTFS_SECRET_KEY
+              value: ChangeMe123!
+            - name: RUSTFS_REGION
+              value: us-east-1
+          ports:
+            - name: s3
+              containerPort: 9000
+          readinessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustfs
+spec:
+  selector:
+    app: rustfs
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000

--- a/examples/file_objstore_s3_vind/run.sh
+++ b/examples/file_objstore_s3_vind/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER_NAME="${DARAMJWEE_VCLUSTER_NAME:-daramjwee-local}"
+CLUSTER_NAMESPACE="${DARAMJWEE_VCLUSTER_NAMESPACE:-${CLUSTER_NAME}}"
+LOCAL_PORT="${DARAMJWEE_S3_LOCAL_PORT:-9000}"
+SERVICE_NAME="rustfs"
+KUBECONFIG_PATH="$(mktemp -t daramjwee-s3-kubeconfig-XXXXXX)"
+PORT_FORWARD_LOG="$(mktemp -t daramjwee-s3-portforward-XXXXXX.log)"
+PORT_FORWARD_PID=""
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+wait_for_port_forward() {
+  local pid="$1"
+  local log_file="$2"
+  local port="$3"
+  for _ in $(seq 1 60); do
+    if ! kill -0 "${pid}" >/dev/null 2>&1; then
+      echo "kubectl port-forward exited before becoming ready" >&2
+      cat "${log_file}" >&2 || true
+      return 1
+    fi
+    if grep -q "Forwarding from 127.0.0.1:${port}" "${log_file}" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timed out waiting for kubectl port-forward on 127.0.0.1:${port}" >&2
+  cat "${log_file}" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${PORT_FORWARD_PID}" ]] && kill -0 "${PORT_FORWARD_PID}" >/dev/null 2>&1; then
+    kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+    wait "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+  fi
+  rm -f "${KUBECONFIG_PATH}" "${PORT_FORWARD_LOG}"
+}
+trap cleanup EXIT
+
+require_cmd docker
+require_cmd go
+require_cmd kubectl
+require_cmd vcluster
+
+if ! vcluster connect "${CLUSTER_NAME}" --namespace "${CLUSTER_NAMESPACE}" --driver docker --print >"${KUBECONFIG_PATH}" 2>/dev/null; then
+  vcluster create "${CLUSTER_NAME}" \
+    --namespace "${CLUSTER_NAMESPACE}" \
+    --driver docker \
+    --connect=false \
+    --background-proxy=false \
+    --create-namespace
+  vcluster connect "${CLUSTER_NAME}" --namespace "${CLUSTER_NAMESPACE}" --driver docker --print >"${KUBECONFIG_PATH}"
+fi
+
+kubectl --kubeconfig "${KUBECONFIG_PATH}" apply -f "${SCRIPT_DIR}/manifests"
+kubectl --kubeconfig "${KUBECONFIG_PATH}" rollout status deployment/"${SERVICE_NAME}" --timeout=180s
+kubectl --kubeconfig "${KUBECONFIG_PATH}" port-forward service/"${SERVICE_NAME}" "${LOCAL_PORT}:9000" >"${PORT_FORWARD_LOG}" 2>&1 &
+PORT_FORWARD_PID=$!
+wait_for_port_forward "${PORT_FORWARD_PID}" "${PORT_FORWARD_LOG}" "${LOCAL_PORT}"
+
+export DARAMJWEE_S3_ENDPOINT="127.0.0.1:${LOCAL_PORT}"
+export DARAMJWEE_S3_BUCKET="${DARAMJWEE_S3_BUCKET:-daramjwee-s3-local}"
+export DARAMJWEE_S3_REGION="${DARAMJWEE_S3_REGION:-us-east-1}"
+export DARAMJWEE_S3_ACCESS_KEY="${DARAMJWEE_S3_ACCESS_KEY:-rustfsadmin}"
+export DARAMJWEE_S3_SECRET_KEY="${DARAMJWEE_S3_SECRET_KEY:-ChangeMe123!}"
+
+cd "${SCRIPT_DIR}"
+go run .

--- a/examples/file_objstore_s3_vind/verify.sh
+++ b/examples/file_objstore_s3_vind/verify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+echo "Verifying local FileStore -> objectstore(S3) transitions..."
+./run.sh

--- a/examples/internal/objectstoredemo/scenario.go
+++ b/examples/internal/objectstoredemo/scenario.go
@@ -1,0 +1,288 @@
+package objectstoredemo
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee"
+	"github.com/mrchypark/daramjwee/pkg/store/filestore"
+	remotestore "github.com/mrchypark/daramjwee/pkg/store/objectstore"
+	objstore "github.com/thanos-io/objstore"
+)
+
+type Observation struct {
+	LocalFiles    int
+	RemoteObjects int
+}
+
+type ScenarioSummary struct {
+	Tier0Dir       string
+	Tier1Workspace string
+	RemoteLabel    string
+	Prefix         string
+	AfterFirstGet  Observation
+	AfterTier0Wipe Observation
+	AfterPromotion Observation
+}
+
+func (s ScenarioSummary) Verify() error {
+	switch {
+	case s.AfterFirstGet.LocalFiles <= 0:
+		return errors.New("tier 0 was not populated after the first get")
+	case s.AfterFirstGet.RemoteObjects <= 0:
+		return errors.New("tier 1 did not persist any remote objects after the first get")
+	case s.AfterTier0Wipe.LocalFiles != 0:
+		return errors.New("tier 0 still had local files after the wipe step")
+	case s.AfterTier0Wipe.RemoteObjects <= 0:
+		return errors.New("tier 1 remote objects disappeared after the tier-0 wipe")
+	case s.AfterPromotion.LocalFiles <= 0:
+		return errors.New("tier 0 was not repopulated after the lower-tier promotion")
+	case s.AfterPromotion.RemoteObjects <= 0:
+		return errors.New("tier 1 remote objects were missing after promotion")
+	default:
+		return nil
+	}
+}
+
+type simpleFetcher struct {
+	data []byte
+}
+
+func (f simpleFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	return &daramjwee.FetchResult{
+		Body:     io.NopCloser(bytes.NewReader(f.data)),
+		Metadata: &daramjwee.Metadata{CacheTag: "v1"},
+	}, nil
+}
+
+// RunOrderedTierScenario runs the same ordered FileStore -> objectstore flow used
+// by the existing examples, but lets callers supply the backing object bucket.
+func RunOrderedTierScenario(ctx context.Context, logger log.Logger, bucket objstore.Bucket, prefix string, remoteLabel string) (ScenarioSummary, error) {
+	summary := ScenarioSummary{
+		RemoteLabel: remoteLabel,
+		Prefix:      prefix,
+	}
+
+	tier1DataDir, err := os.MkdirTemp("", "daramjwee-objectstore-*")
+	if err != nil {
+		return summary, fmt.Errorf("create tier-1 workspace: %w", err)
+	}
+	defer os.RemoveAll(tier1DataDir)
+	summary.Tier1Workspace = filepath.Join(tier1DataDir, "workspace")
+
+	tier1Store := remotestore.New(
+		bucket,
+		log.With(logger, "tier", "1"),
+		remotestore.WithDir(summary.Tier1Workspace),
+		remotestore.WithPrefix(prefix),
+		remotestore.WithPackThreshold(1<<20),
+		remotestore.WithPageSize(256<<10),
+		remotestore.WithBlockCache(64<<20),
+		remotestore.WithCheckpointCache(16<<20),
+		remotestore.WithCheckpointTTL(2*time.Second),
+	)
+
+	hotStoreDir, err := os.MkdirTemp("", "daramjwee-hot-cache-*")
+	if err != nil {
+		return summary, fmt.Errorf("create tier-0 workspace: %w", err)
+	}
+	defer os.RemoveAll(hotStoreDir)
+	summary.Tier0Dir = hotStoreDir
+
+	hotStore, err := filestore.New(hotStoreDir, log.With(logger, "tier", "0"))
+	if err != nil {
+		return summary, fmt.Errorf("create tier-0 filestore: %w", err)
+	}
+
+	cache, err := daramjwee.New(
+		logger,
+		daramjwee.WithTiers(hotStore, tier1Store),
+		daramjwee.WithFreshness(10*time.Minute, time.Minute),
+	)
+	if err != nil {
+		return summary, fmt.Errorf("create cache: %w", err)
+	}
+	defer func() {
+		if cache != nil {
+			cache.Close()
+		}
+	}()
+
+	const cacheKey = "my-object"
+	originData := []byte("Hello from Origin!")
+	fetcher := simpleFetcher{data: originData}
+
+	_ = logger.Log("level", "info", "msg", "Tier 1 objectstore initialized", "remote", remoteLabel, "prefix", prefix, "data_dir", summary.Tier1Workspace)
+	_ = logger.Log("level", "info", "msg", "Tier 0 filestore initialized", "path", hotStoreDir)
+
+	_ = logger.Log("level", "info", "msg", "Scenario 1: miss in both tiers, expect origin fetch")
+	if err := getAndCompare(ctx, cache, cacheKey, fetcher, originData); err != nil {
+		return summary, err
+	}
+	if summary.AfterFirstGet, err = observeState(ctx, bucket, prefix, hotStoreDir, 2); err != nil {
+		return summary, err
+	}
+
+	_ = logger.Log("level", "info", "msg", "Scenario 2: tier-0 hit")
+	if err := getAndCompare(ctx, cache, cacheKey, fetcher, originData); err != nil {
+		return summary, err
+	}
+
+	_ = logger.Log("level", "info", "msg", "Scenario 3: wipe tier 0 and expect lower-tier promotion", "path", hotStoreDir)
+	cache.Close()
+	cache = nil
+
+	if err := os.RemoveAll(hotStoreDir); err != nil {
+		return summary, fmt.Errorf("remove tier-0 workspace: %w", err)
+	}
+	if summary.AfterTier0Wipe, err = observeState(ctx, bucket, prefix, hotStoreDir, 2); err != nil {
+		return summary, err
+	}
+
+	hotStore, err = filestore.New(hotStoreDir, log.With(logger, "tier", "0"))
+	if err != nil {
+		return summary, fmt.Errorf("recreate tier-0 filestore: %w", err)
+	}
+
+	cache, err = daramjwee.New(
+		logger,
+		daramjwee.WithTiers(hotStore, tier1Store),
+		daramjwee.WithFreshness(10*time.Minute, time.Minute),
+	)
+	if err != nil {
+		return summary, fmt.Errorf("recreate cache: %w", err)
+	}
+
+	if err := getAndCompare(ctx, cache, cacheKey, fetcher, originData); err != nil {
+		return summary, err
+	}
+	if summary.AfterPromotion, err = observeState(ctx, bucket, prefix, hotStoreDir, 2); err != nil {
+		return summary, err
+	}
+	if err := summary.Verify(); err != nil {
+		return summary, err
+	}
+
+	_ = logger.Log(
+		"level", "info",
+		"msg", "All ordered-tier scenarios completed successfully",
+		"remote", remoteLabel,
+		"prefix", prefix,
+		"after_first_get_local_files", summary.AfterFirstGet.LocalFiles,
+		"after_first_get_remote_objects", summary.AfterFirstGet.RemoteObjects,
+		"after_wipe_local_files", summary.AfterTier0Wipe.LocalFiles,
+		"after_wipe_remote_objects", summary.AfterTier0Wipe.RemoteObjects,
+		"after_promotion_local_files", summary.AfterPromotion.LocalFiles,
+		"after_promotion_remote_objects", summary.AfterPromotion.RemoteObjects,
+	)
+	return summary, nil
+}
+
+func getAndCompare(ctx context.Context, cache daramjwee.Cache, key string, fetcher daramjwee.Fetcher, expectedData []byte) error {
+	rc, err := cache.Get(ctx, key, daramjwee.GetRequest{}, fetcher)
+	if err != nil {
+		return fmt.Errorf("cache get %q: %w", key, err)
+	}
+	defer rc.Close()
+
+	readData, err := io.ReadAll(rc)
+	if err != nil {
+		return fmt.Errorf("read cache stream %q: %w", key, err)
+	}
+
+	if !bytes.Equal(readData, expectedData) {
+		return fmt.Errorf("data mismatch for %q: expected %q got %q", key, string(expectedData), string(readData))
+	}
+
+	return nil
+}
+
+func SanitizePrefix(name string) string {
+	return strings.ReplaceAll(name, " ", "-")
+}
+
+func observeState(ctx context.Context, bucket objstore.Bucket, prefix string, localDir string, minRemoteObjects int) (Observation, error) {
+	remoteCount, err := waitForRemoteObjects(ctx, bucket, prefix, minRemoteObjects)
+	if err != nil {
+		return Observation{}, err
+	}
+	localCount, err := countLocalFiles(localDir)
+	if err != nil {
+		return Observation{}, err
+	}
+	return Observation{
+		LocalFiles:    localCount,
+		RemoteObjects: remoteCount,
+	}, nil
+}
+
+func waitForRemoteObjects(ctx context.Context, bucket objstore.Bucket, prefix string, minRemoteObjects int) (int, error) {
+	observeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var (
+		lastCount int
+		lastErr   error
+	)
+	for {
+		lastCount, lastErr = countRemoteObjects(observeCtx, bucket, prefix)
+		if lastErr == nil && lastCount >= minRemoteObjects {
+			return lastCount, nil
+		}
+
+		select {
+		case <-observeCtx.Done():
+			if lastErr != nil {
+				return 0, fmt.Errorf("observe remote objects: %w", lastErr)
+			}
+			return lastCount, fmt.Errorf("observe remote objects: timed out waiting for at least %d objects under %q; last count=%d", minRemoteObjects, prefix, lastCount)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func countRemoteObjects(ctx context.Context, bucket objstore.Bucket, prefix string) (int, error) {
+	count := 0
+	err := bucket.Iter(ctx, prefix, func(name string) error {
+		count++
+		return nil
+	}, objstore.WithRecursiveIter())
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func countLocalFiles(root string) (int, error) {
+	if _, err := os.Stat(root); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	count := 0
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		count++
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/examples/internal/objectstoredemo/scenario_test.go
+++ b/examples/internal/objectstoredemo/scenario_test.go
@@ -1,0 +1,87 @@
+package objectstoredemo
+
+import "testing"
+
+func TestScenarioSummaryVerifyPassesForExpectedTransitions(t *testing.T) {
+	summary := ScenarioSummary{
+		AfterFirstGet: Observation{
+			LocalFiles:    1,
+			RemoteObjects: 3,
+		},
+		AfterTier0Wipe: Observation{
+			LocalFiles:    0,
+			RemoteObjects: 3,
+		},
+		AfterPromotion: Observation{
+			LocalFiles:    1,
+			RemoteObjects: 3,
+		},
+	}
+
+	if err := summary.Verify(); err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+}
+
+func TestScenarioSummaryVerifyFailsWhenTier0WasNeverCreated(t *testing.T) {
+	summary := ScenarioSummary{
+		AfterFirstGet: Observation{
+			LocalFiles:    0,
+			RemoteObjects: 3,
+		},
+		AfterTier0Wipe: Observation{
+			LocalFiles:    0,
+			RemoteObjects: 3,
+		},
+		AfterPromotion: Observation{
+			LocalFiles:    1,
+			RemoteObjects: 3,
+		},
+	}
+
+	if err := summary.Verify(); err == nil {
+		t.Fatal("expected Verify to fail when tier 0 was never populated")
+	}
+}
+
+func TestScenarioSummaryVerifyFailsWhenRemoteObjectsDisappear(t *testing.T) {
+	summary := ScenarioSummary{
+		AfterFirstGet: Observation{
+			LocalFiles:    1,
+			RemoteObjects: 3,
+		},
+		AfterTier0Wipe: Observation{
+			LocalFiles:    0,
+			RemoteObjects: 0,
+		},
+		AfterPromotion: Observation{
+			LocalFiles:    1,
+			RemoteObjects: 0,
+		},
+	}
+
+	if err := summary.Verify(); err == nil {
+		t.Fatal("expected Verify to fail when remote objects disappear")
+	}
+}
+
+func TestScenarioSummaryVerifyFailsWhenTier0DoesNotRepopulate(t *testing.T) {
+	summary := ScenarioSummary{
+		AfterFirstGet: Observation{
+			LocalFiles:    1,
+			RemoteObjects: 3,
+		},
+		AfterTier0Wipe: Observation{
+			LocalFiles:    0,
+			RemoteObjects: 3,
+		},
+		AfterPromotion: Observation{
+			LocalFiles:    0,
+			RemoteObjects: 3,
+		},
+	}
+
+	if err := summary.Verify(); err == nil {
+		t.Fatal("expected Verify to fail when tier 0 does not repopulate")
+	}
+}

--- a/group.go
+++ b/group.go
@@ -47,15 +47,10 @@ func NewGroup(logger log.Logger, opts ...GroupOption) (CacheGroup, error) {
 		}
 	}
 
-	rt, err := newGroupRuntime(logger, cfg.Workers, cfg.WorkerTimeout)
-	if err != nil {
-		return nil, err
-	}
-
 	return &cacheGroup{
 		logger: logger,
 		cfg:    cfg,
-		rt:     rt,
+		rt:     newGroupRuntime(logger, cfg.Workers, cfg.WorkerTimeout),
 		caches: make(map[string]*DaramjweeCache),
 	}, nil
 }

--- a/group.go
+++ b/group.go
@@ -1,0 +1,129 @@
+package daramjwee
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+// CacheGroup owns a shared background runtime for multiple caches.
+type CacheGroup interface {
+	NewCache(name string, opts ...Option) (Cache, error)
+	Close()
+}
+
+type cacheGroup struct {
+	logger log.Logger
+	cfg    GroupConfig
+	rt     *groupRuntime
+
+	closed atomic.Bool
+	mu     sync.Mutex
+	caches map[string]*DaramjweeCache
+}
+
+var _ CacheGroup = (*cacheGroup)(nil)
+
+// NewGroup constructs a CacheGroup with a shared bounded runtime.
+func NewGroup(logger log.Logger, opts ...GroupOption) (CacheGroup, error) {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	cfg := GroupConfig{
+		Workers:            1,
+		WorkerTimeout:      30 * time.Second,
+		WorkerQueueDefault: 500,
+		CloseTimeout:       30 * time.Second,
+	}
+
+	for _, opt := range opts {
+		if err := opt(&cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	rt, err := newGroupRuntime(logger, cfg.Workers, cfg.WorkerQueueDefault, cfg.WorkerTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cacheGroup{
+		logger: logger,
+		cfg:    cfg,
+		rt:     rt,
+		caches: make(map[string]*DaramjweeCache),
+	}, nil
+}
+
+func (g *cacheGroup) NewCache(name string, opts ...Option) (Cache, error) {
+	if g.closed.Load() {
+		return nil, &ConfigError{"cache group is closed"}
+	}
+	if name == "" {
+		return nil, &ConfigError{"cache name cannot be empty"}
+	}
+
+	g.mu.Lock()
+	if _, exists := g.caches[name]; exists {
+		g.mu.Unlock()
+		return nil, &ConfigError{fmt.Sprintf("duplicate cache name %q", name)}
+	}
+	g.mu.Unlock()
+
+	cfg, err := buildCacheConfig(cacheConstructionGroup, &g.cfg, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	cache, err := newCacheFromConfig(g.logger, g.rt, name, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	typed, ok := cache.(*DaramjweeCache)
+	if !ok {
+		return nil, &ConfigError{"unexpected cache implementation"}
+	}
+	typed.closeHook = func() {
+		g.mu.Lock()
+		delete(g.caches, name)
+		g.mu.Unlock()
+	}
+
+	g.mu.Lock()
+	if g.closed.Load() {
+		g.mu.Unlock()
+		typed.Close()
+		return nil, &ConfigError{"cache group is closed"}
+	}
+	g.caches[name] = typed
+	g.mu.Unlock()
+	return cache, nil
+}
+
+func (g *cacheGroup) Close() {
+	if g.closed.Swap(true) {
+		return
+	}
+	g.mu.Lock()
+	caches := make([]*DaramjweeCache, 0, len(g.caches))
+	for _, cache := range g.caches {
+		caches = append(caches, cache)
+	}
+	g.mu.Unlock()
+
+	if g.rt != nil {
+		if err := g.rt.Shutdown(g.cfg.CloseTimeout); err != nil {
+			level.Warn(g.logger).Log("msg", "cache group shutdown failed", "err", err)
+		}
+	}
+
+	for _, cache := range caches {
+		cache.Close()
+	}
+}

--- a/group.go
+++ b/group.go
@@ -47,7 +47,7 @@ func NewGroup(logger log.Logger, opts ...GroupOption) (CacheGroup, error) {
 		}
 	}
 
-	rt, err := newGroupRuntime(logger, cfg.Workers, cfg.WorkerQueueDefault, cfg.WorkerTimeout)
+	rt, err := newGroupRuntime(logger, cfg.Workers, cfg.WorkerTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/group_options.go
+++ b/group_options.go
@@ -1,0 +1,58 @@
+package daramjwee
+
+import "time"
+
+// GroupConfig holds the shared runtime defaults used by caches created from a CacheGroup.
+type GroupConfig struct {
+	Workers            int
+	WorkerTimeout      time.Duration
+	WorkerQueueDefault int
+	CloseTimeout       time.Duration
+}
+
+// GroupOption configures a CacheGroup.
+type GroupOption func(*GroupConfig) error
+
+// WithGroupWorkers sets the number of shared runtime workers used by caches in a group.
+func WithGroupWorkers(count int) GroupOption {
+	return func(cfg *GroupConfig) error {
+		if count <= 0 {
+			return &ConfigError{"group worker count must be positive"}
+		}
+		cfg.Workers = count
+		return nil
+	}
+}
+
+// WithGroupWorkerTimeout sets the timeout applied to each shared runtime worker job.
+func WithGroupWorkerTimeout(timeout time.Duration) GroupOption {
+	return func(cfg *GroupConfig) error {
+		if timeout <= 0 {
+			return &ConfigError{"group worker job timeout must be positive"}
+		}
+		cfg.WorkerTimeout = timeout
+		return nil
+	}
+}
+
+// WithGroupWorkerQueueDefault sets the default queue capacity used for group-attached caches.
+func WithGroupWorkerQueueDefault(size int) GroupOption {
+	return func(cfg *GroupConfig) error {
+		if size <= 0 {
+			return &ConfigError{"group worker queue size must be positive"}
+		}
+		cfg.WorkerQueueDefault = size
+		return nil
+	}
+}
+
+// WithGroupCloseTimeout sets the timeout for graceful shutdown of the shared cache group.
+func WithGroupCloseTimeout(timeout time.Duration) GroupOption {
+	return func(cfg *GroupConfig) error {
+		if timeout <= 0 {
+			return &ConfigError{"group close timeout must be positive"}
+		}
+		cfg.CloseTimeout = timeout
+		return nil
+	}
+}

--- a/options.go
+++ b/options.go
@@ -28,6 +28,8 @@ type Config struct {
 	Workers        int
 	WorkerQueue    int
 	WorkerTimeout  time.Duration
+	Weight         int
+	QueueLimit     int
 
 	OpTimeout    time.Duration
 	CloseTimeout time.Duration
@@ -99,6 +101,28 @@ func WithWorkerTimeout(timeout time.Duration) Option {
 			return &ConfigError{"worker job timeout must be positive"}
 		}
 		cfg.WorkerTimeout = timeout
+		return nil
+	}
+}
+
+// WithWeight sets the relative dequeue weight for a cache attached to a shared group runtime.
+func WithWeight(weight int) Option {
+	return func(cfg *Config) error {
+		if weight <= 0 {
+			return &ConfigError{"cache weight must be positive"}
+		}
+		cfg.Weight = weight
+		return nil
+	}
+}
+
+// WithQueueLimit sets the bounded queue capacity for a cache attached to a shared group runtime.
+func WithQueueLimit(limit int) Option {
+	return func(cfg *Config) error {
+		if limit <= 0 {
+			return &ConfigError{"cache queue limit must be positive"}
+		}
+		cfg.QueueLimit = limit
 		return nil
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -3,11 +3,10 @@ package daramjwee
 import (
 	"context"
 	"io"
-	"reflect"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/mrchypark/daramjwee/internal/worker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,6 +69,29 @@ func (s comparableValueStore) Delete(ctx context.Context, key string) error {
 
 func (s comparableValueStore) Stat(ctx context.Context, key string) (*Metadata, error) {
 	return nil, ErrNotFound
+}
+
+type optionsTestNoopFetcher struct{}
+
+func (optionsTestNoopFetcher) Fetch(context.Context, *Metadata) (*FetchResult, error) {
+	return &FetchResult{
+		Body:     io.NopCloser(strings.NewReader("noop")),
+		Metadata: &Metadata{CacheTag: "noop"},
+	}, nil
+}
+
+type optionsTestBlockingFetcher struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (f optionsTestBlockingFetcher) Fetch(context.Context, *Metadata) (*FetchResult, error) {
+	close(f.started)
+	<-f.release
+	return &FetchResult{
+		Body:     io.NopCloser(strings.NewReader("block")),
+		Metadata: &Metadata{CacheTag: "block"},
+	}, nil
 }
 
 func TestNew_OptionValidation(t *testing.T) {
@@ -169,6 +191,24 @@ func TestNew_OptionValidation(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "failure with group-attached cache weight",
+			options: []Option{
+				WithTiers(regularA),
+				WithWeight(2),
+			},
+			expectErr:   true,
+			expectedMsg: "group-attached cache option",
+		},
+		{
+			name: "failure with group-attached cache queue limit",
+			options: []Option{
+				WithTiers(regularA),
+				WithQueueLimit(8),
+			},
+			expectErr:   true,
+			expectedMsg: "group-attached cache option",
+		},
+		{
 			name: "failure with empty worker strategy",
 			options: []Option{
 				WithTiers(regularA),
@@ -241,6 +281,145 @@ func TestNew_OptionValidation(t *testing.T) {
 	}
 }
 
+func TestNewGroup_OptionValidation(t *testing.T) {
+	group, err := NewGroup(nil,
+		WithGroupWorkers(2),
+		WithGroupWorkerTimeout(5*time.Second),
+		WithGroupWorkerQueueDefault(8),
+		WithGroupCloseTimeout(10*time.Second),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, group)
+
+	typedGroup := group.(*cacheGroup)
+	require.Equal(t, 2, typedGroup.cfg.Workers)
+	require.Equal(t, 5*time.Second, typedGroup.cfg.WorkerTimeout)
+	require.Equal(t, 8, typedGroup.cfg.WorkerQueueDefault)
+	require.Equal(t, 10*time.Second, typedGroup.cfg.CloseTimeout)
+
+	cache, err := group.NewCache("shared", WithTiers(&optionsTestMockStore{id: 1}), WithWeight(3), WithQueueLimit(11))
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+	typedCache := cache.(*DaramjweeCache)
+	require.Equal(t, 3, typedCache.runtimeWeight)
+	require.Equal(t, 11, typedCache.runtimeQueueLimit)
+
+	defaultCache, err := group.NewCache("shared-default", WithTiers(&optionsTestMockStore{id: 2}), WithWeight(2))
+	require.NoError(t, err)
+	require.NotNil(t, defaultCache)
+	require.Equal(t, 8, defaultCache.(*DaramjweeCache).runtimeQueueLimit)
+	cache.Close()
+	defaultCache.Close()
+	group.Close()
+}
+
+func TestNewGroup_RejectsEmptyAndDuplicateNames(t *testing.T) {
+	group, err := NewGroup(nil, WithGroupWorkers(1))
+	require.NoError(t, err)
+	defer group.Close()
+
+	_, err = group.NewCache("", WithTiers(&optionsTestMockStore{id: 1}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cache name cannot be empty")
+
+	_, err = group.NewCache("dup", WithTiers(&optionsTestMockStore{id: 1}))
+	require.NoError(t, err)
+
+	_, err = group.NewCache("dup", WithTiers(&optionsTestMockStore{id: 1}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate cache name")
+}
+
+func TestGroupNewCache_RejectsStandaloneWorkerOptions(t *testing.T) {
+	group, err := NewGroup(nil, WithGroupWorkers(1))
+	require.NoError(t, err)
+	defer group.Close()
+
+	testCases := []struct {
+		name string
+		opt  Option
+		msg  string
+	}{
+		{name: "WithWorkers", opt: WithWorkers(2), msg: "standalone worker option"},
+		{name: "WithWorkerQueue", opt: WithWorkerQueue(8), msg: "standalone worker option"},
+		{name: "WithWorkerTimeout", opt: WithWorkerTimeout(5 * time.Second), msg: "standalone worker option"},
+		{name: "WithWorkerStrategy", opt: WithWorkerStrategy("pool"), msg: "standalone worker option"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := group.NewCache("bad", WithTiers(&optionsTestMockStore{id: 1}), tc.opt)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.msg)
+		})
+	}
+}
+
+func TestNewGroup_CloseClosesCreatedCaches(t *testing.T) {
+	group, err := NewGroup(nil, WithGroupWorkers(1), WithGroupCloseTimeout(2*time.Second))
+	require.NoError(t, err)
+
+	cache, err := group.NewCache("closable", WithTiers(&optionsTestMockStore{id: 1}))
+	require.NoError(t, err)
+
+	group.Close()
+
+	_, err = cache.Get(context.Background(), "k", GetRequest{}, optionsTestNoopFetcher{})
+	require.ErrorIs(t, err, ErrCacheClosed)
+}
+
+func TestNewGroup_ReusesClosedCacheName(t *testing.T) {
+	group, err := NewGroup(nil, WithGroupWorkers(1))
+	require.NoError(t, err)
+	defer group.Close()
+
+	first, err := group.NewCache("reusable", WithTiers(&optionsTestMockStore{id: 1}))
+	require.NoError(t, err)
+
+	first.Close()
+
+	second, err := group.NewCache("reusable", WithTiers(&optionsTestMockStore{id: 1}))
+	require.NoError(t, err)
+	defer second.Close()
+}
+
+func TestNewGroup_CloseTimeoutKeepsCacheNameTombstoned(t *testing.T) {
+	group, err := NewGroup(nil, WithGroupWorkers(1), WithGroupCloseTimeout(10*time.Millisecond))
+	require.NoError(t, err)
+
+	cache, err := group.NewCache("tombstone", WithTiers(&optionsTestMockStore{id: 1}), WithCloseTimeout(10*time.Millisecond))
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		close(release)
+		group.Close()
+	})
+
+	require.NoError(t, cache.ScheduleRefresh(context.Background(), "k", optionsTestBlockingFetcher{
+		started: started,
+		release: release,
+	}))
+	<-started
+
+	done := make(chan struct{})
+	go func() {
+		cache.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for cache close to return")
+	}
+
+	_, err = group.NewCache("tombstone", WithTiers(&optionsTestMockStore{id: 1}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate cache name")
+}
+
 func TestOptionOverrides(t *testing.T) {
 	cfg := Config{}
 
@@ -262,23 +441,6 @@ func TestOptionOverrides(t *testing.T) {
 	assert.Equal(t, 20*time.Minute, cfg.TierFreshnessOverrides[1].Negative)
 	assert.Equal(t, 30*time.Minute, cfg.TierFreshnessOverrides[2].Positive)
 	assert.Equal(t, 60*time.Minute, cfg.TierFreshnessOverrides[2].Negative)
-}
-
-func TestNew_WithWorkerStrategyAllUsesAllStrategy(t *testing.T) {
-	cache, err := New(nil,
-		WithTiers(&optionsTestMockStore{id: 1}),
-		WithWorkerStrategy("all"),
-	)
-	require.NoError(t, err)
-	typedCache := cache.(*DaramjweeCache)
-	t.Cleanup(typedCache.Close)
-
-	strategyField := reflect.ValueOf(typedCache.worker).Elem().FieldByName("strategy")
-	require.True(t, strategyField.IsValid())
-	require.False(t, strategyField.IsNil())
-
-	strategyType := strategyField.Elem().Type()
-	assert.Equal(t, reflect.TypeOf((*worker.AllStrategy)(nil)), strategyType)
 }
 
 func TestNew_WithUnknownWorkerStrategyFails(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -383,7 +383,7 @@ func TestNewGroup_ReusesClosedCacheName(t *testing.T) {
 	defer second.Close()
 }
 
-func TestNewGroup_CloseTimeoutKeepsCacheNameTombstoned(t *testing.T) {
+func TestNewGroup_CloseTimeoutAllowsCacheNameReuse(t *testing.T) {
 	group, err := NewGroup(nil, WithGroupWorkers(1), WithGroupCloseTimeout(10*time.Millisecond))
 	require.NoError(t, err)
 
@@ -415,9 +415,9 @@ func TestNewGroup_CloseTimeoutKeepsCacheNameTombstoned(t *testing.T) {
 		t.Fatal("timed out waiting for cache close to return")
 	}
 
-	_, err = group.NewCache("tombstone", WithTiers(&optionsTestMockStore{id: 1}))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate cache name")
+	reused, err := group.NewCache("tombstone", WithTiers(&optionsTestMockStore{id: 1}))
+	require.NoError(t, err)
+	defer reused.Close()
 }
 
 func TestOptionOverrides(t *testing.T) {

--- a/tests/cache_group_integration_test.go
+++ b/tests/cache_group_integration_test.go
@@ -1,0 +1,169 @@
+package daramjwee_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mrchypark/daramjwee"
+)
+
+type groupTestStore struct{}
+
+func (groupTestStore) GetStream(context.Context, string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	return nil, nil, daramjwee.ErrNotFound
+}
+
+func (groupTestStore) BeginSet(context.Context, string, *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return noopWriteSink{}, nil
+}
+
+func (groupTestStore) Delete(context.Context, string) error { return nil }
+
+func (groupTestStore) Stat(context.Context, string) (*daramjwee.Metadata, error) {
+	return nil, daramjwee.ErrNotFound
+}
+
+type noopWriteSink struct{}
+
+func (noopWriteSink) Write(p []byte) (int, error) { return len(p), nil }
+func (noopWriteSink) Close() error                { return nil }
+func (noopWriteSink) Abort() error                { return nil }
+
+func TestCacheGroup_NewCacheAppliesGroupQueueDefault(t *testing.T) {
+	group, err := daramjwee.NewGroup(nil,
+		daramjwee.WithGroupWorkers(2),
+		daramjwee.WithGroupWorkerQueueDefault(12),
+	)
+	require.NoError(t, err)
+	t.Cleanup(group.Close)
+
+	cache, err := group.NewCache("cache-a", daramjwee.WithTiers(groupTestStore{}))
+	require.NoError(t, err)
+	t.Cleanup(cache.Close)
+
+	typed := reflect.ValueOf(cache).Elem()
+	require.Equal(t, 12, int(typed.FieldByName("runtimeQueueLimit").Int()))
+}
+
+func TestCacheGroup_CloseClosesCreatedCaches(t *testing.T) {
+	group, err := daramjwee.NewGroup(nil, daramjwee.WithGroupWorkers(1))
+	require.NoError(t, err)
+
+	cache, err := group.NewCache("cache-b", daramjwee.WithTiers(groupTestStore{}))
+	require.NoError(t, err)
+
+	group.Close()
+
+	_, err = cache.Get(context.Background(), "k", daramjwee.GetRequest{}, groupNoopFetcher{})
+	require.ErrorIs(t, err, daramjwee.ErrCacheClosed)
+}
+
+type groupBlockingFetcher struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (f *groupBlockingFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	close(f.started)
+	<-f.release
+	return &daramjwee.FetchResult{
+		Body:     io.NopCloser(strings.NewReader("value")),
+		Metadata: &daramjwee.Metadata{CacheTag: fmt.Sprintf("tag-%d", time.Now().UnixNano())},
+	}, nil
+}
+
+type groupRecordingFetcher struct {
+	label string
+	mu    *sync.Mutex
+	order *[]string
+}
+
+func (f groupRecordingFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	f.mu.Lock()
+	*f.order = append(*f.order, f.label)
+	f.mu.Unlock()
+	return &daramjwee.FetchResult{
+		Body:     io.NopCloser(strings.NewReader(f.label)),
+		Metadata: &daramjwee.Metadata{CacheTag: f.label},
+	}, nil
+}
+
+type groupNoopFetcher struct{}
+
+func (groupNoopFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	return &daramjwee.FetchResult{
+		Body:     io.NopCloser(strings.NewReader("noop")),
+		Metadata: &daramjwee.Metadata{CacheTag: "noop"},
+	}, nil
+}
+
+func TestCacheGroup_QueueIsolationThroughScheduleRefresh(t *testing.T) {
+	group, err := daramjwee.NewGroup(nil,
+		daramjwee.WithGroupWorkers(1),
+		daramjwee.WithGroupWorkerQueueDefault(1),
+	)
+	require.NoError(t, err)
+	t.Cleanup(group.Close)
+
+	cacheA, err := group.NewCache("cache-a", daramjwee.WithTiers(groupTestStore{}))
+	require.NoError(t, err)
+	t.Cleanup(cacheA.Close)
+
+	cacheB, err := group.NewCache("cache-b", daramjwee.WithTiers(groupTestStore{}))
+	require.NoError(t, err)
+	t.Cleanup(cacheB.Close)
+
+	fetcher := &groupBlockingFetcher{started: make(chan struct{}), release: make(chan struct{})}
+	require.NoError(t, cacheA.ScheduleRefresh(context.Background(), "key-a", fetcher))
+	<-fetcher.started
+
+	require.NoError(t, cacheA.ScheduleRefresh(context.Background(), "key-a-queued", groupNoopFetcher{}))
+	require.ErrorIs(t, cacheA.ScheduleRefresh(context.Background(), "key-a-rejected", groupNoopFetcher{}), daramjwee.ErrBackgroundJobRejected)
+	require.NoError(t, cacheB.ScheduleRefresh(context.Background(), "key-b", groupNoopFetcher{}))
+
+	close(fetcher.release)
+}
+
+func TestCacheGroup_WeightedDequeueProgress(t *testing.T) {
+	group, err := daramjwee.NewGroup(nil,
+		daramjwee.WithGroupWorkers(1),
+		daramjwee.WithGroupWorkerQueueDefault(4),
+	)
+	require.NoError(t, err)
+	t.Cleanup(group.Close)
+
+	cacheA, err := group.NewCache("cache-a", daramjwee.WithTiers(groupTestStore{}), daramjwee.WithWeight(2))
+	require.NoError(t, err)
+	t.Cleanup(cacheA.Close)
+
+	cacheB, err := group.NewCache("cache-b", daramjwee.WithTiers(groupTestStore{}), daramjwee.WithWeight(1))
+	require.NoError(t, err)
+	t.Cleanup(cacheB.Close)
+
+	var mu sync.Mutex
+	order := make([]string, 0, 3)
+	fetcherA := groupRecordingFetcher{label: "A", mu: &mu, order: &order}
+	fetcherB := groupRecordingFetcher{label: "B", mu: &mu, order: &order}
+
+	require.NoError(t, cacheA.ScheduleRefresh(context.Background(), "a1", fetcherA))
+	require.NoError(t, cacheA.ScheduleRefresh(context.Background(), "a2", fetcherA))
+	require.NoError(t, cacheB.ScheduleRefresh(context.Background(), "b1", fetcherB))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(order) >= 3
+	}, 3*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"A", "A", "B"}, order[:3])
+}


### PR DESCRIPTION
## Summary
- add a runnable `examples/cache_group` demo for `NewGroup(...)` and shared runtime usage
- update the README with a minimal `CacheGroup` snippet and correct shutdown wording
- clarify the GCS objectstore example READMEs so their runtime expectations match the current code paths

## Why
`CacheGroup` was implemented recently, but the public docs only described the API at a high level. This adds a local example that users can run without external services and tightens related docs where the previous wording did not match actual behavior.

## Validation
- `go test ./...`
- `go run ./examples/cache_group`
- `go run ./examples/filestore_default`
- `go run ./examples/filestore_policy`
- `go run ./examples/generic_cache`
- `go run ./examples/memstore_lru`
- `go run ./examples/memstore_s3fifo`
- `go run ./examples/memstore_sieve`
- `go run ./examples/multi_tier_cache`
- `go run ./examples/file_objstore_provider`
- `go run ./examples/file_objstore`

## Notes
- `examples/file_objstore` and `examples/file_objstore_provider` still require real GCS credentials to validate lower-tier recovery; with placeholder config they may fail during client setup or later when tier-1 access is attempted.