### PR TITLE
Fix orphan top write reservations

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -134,7 +134,9 @@ func (c *DaramjweeCache) Delete(ctx context.Context, key string) error {
 		return err
 	}
 	coord := c.topWrites.coordinator(key)
-	coord.beginDelete()
+	if err := coord.beginDelete(ctx); err != nil {
+		return err
+	}
 	topDeleteSucceeded := false
 	defer func() {
 		coord.finishDelete(topDeleteSucceeded)

--- a/cache_persist.go
+++ b/cache_persist.go
@@ -74,7 +74,7 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 				c.errorLog("msg", "failed to get writer for destination store", "key", key, "dest_tier", destTierIndex, "err", err)
 				return
 			}
-			destWriter = newConditionalGenerationWriteSink(destWriter, c.topWrites.coordinator(key), expectedGeneration, func() error {
+			destWriter = newConditionalGenerationWriteSink(destWriter, c.topWrites.coordinator(key), expectedGeneration, c.closeTimeout, func() error {
 				cleanupCtx, cancel := c.newCtxWithTimeout(valueCtx)
 				defer cancel()
 				return c.deleteFromStore(cleanupCtx, dest, key)

--- a/daramjwee.go
+++ b/daramjwee.go
@@ -220,7 +220,9 @@ type StagedWriteSink interface {
 // BeginStagedSet must keep the currently readable value for key unchanged
 // until Commit succeeds. Abort and failed Commit must leave no visible value
 // from the staged writer, and Delete must not wait for an uncommitted staged
-// writer on the same key to commit or abort.
+// writer on the same key to commit or abort. Commit and Abort are terminal and
+// must tolerate repeated cleanup calls because the cache may call Abort after a
+// failed Commit to release hidden staging resources.
 type StagingStore interface {
 	BeginStagedSet(ctx context.Context, key string, metadata *Metadata) (StagedWriteSink, error)
 }
@@ -230,9 +232,13 @@ type Store interface {
 	// GetStream retrieves an object and its metadata as a stream.
 	// Successful lookups must return non-nil metadata.
 	GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error)
-	// BeginSet returns a sink that writes data into the store.
+	// BeginSet returns a sink that stages data into the store.
+	// The currently readable value for key must remain unchanged until the
+	// returned sink is successfully closed or aborted.
 	BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error)
-	// Delete removes an object from the store.
+	// Delete removes the last committed object from the store.
+	// It must not wait for an uncommitted BeginSet sink on the same key to
+	// close or abort.
 	Delete(ctx context.Context, key string) error
 	// Stat retrieves metadata for an object without its data.
 	Stat(ctx context.Context, key string) (*Metadata, error)

--- a/daramjwee.go
+++ b/daramjwee.go
@@ -206,18 +206,33 @@ type WriteSink interface {
 	Abort() error
 }
 
+// StagedWriteSink is an optional store capability used by the cache core to
+// separate invisible staging from visible publish.
+type StagedWriteSink interface {
+	io.Writer
+	Commit(ctx context.Context) error
+	Abort() error
+}
+
+// StagingStore is an optional Store extension. Stores that implement it let the
+// cache coordinate only the short commit phase instead of holding cache-level
+// same-key ownership for the full caller-controlled write lifetime.
+// BeginStagedSet must keep the currently readable value for key unchanged
+// until Commit succeeds. Abort and failed Commit must leave no visible value
+// from the staged writer, and Delete must not wait for an uncommitted staged
+// writer on the same key to commit or abort.
+type StagingStore interface {
+	BeginStagedSet(ctx context.Context, key string, metadata *Metadata) (StagedWriteSink, error)
+}
+
 // Store defines the interface for a single cache storage tier (e.g., memory, disk).
 type Store interface {
 	// GetStream retrieves an object and its metadata as a stream.
 	// Successful lookups must return non-nil metadata.
 	GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error)
-	// BeginSet returns a sink that stages data into the store.
-	// The currently readable value for key must remain unchanged until the
-	// returned sink is successfully closed or aborted.
+	// BeginSet returns a sink that writes data into the store.
 	BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error)
-	// Delete removes the last committed object from the store.
-	// It must not wait for an uncommitted BeginSet sink on the same key to
-	// close or abort.
+	// Delete removes an object from the store.
 	Delete(ctx context.Context, key string) error
 	// Stat retrieves metadata for an object without its data.
 	Stat(ctx context.Context, key string) (*Metadata, error)

--- a/pkg/store/filestore/storage.go
+++ b/pkg/store/filestore/storage.go
@@ -220,6 +220,12 @@ func (fs *FileStore) GetStream(ctx context.Context, key string) (io.ReadCloser, 
 // The data is written to a temporary file and then atomically moved to the final location
 // upon closing the writer, or copied if WithCopyWrite option is used.
 func (fs *FileStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return fs.beginStagedSet(key, metadata)
 }
 

--- a/pkg/store/filestore/storage.go
+++ b/pkg/store/filestore/storage.go
@@ -42,6 +42,7 @@ type FileStore struct {
 }
 
 var _ daramjwee.TierValidator = (*FileStore)(nil)
+var _ daramjwee.StagingStore = (*FileStore)(nil)
 
 const encodedKeyPrefix = "b64_"
 const encodedKeyDir = "__encoded__"
@@ -219,6 +220,20 @@ func (fs *FileStore) GetStream(ctx context.Context, key string) (io.ReadCloser, 
 // The data is written to a temporary file and then atomically moved to the final location
 // upon closing the writer, or copied if WithCopyWrite option is used.
 func (fs *FileStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return fs.beginStagedSet(key, metadata)
+}
+
+func (fs *FileStore) BeginStagedSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.StagedWriteSink, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return fs.beginStagedSet(key, metadata)
+}
+
+func (fs *FileStore) beginStagedSet(key string, metadata *daramjwee.Metadata) (*stagedFileWriteSink, error) {
 	path := fs.toDataPath(key)
 	fs.beginGenerationTracking(key)
 	trackingActive := true
@@ -259,7 +274,10 @@ func (fs *FileStore) BeginSet(ctx context.Context, key string, metadata *daramjw
 		return cleanupTemp()
 	}
 
-	onClose := func() (err error) {
+	onCommit := func(ctx context.Context) (err error) {
+		if ctx == nil {
+			ctx = context.Background()
+		}
 		defer fs.finishGenerationTracking(key)
 		defer func() {
 			if cleanupErr := cleanupTemp(); cleanupErr != nil && err == nil {
@@ -267,10 +285,18 @@ func (fs *FileStore) BeginSet(ctx context.Context, key string, metadata *daramjw
 			}
 		}()
 
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		locked := fs.lockPaths([]string{path}, nil)
 		defer func() {
 			fs.unlockPaths(locked)
 		}()
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 
 		if current := fs.generationFloor(key); current > generation {
 			return nil
@@ -306,7 +332,7 @@ func (fs *FileStore) BeginSet(ctx context.Context, key string, metadata *daramjw
 
 	// Hand off tracking responsibility to the writer's terminal callbacks.
 	trackingActive = false
-	return newLockedWriteCloser(tmpFile, onClose, abortCleanup), nil
+	return newStagedFileWriteSink(tmpFile, onCommit, abortCleanup), nil
 }
 
 // Delete removes an object from the store.
@@ -665,67 +691,78 @@ func (lrc *lockedReadCloser) Close() error {
 	return lrc.File.Close()
 }
 
-// lockedWriteCloser wraps an os.File and executes an onClose function on Close.
-type lockedWriteCloser struct {
-	*os.File
-	onClose func() error
-	onAbort func() error
-	mu      sync.Mutex
-	done    bool
+type stagedFileWriteSink struct {
+	file     *os.File
+	onCommit func(context.Context) error
+	onAbort  func() error
+	mu       sync.Mutex
+	done     bool
 }
 
-// newLockedWriteCloser creates a new lockedWriteCloser.
-func newLockedWriteCloser(f *os.File, onClose func() error, onAbort func() error) daramjwee.WriteSink {
-	return &lockedWriteCloser{File: f, onClose: onClose, onAbort: onAbort}
+func newStagedFileWriteSink(f *os.File, onCommit func(context.Context) error, onAbort func() error) *stagedFileWriteSink {
+	return &stagedFileWriteSink{file: f, onCommit: onCommit, onAbort: onAbort}
 }
 
-// Close closes the underlying file and then executes the onClose callback.
-// It prioritizes the error from the onClose callback.
-func (lwc *lockedWriteCloser) Close() error {
-	if !lwc.markDone() {
+func (s *stagedFileWriteSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done || s.file == nil {
+		return 0, io.ErrClosedPipe
+	}
+	return s.file.Write(p)
+}
+
+func (s *stagedFileWriteSink) Close() error {
+	return s.Commit(context.Background())
+}
+
+func (s *stagedFileWriteSink) Commit(ctx context.Context) error {
+	file, ok := s.markDone()
+	if !ok {
 		return nil
 	}
 
-	closeErr := lwc.File.Close()
+	closeErr := file.Close()
 	if closeErr != nil {
-		if lwc.onAbort != nil {
-			abortErr := lwc.onAbort()
-			if abortErr != nil {
-				return errors.Join(closeErr, abortErr)
-			}
-		}
-		return closeErr
+		abortErr := s.abort()
+		return errors.Join(closeErr, abortErr)
 	}
 
-	onCloseErr := lwc.onClose()
-
-	if onCloseErr != nil {
-		return onCloseErr
+	commitErr := s.onCommit(ctx)
+	if commitErr != nil {
+		return commitErr
 	}
 	return closeErr
 }
 
-func (lwc *lockedWriteCloser) Abort() error {
-	if !lwc.markDone() {
+func (s *stagedFileWriteSink) Abort() error {
+	file, ok := s.markDone()
+	if !ok {
 		return nil
 	}
 
-	closeErr := lwc.File.Close()
-	var abortErr error
-	if lwc.onAbort != nil {
-		abortErr = lwc.onAbort()
-	}
+	closeErr := file.Close()
+	abortErr := s.abort()
 	return errors.Join(closeErr, abortErr)
 }
 
-func (lwc *lockedWriteCloser) markDone() bool {
-	lwc.mu.Lock()
-	defer lwc.mu.Unlock()
-	if lwc.done {
-		return false
+func (s *stagedFileWriteSink) markDone() (*os.File, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done || s.file == nil {
+		return nil, false
 	}
-	lwc.done = true
-	return true
+	s.done = true
+	file := s.file
+	s.file = nil
+	return file, true
+}
+
+func (s *stagedFileWriteSink) abort() error {
+	if s.onAbort == nil {
+		return nil
+	}
+	return s.onAbort()
 }
 
 // initializeCurrentSize scans the base directory to calculate the current total size

--- a/pkg/store/filestore/storage.go
+++ b/pkg/store/filestore/storage.go
@@ -287,7 +287,7 @@ func (fs *FileStore) beginStagedSet(key string, metadata *daramjwee.Metadata) (*
 		defer fs.finishGenerationTracking(key)
 		defer func() {
 			if cleanupErr := cleanupTemp(); cleanupErr != nil && err == nil {
-				err = cleanupErr
+				err = fmt.Errorf("filestore: cleanup: %w", cleanupErr)
 			}
 		}()
 

--- a/pkg/store/filestore/storage.go
+++ b/pkg/store/filestore/storage.go
@@ -224,7 +224,7 @@ func (fs *FileStore) BeginSet(ctx context.Context, key string, metadata *daramjw
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("filestore: begin set: %w", err)
 	}
 	return fs.beginStagedSet(key, metadata)
 }
@@ -234,7 +234,7 @@ func (fs *FileStore) BeginStagedSet(ctx context.Context, key string, metadata *d
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("filestore: begin staged set: %w", err)
 	}
 	return fs.beginStagedSet(key, metadata)
 }
@@ -292,7 +292,7 @@ func (fs *FileStore) beginStagedSet(key string, metadata *daramjwee.Metadata) (*
 		}()
 
 		if err := ctx.Err(); err != nil {
-			return err
+			return fmt.Errorf("filestore: commit: %w", err)
 		}
 
 		locked := fs.lockPaths([]string{path}, nil)
@@ -301,7 +301,7 @@ func (fs *FileStore) beginStagedSet(key string, metadata *daramjwee.Metadata) (*
 		}()
 
 		if err := ctx.Err(); err != nil {
-			return err
+			return fmt.Errorf("filestore: commit: %w", err)
 		}
 
 		if current := fs.generationFloor(key); current > generation {

--- a/pkg/store/filestore/storage_test.go
+++ b/pkg/store/filestore/storage_test.go
@@ -131,6 +131,17 @@ func TestFileStore_StagedWriteInvisibleBeforeCommit(t *testing.T) {
 	assert.Equal(t, "staged payload", string(body))
 }
 
+func TestFileStore_BeginSetRejectsCanceledContext(t *testing.T) {
+	fs := setupTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	writer, err := fs.BeginSet(ctx, "canceled-begin", &daramjwee.Metadata{CacheTag: "v1"})
+	require.Nil(t, writer)
+	require.ErrorIs(t, err, context.Canceled)
+	requireNoTempFiles(t, fs)
+}
+
 func TestFileStore_StagedAbortDiscardsTempData(t *testing.T) {
 	fs := setupTestStore(t)
 	ctx := context.Background()

--- a/pkg/store/filestore/storage_test.go
+++ b/pkg/store/filestore/storage_test.go
@@ -107,6 +107,118 @@ func TestFileStore_SetAndGet(t *testing.T) {
 	assert.Equal(t, content, string(readBytes))
 }
 
+func TestFileStore_StagedWriteInvisibleBeforeCommit(t *testing.T) {
+	fs := setupTestStore(t)
+	ctx := context.Background()
+	key := "staged-invisible"
+
+	writer, err := fs.BeginStagedSet(ctx, key, &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("staged payload"))
+	require.NoError(t, err)
+
+	_, _, err = fs.GetStream(ctx, key)
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+
+	require.NoError(t, writer.Commit(ctx))
+
+	reader, meta, err := fs.GetStream(ctx, key)
+	require.NoError(t, err)
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", meta.CacheTag)
+	assert.Equal(t, "staged payload", string(body))
+}
+
+func TestFileStore_StagedAbortDiscardsTempData(t *testing.T) {
+	fs := setupTestStore(t)
+	ctx := context.Background()
+	key := "staged-abort"
+
+	writer, err := fs.BeginStagedSet(ctx, key, &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("discard me"))
+	require.NoError(t, err)
+
+	require.NoError(t, writer.Abort())
+
+	_, _, err = fs.GetStream(ctx, key)
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+	_, err = os.Stat(fs.toDataPath(key))
+	require.True(t, os.IsNotExist(err), "aborted staged write should not leave final data")
+	requireNoTempFiles(t, fs)
+}
+
+func TestFileStore_StagedCommitWithCanceledContextDoesNotPublish(t *testing.T) {
+	fs := setupTestStore(t)
+	ctx := context.Background()
+	key := "staged-canceled"
+
+	current, err := fs.BeginSet(ctx, key, &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = current.Write([]byte("current"))
+	require.NoError(t, err)
+	require.NoError(t, current.Close())
+
+	writer, err := fs.BeginStagedSet(ctx, key, &daramjwee.Metadata{CacheTag: "v2"})
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("new"))
+	require.NoError(t, err)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.ErrorIs(t, writer.Commit(canceledCtx), context.Canceled)
+
+	reader, meta, err := fs.GetStream(ctx, key)
+	require.NoError(t, err)
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", meta.CacheTag)
+	assert.Equal(t, "current", string(body))
+	requireNoTempFiles(t, fs)
+}
+
+func TestFileStore_StagedCommitPublishesWhileOlderStagedWriterIsAbandoned(t *testing.T) {
+	fs := setupTestStore(t)
+	ctx := context.Background()
+	key := "staged-abandoned"
+
+	older, err := fs.BeginStagedSet(ctx, key, &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = older.Abort()
+	})
+	_, err = older.Write([]byte("older"))
+	require.NoError(t, err)
+
+	newer, err := fs.BeginStagedSet(ctx, key, &daramjwee.Metadata{CacheTag: "v2"})
+	require.NoError(t, err)
+	_, err = newer.Write([]byte("newer"))
+	require.NoError(t, err)
+
+	commitDone := make(chan error, 1)
+	go func() {
+		commitDone <- newer.Commit(ctx)
+	}()
+
+	select {
+	case err := <-commitDone:
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("newer staged commit blocked behind abandoned staged writer")
+	}
+
+	reader, meta, err := fs.GetStream(ctx, key)
+	require.NoError(t, err)
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "v2", meta.CacheTag)
+	assert.Equal(t, "newer", string(body))
+}
+
 // TestFileStore_Get_NotFound tests that getting a non-existent key returns the correct error.
 func TestFileStore_Get_NotFound(t *testing.T) {
 	fs := setupTestStore(t)
@@ -114,6 +226,19 @@ func TestFileStore_Get_NotFound(t *testing.T) {
 
 	_, _, err := fs.GetStream(ctx, "non-existent-key")
 	assert.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
+func requireNoTempFiles(t *testing.T, fs *FileStore) {
+	t.Helper()
+	err := filepath.Walk(fs.baseDir, func(path string, info os.FileInfo, err error) error {
+		require.NoError(t, err)
+		if info.IsDir() {
+			return nil
+		}
+		require.Falsef(t, strings.HasPrefix(info.Name(), "daramjwee-tmp-"), "temporary file still exists: %s", path)
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 // TestFileStore_Stat tests getting metadata without file content.
@@ -1105,14 +1230,16 @@ func TestFileStore_InitializeCurrentSizeDoesNotDoubleCountDuplicateLogicalKeys(t
 	assert.NotEqual(t, legacyInfo.Size()+encodedInfo.Size(), currentSize)
 }
 
-func TestLockedWriteCloser_DoesNotCommitWhenFileCloseFails(t *testing.T) {
+func TestStagedFileWriteSink_DoesNotCommitWhenFileCloseFails(t *testing.T) {
 	var committed bool
 	var aborted bool
 
-	badFile := os.NewFile(^uintptr(0), "bad-file")
-	writer := newLockedWriteCloser(
+	badFile, err := os.CreateTemp(t.TempDir(), "bad-file-*")
+	require.NoError(t, err)
+	require.NoError(t, badFile.Close())
+	writer := newStagedFileWriteSink(
 		badFile,
-		func() error {
+		func(context.Context) error {
 			committed = true
 			return nil
 		},
@@ -1122,7 +1249,7 @@ func TestLockedWriteCloser_DoesNotCommitWhenFileCloseFails(t *testing.T) {
 		},
 	)
 
-	err := writer.Close()
+	err = writer.Close()
 	require.Error(t, err)
 	assert.False(t, committed)
 	assert.True(t, aborted)

--- a/pkg/store/filestore/storage_test.go
+++ b/pkg/store/filestore/storage_test.go
@@ -139,6 +139,7 @@ func TestFileStore_BeginSetRejectsCanceledContext(t *testing.T) {
 	writer, err := fs.BeginSet(ctx, "canceled-begin", &daramjwee.Metadata{CacheTag: "v1"})
 	require.Nil(t, writer)
 	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "filestore: begin set")
 	requireNoTempFiles(t, fs)
 }
 
@@ -179,7 +180,9 @@ func TestFileStore_StagedCommitWithCanceledContextDoesNotPublish(t *testing.T) {
 
 	canceledCtx, cancel := context.WithCancel(ctx)
 	cancel()
-	require.ErrorIs(t, writer.Commit(canceledCtx), context.Canceled)
+	err = writer.Commit(canceledCtx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "filestore: commit")
 
 	reader, meta, err := fs.GetStream(ctx, key)
 	require.NoError(t, err)

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -68,15 +68,25 @@ func (ms *MemStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *
 // BeginSet returns a writer that streams data into an in-memory buffer.
 // When the writer is closed, the buffered data is committed to the main map.
 func (ms *MemStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return ms.beginSet(key, metadata), nil
+}
+
+func (ms *MemStore) BeginStagedSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.StagedWriteSink, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return ms.beginSet(key, metadata), nil
+}
+
+func (ms *MemStore) beginSet(key string, metadata *daramjwee.Metadata) *memStoreSink {
 	buf := bufferPool.Get().(*bytes.Buffer)
 	buf.Reset()
-	w := &memStoreSink{
+	return &memStoreSink{
 		ms:       ms,
 		key:      key,
 		metadata: metadata,
 		buf:      buf,
 	}
-	return w, nil
 }
 
 // Delete removes an object from the in-memory map.
@@ -132,12 +142,28 @@ func (w *memStoreSink) Write(p []byte) (n int, err error) {
 // Close is called when the write operation is complete.
 // It commits the buffered data to the MemStore and handles eviction if capacity is exceeded.
 func (w *memStoreSink) Close() error {
+	return w.Commit(context.Background())
+}
+
+func (w *memStoreSink) Commit(ctx context.Context) error {
 	if w.done {
 		return nil
 	}
-	w.done = true
+	if err := ctx.Err(); err != nil {
+		w.done = true
+		w.buf.Reset()
+		w.release()
+		return err
+	}
 	w.ms.mu.Lock()
 	defer w.ms.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		w.done = true
+		w.buf.Reset()
+		w.release()
+		return err
+	}
+	w.done = true
 
 	finalData := make([]byte, w.buf.Len())
 	copy(finalData, w.buf.Bytes())

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -172,29 +172,28 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 		w.release()
 		return fmt.Errorf("memstore: commit: %w", err)
 	}
+
+	finalData := make([]byte, w.buf.Len())
+	copy(finalData, w.buf.Bytes())
+	newItemSize := int64(len(finalData))
+	newEntry := entry{
+		value:    finalData,
+		metadata: cloneMetadata(w.metadata),
+	}
+
 	ms := w.ms
 	ms.mu.Lock()
+	defer w.release()
+	defer ms.mu.Unlock()
 	if err := ctx.Err(); err != nil {
 		w.done = true
-		ms.mu.Unlock()
-		w.release()
 		return fmt.Errorf("memstore: commit: %w", err)
 	}
 	w.done = true
 
-	finalData := make([]byte, w.buf.Len())
-	copy(finalData, w.buf.Bytes())
-
-	newItemSize := int64(len(finalData))
-
 	// If the item already exists, subtract its old size from currentSize.
 	if oldEntry, ok := ms.data[w.key]; ok {
 		ms.currentSize -= int64(len(oldEntry.value))
-	}
-
-	newEntry := entry{
-		value:    finalData,
-		metadata: cloneMetadata(w.metadata),
 	}
 
 	ms.data[w.key] = newEntry
@@ -227,9 +226,6 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 			}
 		}
 	}
-
-	ms.mu.Unlock()
-	w.release()
 
 	return nil
 }

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -72,6 +72,9 @@ func (ms *MemStore) BeginSet(ctx context.Context, key string, metadata *daramjwe
 }
 
 func (ms *MemStore) BeginStagedSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.StagedWriteSink, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -152,6 +152,9 @@ func (w *memStoreSink) Close() error {
 }
 
 func (w *memStoreSink) Commit(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.done {

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -124,6 +124,7 @@ func (ms *MemStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, 
 
 // memStoreSink is a helper type that satisfies the daramjwee.WriteSink interface.
 type memStoreSink struct {
+	mu       sync.Mutex
 	ms       *MemStore
 	key      string
 	metadata *daramjwee.Metadata
@@ -133,6 +134,8 @@ type memStoreSink struct {
 
 // Write writes the provided data to the internal buffer.
 func (w *memStoreSink) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.done {
 		return 0, io.ErrClosedPipe
 	}
@@ -146,6 +149,8 @@ func (w *memStoreSink) Close() error {
 }
 
 func (w *memStoreSink) Commit(ctx context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.done {
 		return nil
 	}
@@ -217,6 +222,8 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 }
 
 func (w *memStoreSink) Abort() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.done {
 		return nil
 	}

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -173,8 +173,7 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 		return fmt.Errorf("memstore: commit: %w", err)
 	}
 
-	finalData := make([]byte, w.buf.Len())
-	copy(finalData, w.buf.Bytes())
+	finalData := bytes.Clone(w.buf.Bytes())
 	newItemSize := int64(len(finalData))
 	newEntry := entry{
 		value:    finalData,

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -151,15 +151,14 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 	}
 	if err := ctx.Err(); err != nil {
 		w.done = true
-		w.buf.Reset()
 		w.release()
 		return err
 	}
-	w.ms.mu.Lock()
-	defer w.ms.mu.Unlock()
+	ms := w.ms
+	ms.mu.Lock()
 	if err := ctx.Err(); err != nil {
 		w.done = true
-		w.buf.Reset()
+		ms.mu.Unlock()
 		w.release()
 		return err
 	}
@@ -171,8 +170,8 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 	newItemSize := int64(len(finalData))
 
 	// If the item already exists, subtract its old size from currentSize.
-	if oldEntry, ok := w.ms.data[w.key]; ok {
-		w.ms.currentSize -= int64(len(oldEntry.value))
+	if oldEntry, ok := ms.data[w.key]; ok {
+		ms.currentSize -= int64(len(oldEntry.value))
 	}
 
 	newEntry := entry{
@@ -180,15 +179,15 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 		metadata: cloneMetadata(w.metadata),
 	}
 
-	w.ms.data[w.key] = newEntry
+	ms.data[w.key] = newEntry
 	// Add the new item's size to currentSize.
-	w.ms.currentSize += newItemSize
-	w.ms.policy.Add(w.key, newItemSize)
+	ms.currentSize += newItemSize
+	ms.policy.Add(w.key, newItemSize)
 
 	// Eviction logic: if capacity is positive and exceeded, evict items.
-	if w.ms.capacity > 0 {
-		for w.ms.currentSize > w.ms.capacity {
-			keysToEvict := w.ms.policy.Evict()
+	if ms.capacity > 0 {
+		for ms.currentSize > ms.capacity {
+			keysToEvict := ms.policy.Evict()
 			if len(keysToEvict) == 0 {
 				// No more candidates for eviction, break to prevent infinite loop.
 				break
@@ -196,10 +195,10 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 
 			var actuallyEvicted bool
 			for _, keyToEvict := range keysToEvict {
-				if entryToEvict, ok := w.ms.data[keyToEvict]; ok {
-					w.ms.currentSize -= int64(len(entryToEvict.value))
-					delete(w.ms.data, keyToEvict)
-					w.ms.policy.Remove(keyToEvict)
+				if entryToEvict, ok := ms.data[keyToEvict]; ok {
+					ms.currentSize -= int64(len(entryToEvict.value))
+					delete(ms.data, keyToEvict)
+					ms.policy.Remove(keyToEvict)
 					actuallyEvicted = true
 				}
 			}
@@ -211,8 +210,7 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 		}
 	}
 
-	// Reset the writer and return it to the pool.
-	w.buf.Reset()
+	ms.mu.Unlock()
 	w.release()
 
 	return nil

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -68,6 +68,12 @@ func (ms *MemStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *
 // BeginSet returns a writer that streams data into an in-memory buffer.
 // When the writer is closed, the buffered data is committed to the main map.
 func (ms *MemStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return ms.beginSet(key, metadata), nil
 }
 

--- a/pkg/store/memstore/memory.go
+++ b/pkg/store/memstore/memory.go
@@ -3,6 +3,7 @@ package memstore
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
@@ -72,7 +73,7 @@ func (ms *MemStore) BeginSet(ctx context.Context, key string, metadata *daramjwe
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("memstore: begin set: %w", err)
 	}
 	return ms.beginSet(key, metadata), nil
 }
@@ -82,7 +83,7 @@ func (ms *MemStore) BeginStagedSet(ctx context.Context, key string, metadata *da
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("memstore: begin staged set: %w", err)
 	}
 	return ms.beginSet(key, metadata), nil
 }
@@ -169,7 +170,7 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		w.done = true
 		w.release()
-		return err
+		return fmt.Errorf("memstore: commit: %w", err)
 	}
 	ms := w.ms
 	ms.mu.Lock()
@@ -177,7 +178,7 @@ func (w *memStoreSink) Commit(ctx context.Context) error {
 		w.done = true
 		ms.mu.Unlock()
 		w.release()
-		return err
+		return fmt.Errorf("memstore: commit: %w", err)
 	}
 	w.done = true
 

--- a/pkg/store/memstore/memory_test.go
+++ b/pkg/store/memstore/memory_test.go
@@ -128,7 +128,9 @@ func TestMemStore_CanceledStagedCommitIsTerminal(t *testing.T) {
 
 	commitCtx, cancel := context.WithCancel(ctx)
 	cancel()
-	require.ErrorIs(t, writer.Commit(commitCtx), context.Canceled)
+	err = writer.Commit(commitCtx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "memstore: commit")
 	require.NoError(t, writer.Commit(ctx))
 
 	_, _, err = store.GetStream(ctx, "staged-cancel")
@@ -161,6 +163,7 @@ func TestMemStore_BeginSetRejectsCanceledContext(t *testing.T) {
 	writer, err := store.BeginSet(ctx, "canceled-begin", &daramjwee.Metadata{CacheTag: "v1"})
 	require.Nil(t, writer)
 	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "memstore: begin set")
 }
 
 // TestMemStore_Get_NotFound tests getting a non-existent key.

--- a/pkg/store/memstore/memory_test.go
+++ b/pkg/store/memstore/memory_test.go
@@ -117,6 +117,24 @@ func TestMemStore_SetAndGetStream(t *testing.T) {
 	assert.Equal(t, etag, meta.CacheTag)
 }
 
+func TestMemStore_CanceledStagedCommitIsTerminal(t *testing.T) {
+	ctx := context.Background()
+	store := New(0, nil)
+
+	writer, err := store.BeginStagedSet(ctx, "staged-cancel", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("partial"))
+	require.NoError(t, err)
+
+	commitCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.ErrorIs(t, writer.Commit(commitCtx), context.Canceled)
+	require.NoError(t, writer.Commit(ctx))
+
+	_, _, err = store.GetStream(ctx, "staged-cancel")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
 // TestMemStore_Get_NotFound tests getting a non-existent key.
 func TestMemStore_Get_NotFound(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/store/memstore/memory_test.go
+++ b/pkg/store/memstore/memory_test.go
@@ -153,6 +153,16 @@ func TestMemStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
 	assert.Equal(t, "v1", meta.CacheTag)
 }
 
+func TestMemStore_BeginSetRejectsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	store := New(0, nil)
+
+	writer, err := store.BeginSet(ctx, "canceled-begin", &daramjwee.Metadata{CacheTag: "v1"})
+	require.Nil(t, writer)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 // TestMemStore_Get_NotFound tests getting a non-existent key.
 func TestMemStore_Get_NotFound(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/store/memstore/memory_test.go
+++ b/pkg/store/memstore/memory_test.go
@@ -142,7 +142,7 @@ func TestMemStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
 	require.NoError(t, err)
 	_, err = writer.Write([]byte("value"))
 	require.NoError(t, err)
-	require.NoError(t, writer.Commit(context.Background()))
+	require.NoError(t, writer.Commit(nil))
 
 	reader, meta, err := store.GetStream(context.Background(), "nil-context")
 	require.NoError(t, err)

--- a/pkg/store/memstore/memory_test.go
+++ b/pkg/store/memstore/memory_test.go
@@ -135,6 +135,24 @@ func TestMemStore_CanceledStagedCommitIsTerminal(t *testing.T) {
 	require.ErrorIs(t, err, daramjwee.ErrNotFound)
 }
 
+func TestMemStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
+	store := New(0, nil)
+
+	writer, err := store.BeginStagedSet(nil, "nil-context", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("value"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Commit(context.Background()))
+
+	reader, meta, err := store.GetStream(context.Background(), "nil-context")
+	require.NoError(t, err)
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "value", string(body))
+	assert.Equal(t, "v1", meta.CacheTag)
+}
+
 // TestMemStore_Get_NotFound tests getting a non-existent key.
 func TestMemStore_Get_NotFound(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/store/objectstore/ingest_test.go
+++ b/pkg/store/objectstore/ingest_test.go
@@ -105,6 +105,22 @@ func TestStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
 	require.NoError(t, store.Delete(nil, "staged-nil-context"))
 }
 
+func TestStore_BeginStagedSetRejectsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	dataDir := t.TempDir()
+	store := New(
+		objstore.NewInMemBucket(),
+		log.NewNopLogger(),
+		WithDir(dataDir),
+	)
+
+	writer, err := store.BeginStagedSet(ctx, "staged-canceled-begin", &daramjwee.Metadata{CacheTag: "v1"})
+	require.Nil(t, writer)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "objectstore: begin staged set")
+}
+
 func TestStore_StagedAbortLeavesNoVisibleLocalEntry(t *testing.T) {
 	ctx := context.Background()
 	dataDir := t.TempDir()
@@ -142,7 +158,9 @@ func TestStore_CanceledStagedCommitLeavesNoVisibleLocalEntry(t *testing.T) {
 
 	commitCtx, cancel := context.WithCancel(ctx)
 	cancel()
-	require.ErrorIs(t, writer.Commit(commitCtx), context.Canceled)
+	err = writer.Commit(commitCtx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "objectstore: commit")
 
 	_, err = store.Stat(ctx, "staged-cancel-local")
 	require.ErrorIs(t, err, daramjwee.ErrNotFound)

--- a/pkg/store/objectstore/ingest_test.go
+++ b/pkg/store/objectstore/ingest_test.go
@@ -76,6 +76,32 @@ func TestStore_StagedWriteCommitsOnlyOnCommit(t *testing.T) {
 	assert.Equal(t, "v1", meta.CacheTag)
 }
 
+func TestStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	store := New(
+		objstore.NewInMemBucket(),
+		log.NewNopLogger(),
+		WithDir(dataDir),
+	)
+	store.autoFlush = false
+
+	writer, err := store.BeginStagedSet(nil, "staged-nil-context", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, "nil context staged")
+	require.NoError(t, err)
+	require.NoError(t, writer.Commit(ctx))
+
+	stream, meta, err := store.GetStream(ctx, "staged-nil-context")
+	require.NoError(t, err)
+	defer stream.Close()
+
+	body, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	assert.Equal(t, "nil context staged", string(body))
+	assert.Equal(t, "v1", meta.CacheTag)
+}
+
 func TestStore_StagedAbortLeavesNoVisibleLocalEntry(t *testing.T) {
 	ctx := context.Background()
 	dataDir := t.TempDir()

--- a/pkg/store/objectstore/ingest_test.go
+++ b/pkg/store/objectstore/ingest_test.go
@@ -46,6 +46,79 @@ func TestStore_BeginSetIsNotVisibleBeforeClose(t *testing.T) {
 	assert.Equal(t, "v1", meta.CacheTag)
 }
 
+func TestStore_StagedWriteCommitsOnlyOnCommit(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	store := New(
+		objstore.NewInMemBucket(),
+		log.NewNopLogger(),
+		WithDir(dataDir),
+	)
+	store.autoFlush = false
+
+	writer, err := store.BeginStagedSet(ctx, "staged-local-key", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, "hello staged local")
+	require.NoError(t, err)
+
+	_, err = store.Stat(ctx, "staged-local-key")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+
+	require.NoError(t, writer.Commit(ctx))
+
+	stream, meta, err := store.GetStream(ctx, "staged-local-key")
+	require.NoError(t, err)
+	defer stream.Close()
+
+	body, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	assert.Equal(t, "hello staged local", string(body))
+	assert.Equal(t, "v1", meta.CacheTag)
+}
+
+func TestStore_StagedAbortLeavesNoVisibleLocalEntry(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	store := New(
+		objstore.NewInMemBucket(),
+		log.NewNopLogger(),
+		WithDir(dataDir),
+	)
+	store.autoFlush = false
+
+	writer, err := store.BeginStagedSet(ctx, "staged-abort-local", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, "partial")
+	require.NoError(t, err)
+	require.NoError(t, writer.Abort())
+
+	_, err = store.Stat(ctx, "staged-abort-local")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
+func TestStore_CanceledStagedCommitLeavesNoVisibleLocalEntry(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	store := New(
+		objstore.NewInMemBucket(),
+		log.NewNopLogger(),
+		WithDir(dataDir),
+	)
+	store.autoFlush = false
+
+	writer, err := store.BeginStagedSet(ctx, "staged-cancel-local", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, "partial")
+	require.NoError(t, err)
+
+	commitCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.ErrorIs(t, writer.Commit(commitCtx), context.Canceled)
+
+	_, err = store.Stat(ctx, "staged-cancel-local")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
 func TestStore_BeginSetDoesNotHoldKeyLockForWriterLifetime(t *testing.T) {
 	ctx := context.Background()
 	dataDir := t.TempDir()

--- a/pkg/store/objectstore/ingest_test.go
+++ b/pkg/store/objectstore/ingest_test.go
@@ -77,7 +77,6 @@ func TestStore_StagedWriteCommitsOnlyOnCommit(t *testing.T) {
 }
 
 func TestStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
-	ctx := context.Background()
 	dataDir := t.TempDir()
 	store := New(
 		objstore.NewInMemBucket(),
@@ -90,9 +89,9 @@ func TestStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
 	require.NoError(t, err)
 	_, err = io.WriteString(writer, "nil context staged")
 	require.NoError(t, err)
-	require.NoError(t, writer.Commit(ctx))
+	require.NoError(t, writer.Commit(nil))
 
-	stream, meta, err := store.GetStream(ctx, "staged-nil-context")
+	stream, meta, err := store.GetStream(nil, "staged-nil-context")
 	require.NoError(t, err)
 	defer stream.Close()
 
@@ -100,6 +99,10 @@ func TestStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "nil context staged", string(body))
 	assert.Equal(t, "v1", meta.CacheTag)
+	stat, err := store.Stat(nil, "staged-nil-context")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", stat.CacheTag)
+	require.NoError(t, store.Delete(nil, "staged-nil-context"))
 }
 
 func TestStore_StagedAbortLeavesNoVisibleLocalEntry(t *testing.T) {

--- a/pkg/store/objectstore/store.go
+++ b/pkg/store/objectstore/store.go
@@ -163,6 +163,9 @@ func (s *Store) ValidateTier(index int) error {
 
 // GetStream returns the current published generation for a key.
 func (s *Store) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := s.ensureReady(); err != nil {
 		return nil, nil, err
 	}
@@ -302,6 +305,9 @@ func (s *Store) beginSet(ctx context.Context, key string, metadata *daramjwee.Me
 // Delete removes the currently visible entry for a key.
 // Blob reclamation is handled by best-effort cleanup and conservative sweep.
 func (s *Store) Delete(ctx context.Context, key string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := s.ensureReady(); err != nil {
 		return err
 	}
@@ -327,6 +333,9 @@ func (s *Store) Delete(ctx context.Context, key string) error {
 
 // Stat returns metadata for the published generation.
 func (s *Store) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := s.ensureReady(); err != nil {
 		return nil, err
 	}

--- a/pkg/store/objectstore/store.go
+++ b/pkg/store/objectstore/store.go
@@ -265,21 +265,21 @@ func (s *Store) openCurrentLocalEntry(key string) (io.ReadCloser, *daramjwee.Met
 
 // BeginSet starts a staged write for a new immutable generation.
 func (s *Store) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
-	return s.beginSet(ctx, key, metadata)
+	return s.beginSet(ctx, key, metadata, "begin set")
 }
 
 func (s *Store) BeginStagedSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.StagedWriteSink, error) {
-	return s.beginSet(ctx, key, metadata)
+	return s.beginSet(ctx, key, metadata, "begin staged set")
 }
 
-func (s *Store) beginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (*writer, error) {
+func (s *Store) beginSet(ctx context.Context, key string, metadata *daramjwee.Metadata, operation string) (*writer, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if err := s.ensureReady(); err != nil {
-		return nil, err
-	}
 	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("objectstore: %s: %w", operation, err)
+	}
+	if err := s.ensureReady(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/store/objectstore/store.go
+++ b/pkg/store/objectstore/store.go
@@ -270,6 +270,9 @@ func (s *Store) BeginStagedSet(ctx context.Context, key string, metadata *daramj
 }
 
 func (s *Store) beginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (*writer, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := s.ensureReady(); err != nil {
 		return nil, err
 	}

--- a/pkg/store/objectstore/store.go
+++ b/pkg/store/objectstore/store.go
@@ -262,6 +262,14 @@ func (s *Store) openCurrentLocalEntry(key string) (io.ReadCloser, *daramjwee.Met
 
 // BeginSet starts a staged write for a new immutable generation.
 func (s *Store) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return s.beginSet(ctx, key, metadata)
+}
+
+func (s *Store) BeginStagedSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.StagedWriteSink, error) {
+	return s.beginSet(ctx, key, metadata)
+}
+
+func (s *Store) beginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (*writer, error) {
 	if err := s.ensureReady(); err != nil {
 		return nil, err
 	}

--- a/pkg/store/objectstore/writer.go
+++ b/pkg/store/objectstore/writer.go
@@ -41,8 +41,16 @@ func (w *writer) Write(p []byte) (int, error) {
 }
 
 func (w *writer) Close() error {
+	return w.Commit(w.ctx)
+}
+
+func (w *writer) Commit(ctx context.Context) error {
 	if !w.markDone() {
 		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		_ = w.segment.Abort()
+		return err
 	}
 	if err := w.ctx.Err(); err != nil {
 		_ = w.segment.Abort()

--- a/pkg/store/objectstore/writer.go
+++ b/pkg/store/objectstore/writer.go
@@ -2,6 +2,7 @@ package objectstore
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
@@ -53,11 +54,11 @@ func (w *writer) Commit(ctx context.Context) error {
 	}
 	if err := ctx.Err(); err != nil {
 		_ = w.segment.Abort()
-		return err
+		return fmt.Errorf("objectstore: commit: %w", err)
 	}
 	if err := w.ctx.Err(); err != nil {
 		_ = w.segment.Abort()
-		return err
+		return fmt.Errorf("objectstore: commit: %w", err)
 	}
 
 	sealedPath, size, err := w.segment.Seal()

--- a/pkg/store/objectstore/writer.go
+++ b/pkg/store/objectstore/writer.go
@@ -45,6 +45,9 @@ func (w *writer) Close() error {
 }
 
 func (w *writer) Commit(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !w.markDone() {
 		return nil
 	}

--- a/pkg/store/redisstore/redis.go
+++ b/pkg/store/redisstore/redis.go
@@ -227,9 +227,6 @@ func (w *redisStoreWriter) Commit(ctx context.Context) error {
 	case <-ctx.Done():
 		_ = w.rs.client.Del(context.Background(), w.tempKey).Err()
 		return fmt.Errorf("redisstore: commit: %w", ctx.Err())
-	default:
-	}
-	select {
 	case <-w.ctx.Done():
 		_ = w.rs.client.Del(context.Background(), w.tempKey).Err()
 		return fmt.Errorf("redisstore: commit: %w", w.ctx.Err())
@@ -242,7 +239,7 @@ func (w *redisStoreWriter) Commit(ctx context.Context) error {
 		if delErr := w.rs.client.Del(context.Background(), w.tempKey).Err(); delErr != nil {
 			level.Error(w.rs.logger).Log("msg", "failed to delete temporary key", "key", w.key, "err", delErr)
 		}
-		return err
+		return fmt.Errorf("redisstore: marshal metadata: %w", err)
 	}
 
 	_, err = w.rs.client.Eval(
@@ -257,7 +254,7 @@ func (w *redisStoreWriter) Commit(ctx context.Context) error {
 		if delErr := w.rs.client.Del(context.Background(), w.tempKey).Err(); delErr != nil {
 			level.Error(w.rs.logger).Log("msg", "failed to delete temporary key", "key", w.key, "err", delErr)
 		}
-		return err
+		return fmt.Errorf("redisstore: commit: %w", err)
 	}
 
 	return nil

--- a/pkg/store/redisstore/redis.go
+++ b/pkg/store/redisstore/redis.go
@@ -127,6 +127,14 @@ func (rs *RedisStore) GetStream(ctx context.Context, key string) (io.ReadCloser,
 
 // BeginSet returns a sink that streams data into Redis.
 func (rs *RedisStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return rs.beginSet(ctx, key, metadata)
+}
+
+func (rs *RedisStore) BeginStagedSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.StagedWriteSink, error) {
+	return rs.beginSet(ctx, key, metadata)
+}
+
+func (rs *RedisStore) beginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (*redisStoreWriter, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -193,8 +201,18 @@ func (w *redisStoreWriter) Write(p []byte) (n int, err error) {
 
 // Close commits the metadata to Redis.
 func (w *redisStoreWriter) Close() error {
+	return w.Commit(w.ctx)
+}
+
+func (w *redisStoreWriter) Commit(ctx context.Context) error {
 	if !w.markDone() {
 		return nil
+	}
+	select {
+	case <-ctx.Done():
+		_ = w.rs.client.Del(context.Background(), w.tempKey).Err()
+		return ctx.Err()
+	default:
 	}
 	select {
 	case <-w.ctx.Done():
@@ -206,11 +224,14 @@ func (w *redisStoreWriter) Close() error {
 	metaBytes, err := json.Marshal(w.metadata)
 	if err != nil {
 		level.Error(w.rs.logger).Log("msg", "failed to marshal metadata", "key", w.key, "err", err)
+		if delErr := w.rs.client.Del(context.Background(), w.tempKey).Err(); delErr != nil {
+			level.Error(w.rs.logger).Log("msg", "failed to delete temporary key", "key", w.key, "err", delErr)
+		}
 		return err
 	}
 
 	_, err = w.rs.client.Eval(
-		w.ctx,
+		ctx,
 		commitLuaScript,
 		[]string{w.rs.DataKey(w.key), w.rs.MetaKey(w.key), w.tempKey},
 		metaBytes,
@@ -218,7 +239,7 @@ func (w *redisStoreWriter) Close() error {
 	if err != nil {
 		level.Error(w.rs.logger).Log("msg", "failed to commit data and metadata", "key", w.key, "err", err)
 		// Attempt to clean up the temporary key
-		if delErr := w.rs.client.Del(w.ctx, w.tempKey).Err(); delErr != nil {
+		if delErr := w.rs.client.Del(context.Background(), w.tempKey).Err(); delErr != nil {
 			level.Error(w.rs.logger).Log("msg", "failed to delete temporary key", "key", w.key, "err", delErr)
 		}
 		return err

--- a/pkg/store/redisstore/redis.go
+++ b/pkg/store/redisstore/redis.go
@@ -135,6 +135,9 @@ func (rs *RedisStore) BeginStagedSet(ctx context.Context, key string, metadata *
 }
 
 func (rs *RedisStore) beginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (*redisStoreWriter, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/pkg/store/redisstore/redis.go
+++ b/pkg/store/redisstore/redis.go
@@ -130,20 +130,20 @@ func (rs *RedisStore) GetStream(ctx context.Context, key string) (io.ReadCloser,
 
 // BeginSet returns a sink that streams data into Redis.
 func (rs *RedisStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
-	return rs.beginSet(ctx, key, metadata)
+	return rs.beginSet(ctx, key, metadata, "begin set")
 }
 
 func (rs *RedisStore) BeginStagedSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.StagedWriteSink, error) {
-	return rs.beginSet(ctx, key, metadata)
+	return rs.beginSet(ctx, key, metadata, "begin staged set")
 }
 
-func (rs *RedisStore) beginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (*redisStoreWriter, error) {
+func (rs *RedisStore) beginSet(ctx context.Context, key string, metadata *daramjwee.Metadata, operation string) (*redisStoreWriter, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, fmt.Errorf("redisstore: %s: %w", operation, ctx.Err())
 	default:
 	}
 
@@ -226,13 +226,13 @@ func (w *redisStoreWriter) Commit(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		_ = w.rs.client.Del(context.Background(), w.tempKey).Err()
-		return ctx.Err()
+		return fmt.Errorf("redisstore: commit: %w", ctx.Err())
 	default:
 	}
 	select {
 	case <-w.ctx.Done():
 		_ = w.rs.client.Del(context.Background(), w.tempKey).Err()
-		return w.ctx.Err()
+		return fmt.Errorf("redisstore: commit: %w", w.ctx.Err())
 	default:
 	}
 

--- a/pkg/store/redisstore/redis.go
+++ b/pkg/store/redisstore/redis.go
@@ -87,6 +87,9 @@ func (rs *RedisStore) getMetadata(ctx context.Context, key string) (*daramjwee.M
 
 // GetStream retrieves an object and its metadata as a stream from Redis.
 func (rs *RedisStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	select {
 	case <-ctx.Done():
 		return nil, nil, ctx.Err()
@@ -156,6 +159,9 @@ func (rs *RedisStore) beginSet(ctx context.Context, key string, metadata *daramj
 
 // Delete removes an object and its metadata from Redis.
 func (rs *RedisStore) Delete(ctx context.Context, key string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -166,6 +172,9 @@ func (rs *RedisStore) Delete(ctx context.Context, key string) error {
 
 // Stat retrieves metadata for an object without its data from Redis.
 func (rs *RedisStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -208,6 +217,9 @@ func (w *redisStoreWriter) Close() error {
 }
 
 func (w *redisStoreWriter) Commit(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !w.markDone() {
 		return nil
 	}

--- a/pkg/store/redisstore/redis_test.go
+++ b/pkg/store/redisstore/redis_test.go
@@ -302,6 +302,30 @@ func TestRedisStore_StagedWriteCommitsOnlyOnCommit(t *testing.T) {
 	require.Equal(t, "v1", meta.CacheTag)
 }
 
+func TestRedisStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
+	mr := setupMiniRedis(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	store := New(client, log.NewNopLogger()).(*RedisStore)
+	ctx := context.Background()
+
+	sink, err := store.BeginStagedSet(nil, "staged-nil-context", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = sink.Write([]byte("nil context staged"))
+	require.NoError(t, err)
+	require.NoError(t, sink.Commit(ctx))
+
+	reader, meta, err := store.GetStream(ctx, "staged-nil-context")
+	require.NoError(t, err)
+	defer reader.Close()
+
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, "nil context staged", string(body))
+	require.Equal(t, "v1", meta.CacheTag)
+}
+
 func TestRedisStore_StagedAbortDeletesTempKey(t *testing.T) {
 	mr := setupMiniRedis(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})

--- a/pkg/store/redisstore/redis_test.go
+++ b/pkg/store/redisstore/redis_test.go
@@ -274,6 +274,78 @@ func TestRedisStore_AbortDeletesTempKey(t *testing.T) {
 	require.False(t, mr.Exists(store.MetaKey("abort-key")))
 }
 
+func TestRedisStore_StagedWriteCommitsOnlyOnCommit(t *testing.T) {
+	mr := setupMiniRedis(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	store := New(client, log.NewNopLogger()).(*RedisStore)
+	ctx := context.Background()
+
+	sink, err := store.BeginStagedSet(ctx, "staged-key", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = sink.Write([]byte("staged value"))
+	require.NoError(t, err)
+
+	_, err = store.Stat(ctx, "staged-key")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+
+	require.NoError(t, sink.Commit(ctx))
+
+	reader, meta, err := store.GetStream(ctx, "staged-key")
+	require.NoError(t, err)
+	defer reader.Close()
+
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, "staged value", string(body))
+	require.Equal(t, "v1", meta.CacheTag)
+}
+
+func TestRedisStore_StagedAbortDeletesTempKey(t *testing.T) {
+	mr := setupMiniRedis(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	store := New(client, log.NewNopLogger()).(*RedisStore)
+	ctx := context.Background()
+
+	sink, err := store.BeginStagedSet(ctx, "staged-abort", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	writer := sink.(*redisStoreWriter)
+	_, err = sink.Write([]byte("partial"))
+	require.NoError(t, err)
+	require.True(t, mr.Exists(writer.tempKey))
+
+	require.NoError(t, sink.Abort())
+	require.False(t, mr.Exists(writer.tempKey))
+	require.False(t, mr.Exists(store.DataKey("staged-abort")))
+	require.False(t, mr.Exists(store.MetaKey("staged-abort")))
+}
+
+func TestRedisStore_CanceledStagedCommitDeletesTempKey(t *testing.T) {
+	mr := setupMiniRedis(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	store := New(client, log.NewNopLogger()).(*RedisStore)
+	ctx := context.Background()
+
+	sink, err := store.BeginStagedSet(ctx, "staged-cancel", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	writer := sink.(*redisStoreWriter)
+	_, err = sink.Write([]byte("partial"))
+	require.NoError(t, err)
+	require.True(t, mr.Exists(writer.tempKey))
+
+	commitCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.ErrorIs(t, sink.Commit(commitCtx), context.Canceled)
+	require.False(t, mr.Exists(writer.tempKey))
+	require.False(t, mr.Exists(store.DataKey("staged-cancel")))
+	require.False(t, mr.Exists(store.MetaKey("staged-cancel")))
+}
+
 func TestRedisStore_ActiveStreamKeepsTempKeyVisible(t *testing.T) {
 	mr := setupMiniRedis(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})

--- a/pkg/store/redisstore/redis_test.go
+++ b/pkg/store/redisstore/redis_test.go
@@ -216,6 +216,15 @@ func TestRedisStore_ContextCancellation(t *testing.T) {
 		cancel()
 		_, err := store.BeginSet(ctx, key, metadata)
 		assert.ErrorIs(t, err, context.Canceled)
+		assert.Contains(t, err.Error(), "redisstore: begin set")
+	})
+
+	t.Run("BeginStagedSet", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := store.(daramjwee.StagingStore).BeginStagedSet(ctx, key, metadata)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Contains(t, err.Error(), "redisstore: begin staged set")
 	})
 
 	t.Run("GetStream", func(t *testing.T) {
@@ -367,7 +376,9 @@ func TestRedisStore_CanceledStagedCommitDeletesTempKey(t *testing.T) {
 
 	commitCtx, cancel := context.WithCancel(ctx)
 	cancel()
-	require.ErrorIs(t, sink.Commit(commitCtx), context.Canceled)
+	err = sink.Commit(commitCtx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "redisstore: commit")
 	require.False(t, mr.Exists(writer.tempKey))
 	require.False(t, mr.Exists(store.DataKey("staged-cancel")))
 	require.False(t, mr.Exists(store.MetaKey("staged-cancel")))

--- a/pkg/store/redisstore/redis_test.go
+++ b/pkg/store/redisstore/redis_test.go
@@ -308,15 +308,14 @@ func TestRedisStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
 	t.Cleanup(func() { _ = client.Close() })
 
 	store := New(client, log.NewNopLogger()).(*RedisStore)
-	ctx := context.Background()
 
 	sink, err := store.BeginStagedSet(nil, "staged-nil-context", &daramjwee.Metadata{CacheTag: "v1"})
 	require.NoError(t, err)
 	_, err = sink.Write([]byte("nil context staged"))
 	require.NoError(t, err)
-	require.NoError(t, sink.Commit(ctx))
+	require.NoError(t, sink.Commit(nil))
 
-	reader, meta, err := store.GetStream(ctx, "staged-nil-context")
+	reader, meta, err := store.GetStream(nil, "staged-nil-context")
 	require.NoError(t, err)
 	defer reader.Close()
 
@@ -324,6 +323,10 @@ func TestRedisStore_BeginStagedSetAcceptsNilContext(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "nil context staged", string(body))
 	require.Equal(t, "v1", meta.CacheTag)
+	stat, err := store.Stat(nil, "staged-nil-context")
+	require.NoError(t, err)
+	require.Equal(t, "v1", stat.CacheTag)
+	require.NoError(t, store.Delete(nil, "staged-nil-context"))
 }
 
 func TestRedisStore_StagedAbortDeletesTempKey(t *testing.T) {

--- a/scripts/run_top_write_liveness_fuzz.sh
+++ b/scripts/run_top_write_liveness_fuzz.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FUZZTIME="${DJ_LIVENESS_FUZZTIME:-10s}"
+TIMEOUT="${DJ_LIVENESS_TIMEOUT:-1m}"
+RUN_RACE="${DJ_LIVENESS_RACE:-0}"
+
+SEED_PATTERN='^(TestCache_.*(BuiltInStagingStores|ContextAwareStagingStores)|FuzzCacheTopWriteLiveness)$'
+FUZZ_PATTERN='^FuzzCacheTopWriteLiveness$'
+
+echo "== cache top-write liveness seed tests =="
+(
+  cd "${ROOT_DIR}"
+  go test ./tests -run "${SEED_PATTERN}" -count=1 -timeout="${TIMEOUT}"
+)
+
+if [[ "${RUN_RACE}" == "1" ]]; then
+  echo
+  echo "== cache top-write liveness seed tests (-race) =="
+  (
+    cd "${ROOT_DIR}"
+    go test -race ./tests -run "${SEED_PATTERN}" -count=1 -timeout="${TIMEOUT}"
+  )
+fi
+
+echo
+echo "== cache top-write liveness fuzz (fuzztime=${FUZZTIME}) =="
+(
+  cd "${ROOT_DIR}"
+  go test ./tests -run '^$' -fuzz "${FUZZ_PATTERN}" -fuzztime="${FUZZTIME}" -timeout="${TIMEOUT}"
+)

--- a/tests/pure_streaming_integration_test.go
+++ b/tests/pure_streaming_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mrchypark/daramjwee"
+	"github.com/mrchypark/daramjwee/pkg/store/memstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -160,6 +161,48 @@ func TestCache_PartialMissReadCloseDoesNotPublishToHot(t *testing.T) {
 
 	_, _, err = hot.GetStream(context.Background(), "partial-miss-key")
 	assert.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
+func TestCache_PartialMissStreamDoesNotBlockSameKeySet(t *testing.T) {
+	hot := memstore.New(0, nil)
+	source := newBlockingReadCloser([]byte("origin"), []byte("-value"))
+	fetcher := &blockingSourceFetcher{source: source, metadata: &daramjwee.Metadata{CacheTag: "origin-v1"}}
+
+	cache, err := daramjwee.New(nil, daramjwee.WithTiers(hot), daramjwee.WithOpTimeout(2*time.Second))
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "same-key", daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	buf := make([]byte, len("origin"))
+	n, err := resp.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, len("origin"), n)
+	require.Equal(t, "origin", string(buf[:n]))
+
+	setCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	sink, err := cache.Set(setCtx, "same-key", &daramjwee.Metadata{CacheTag: "user-v2"})
+	require.NoError(t, err)
+	_, err = sink.Write([]byte("user-value"))
+	require.NoError(t, err)
+	require.NoError(t, sink.Close())
+
+	source.Release()
+	rest, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	require.Equal(t, "-value", string(rest))
+	require.ErrorIs(t, resp.Close(), daramjwee.ErrTopWriteInvalidated)
+
+	reader, meta, err := hot.GetStream(context.Background(), "same-key")
+	require.NoError(t, err)
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, "user-value", string(body))
+	require.Equal(t, "user-v2", meta.CacheTag)
 }
 
 func TestCache_PartialColdHitReadCloseDoesNotPublishToHot(t *testing.T) {

--- a/tests/race_test.go
+++ b/tests/race_test.go
@@ -74,7 +74,7 @@ func TestConcurrentAccess(t *testing.T) {
 					// Set
 					value := fmt.Sprintf("set-value-%d-%d", id, j)
 					err := stringCache.Set(ctx, key, value, &daramjwee.Metadata{CacheTag: "test"})
-					if err != nil {
+					if err != nil && !isExpectedTopWriteConflict(err) {
 						errors <- fmt.Errorf("goroutine %d: Set failed: %v", id, err)
 					}
 				}
@@ -249,6 +249,8 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 				if err != nil {
 					if isExpectedTopWriteConflict(err) {
 						conflictCount.Add(1)
+						i++
+						continue
 					}
 					firstErr.CompareAndSwap(nil, fmt.Errorf("set failed: %w", err))
 					return

--- a/tests/top_write_liveness_test.go
+++ b/tests/top_write_liveness_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -284,10 +285,11 @@ func topWriteLivenessStores(t *testing.T) []topWriteLivenessStore {
 	fileStore, err := filestore.New(t.TempDir(), log.NewNopLogger())
 	require.NoError(t, err)
 
+	objectDir := objectStoreTempDir(t)
 	objectStore := objectstore.New(
 		objstore.NewInMemBucket(),
 		log.NewNopLogger(),
-		objectstore.WithDir(t.TempDir()),
+		objectstore.WithDir(objectDir),
 	)
 
 	mr, err := miniredis.Run()
@@ -307,10 +309,11 @@ func topWriteLivenessStores(t *testing.T) []topWriteLivenessStore {
 func contextAwareTopWriteLivenessStores(t *testing.T) []topWriteLivenessStore {
 	t.Helper()
 
+	objectDir := objectStoreTempDir(t)
 	objectStore := objectstore.New(
 		objstore.NewInMemBucket(),
 		log.NewNopLogger(),
-		objectstore.WithDir(t.TempDir()),
+		objectstore.WithDir(objectDir),
 	)
 
 	mr, err := miniredis.Run()
@@ -323,6 +326,18 @@ func contextAwareTopWriteLivenessStores(t *testing.T) []topWriteLivenessStore {
 		{name: "objectstore", store: objectStore},
 		{name: "redisstore", store: redisstore.New(client, log.NewNopLogger())},
 	}
+}
+
+func objectStoreTempDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "daramjwee-liveness-objectstore-*")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		time.Sleep(2 * topWriteLivenessTimeout)
+		_ = os.RemoveAll(dir)
+	})
+	return dir
 }
 
 func setAndCloseWithin(t *testing.T, cache daramjwee.Cache, key, value, tag string, timeout time.Duration) {

--- a/tests/top_write_liveness_test.go
+++ b/tests/top_write_liveness_test.go
@@ -1,0 +1,452 @@
+package daramjwee_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee"
+	"github.com/mrchypark/daramjwee/pkg/store/filestore"
+	"github.com/mrchypark/daramjwee/pkg/store/memstore"
+	"github.com/mrchypark/daramjwee/pkg/store/objectstore"
+	"github.com/mrchypark/daramjwee/pkg/store/redisstore"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+)
+
+const topWriteLivenessTimeout = 500 * time.Millisecond
+
+func TestCache_AbandonedTopWriteSinkDoesNotBlockSameKeySetForBuiltInStagingStores(t *testing.T) {
+	for _, tc := range topWriteLivenessStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			cache, err := daramjwee.New(nil, daramjwee.WithTiers(tc.store), daramjwee.WithOpTimeout(2*time.Second))
+			require.NoError(t, err)
+			defer cache.Close()
+
+			first, err := cache.Set(context.Background(), "same-key", &daramjwee.Metadata{CacheTag: "abandoned"})
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = first.Abort() })
+			_, err = first.Write([]byte("abandoned-value"))
+			require.NoError(t, err)
+
+			setAndCloseWithin(t, cache, "same-key", "user-value", "user-v2", topWriteLivenessTimeout)
+			requireStoreValue(t, tc.store, "same-key", "user-value", "user-v2")
+		})
+	}
+}
+
+func TestCache_PartialMissStreamDoesNotBlockSameKeySetForBuiltInStagingStores(t *testing.T) {
+	for _, tc := range topWriteLivenessStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			cache, err := daramjwee.New(nil, daramjwee.WithTiers(tc.store), daramjwee.WithOpTimeout(2*time.Second))
+			require.NoError(t, err)
+			defer cache.Close()
+
+			source := newBlockingReadCloser([]byte("origin"), []byte("-value"))
+			fetcher := &blockingSourceFetcher{source: source, metadata: &daramjwee.Metadata{CacheTag: "origin-v1"}}
+
+			resp, err := cache.Get(context.Background(), "same-key", daramjwee.GetRequest{}, fetcher)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			buf := make([]byte, len("origin"))
+			n, err := resp.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, len("origin"), n)
+			require.Equal(t, "origin", string(buf[:n]))
+
+			setAndCloseWithin(t, cache, "same-key", "user-value", "user-v2", topWriteLivenessTimeout)
+
+			source.Release()
+			rest, err := io.ReadAll(resp)
+			require.NoError(t, err)
+			require.Equal(t, "-value", string(rest))
+			require.ErrorIs(t, resp.Close(), daramjwee.ErrTopWriteInvalidated)
+
+			requireStoreValue(t, tc.store, "same-key", "user-value", "user-v2")
+		})
+	}
+}
+
+func TestCache_NewerAbortedSetDoesNotInvalidateOlderSetForBuiltInStagingStores(t *testing.T) {
+	for _, tc := range topWriteLivenessStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			cache, err := daramjwee.New(nil, daramjwee.WithTiers(tc.store), daramjwee.WithOpTimeout(2*time.Second))
+			require.NoError(t, err)
+			defer cache.Close()
+
+			older := beginSetWithin(t, cache, "same-key", "older-v1", topWriteLivenessTimeout)
+			t.Cleanup(func() { _ = older.Abort() })
+			_, err = older.Write([]byte("older-value"))
+			require.NoError(t, err)
+
+			newer := beginSetWithin(t, cache, "same-key", "newer-v2", topWriteLivenessTimeout)
+			_, err = newer.Write([]byte("newer-value"))
+			require.NoError(t, err)
+			require.NoError(t, newer.Abort())
+
+			require.NoError(t, closeSinkWithin(t, older, topWriteLivenessTimeout))
+			requireStoreValue(t, tc.store, "same-key", "older-value", "older-v1")
+		})
+	}
+}
+
+func TestCache_StaleSetCloseReportsInvalidatedForBuiltInStagingStores(t *testing.T) {
+	for _, tc := range topWriteLivenessStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			cache, err := daramjwee.New(nil, daramjwee.WithTiers(tc.store), daramjwee.WithOpTimeout(2*time.Second))
+			require.NoError(t, err)
+			defer cache.Close()
+
+			older := beginSetWithin(t, cache, "same-key", "older-v1", topWriteLivenessTimeout)
+			t.Cleanup(func() { _ = older.Abort() })
+			_, err = older.Write([]byte("older-value"))
+			require.NoError(t, err)
+
+			setAndCloseWithin(t, cache, "same-key", "newer-value", "newer-v2", topWriteLivenessTimeout)
+
+			require.ErrorIs(t, closeSinkWithin(t, older, topWriteLivenessTimeout), daramjwee.ErrTopWriteInvalidated)
+			requireStoreValue(t, tc.store, "same-key", "newer-value", "newer-v2")
+		})
+	}
+}
+
+func TestCache_AbortedSetDoesNotPoisonLaterMissFillForBuiltInStagingStores(t *testing.T) {
+	for _, tc := range topWriteLivenessStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			cache, err := daramjwee.New(nil, daramjwee.WithTiers(tc.store), daramjwee.WithOpTimeout(2*time.Second))
+			require.NoError(t, err)
+			defer cache.Close()
+
+			aborted := beginSetWithin(t, cache, "same-key", "aborted-v1", topWriteLivenessTimeout)
+			_, err = aborted.Write([]byte("aborted-value"))
+			require.NoError(t, err)
+			require.NoError(t, aborted.Abort())
+
+			source := newBlockingReadCloser([]byte("origin"), []byte("-value"))
+			source.Release()
+			fetcher := &blockingSourceFetcher{source: source, metadata: &daramjwee.Metadata{CacheTag: "origin-v2"}}
+			resp, err := cache.Get(context.Background(), "same-key", daramjwee.GetRequest{}, fetcher)
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp)
+			require.NoError(t, err)
+			require.Equal(t, "origin-value", string(body))
+			require.NoError(t, resp.Close())
+
+			requireStoreValue(t, tc.store, "same-key", "origin-value", "origin-v2")
+		})
+	}
+}
+
+func TestCache_CanceledSetContextDoesNotPublishContextAwareStagingStores(t *testing.T) {
+	for _, tc := range contextAwareTopWriteLivenessStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			cache, err := daramjwee.New(nil, daramjwee.WithTiers(tc.store), daramjwee.WithOpTimeout(2*time.Second))
+			require.NoError(t, err)
+			defer cache.Close()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			sink, err := cache.Set(ctx, "same-key", &daramjwee.Metadata{CacheTag: "canceled-v1"})
+			require.NoError(t, err)
+			_, err = sink.Write([]byte("canceled-value"))
+			require.NoError(t, err)
+			cancel()
+
+			require.ErrorIs(t, closeSinkWithin(t, sink, topWriteLivenessTimeout), context.Canceled)
+			_, _, err = tc.store.GetStream(context.Background(), "same-key")
+			require.ErrorIs(t, err, daramjwee.ErrNotFound)
+		})
+	}
+}
+
+func FuzzCacheTopWriteLiveness(f *testing.F) {
+	f.Add([]byte{0, 3, 1, 4, 3, 5, 2, 6})
+	f.Add([]byte{4, 3, 4, 3, 5, 6, 0, 3, 1})
+	f.Add([]byte{0, 0, 3, 6, 1, 2, 4, 5})
+
+	f.Fuzz(func(t *testing.T, ops []byte) {
+		if len(ops) > 18 {
+			ops = ops[:18]
+		}
+
+		hot := memstore.New(0, nil)
+		cache, err := daramjwee.New(nil, daramjwee.WithTiers(hot), daramjwee.WithOpTimeout(2*time.Second))
+		require.NoError(t, err)
+		defer cache.Close()
+
+		keys := []string{"liveness-key-0", "liveness-key-1", "liveness-key-2"}
+		var openSinks []daramjwee.WriteSink
+		var openStreams []openFuzzStream
+		defer func() {
+			for _, sink := range openSinks {
+				_ = sink.Abort()
+			}
+			for _, stream := range openStreams {
+				stream.source.Release()
+				_ = stream.resp.Close()
+			}
+		}()
+
+		for i, op := range ops {
+			key := keys[int(op>>3)%len(keys)]
+			value := fmt.Sprintf("value-%d-%d", i, op)
+
+			switch op % 7 {
+			case 0:
+				sink := beginSetWithin(t, cache, key, value, topWriteLivenessTimeout)
+				_, err := sink.Write([]byte(value))
+				require.NoError(t, err)
+				openSinks = append(openSinks, sink)
+				if len(openSinks) > 4 {
+					_ = openSinks[0].Abort()
+					openSinks = openSinks[1:]
+				}
+			case 1:
+				if len(openSinks) == 0 {
+					continue
+				}
+				last := openSinks[len(openSinks)-1]
+				openSinks = openSinks[:len(openSinks)-1]
+				err := closeSinkWithin(t, last, topWriteLivenessTimeout)
+				if err != nil && !errors.Is(err, daramjwee.ErrTopWriteInvalidated) {
+					t.Fatalf("close open sink: %v", err)
+				}
+			case 2:
+				if len(openSinks) == 0 {
+					continue
+				}
+				last := openSinks[len(openSinks)-1]
+				openSinks = openSinks[:len(openSinks)-1]
+				require.NoError(t, last.Abort())
+			case 3:
+				setAndCloseWithin(t, cache, key, value, value, topWriteLivenessTimeout)
+			case 4:
+				stream := beginPartialMissWithin(t, cache, key, value, topWriteLivenessTimeout)
+				openStreams = append(openStreams, stream)
+				if len(openStreams) > 4 {
+					closeFuzzStreamWithin(t, openStreams[0], topWriteLivenessTimeout)
+					openStreams = openStreams[1:]
+				}
+			case 5:
+				if len(openStreams) == 0 {
+					continue
+				}
+				last := openStreams[len(openStreams)-1]
+				openStreams = openStreams[:len(openStreams)-1]
+				closeFuzzStreamWithin(t, last, topWriteLivenessTimeout)
+			case 6:
+				deleteWithin(t, cache, key, topWriteLivenessTimeout)
+			}
+		}
+	})
+}
+
+type topWriteLivenessStore struct {
+	name  string
+	store daramjwee.Store
+}
+
+func topWriteLivenessStores(t *testing.T) []topWriteLivenessStore {
+	t.Helper()
+
+	fileStore, err := filestore.New(t.TempDir(), log.NewNopLogger())
+	require.NoError(t, err)
+
+	objectStore := objectstore.New(
+		objstore.NewInMemBucket(),
+		log.NewNopLogger(),
+		objectstore.WithDir(t.TempDir()),
+	)
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	return []topWriteLivenessStore{
+		{name: "memstore", store: memstore.New(0, nil)},
+		{name: "filestore", store: fileStore},
+		{name: "objectstore", store: objectStore},
+		{name: "redisstore", store: redisstore.New(client, log.NewNopLogger())},
+	}
+}
+
+func contextAwareTopWriteLivenessStores(t *testing.T) []topWriteLivenessStore {
+	t.Helper()
+
+	objectStore := objectstore.New(
+		objstore.NewInMemBucket(),
+		log.NewNopLogger(),
+		objectstore.WithDir(t.TempDir()),
+	)
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	return []topWriteLivenessStore{
+		{name: "objectstore", store: objectStore},
+		{name: "redisstore", store: redisstore.New(client, log.NewNopLogger())},
+	}
+}
+
+func setAndCloseWithin(t *testing.T, cache daramjwee.Cache, key, value, tag string, timeout time.Duration) {
+	t.Helper()
+	sink := beginSetWithin(t, cache, key, tag, timeout)
+	_, err := sink.Write([]byte(value))
+	require.NoError(t, err)
+	require.NoError(t, closeSinkWithin(t, sink, timeout))
+}
+
+func beginSetWithin(t *testing.T, cache daramjwee.Cache, key, tag string, timeout time.Duration) daramjwee.WriteSink {
+	t.Helper()
+
+	type result struct {
+		sink daramjwee.WriteSink
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		sink, err := cache.Set(context.Background(), key, &daramjwee.Metadata{CacheTag: tag})
+		done <- result{sink: sink, err: err}
+	}()
+
+	select {
+	case result := <-done:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.sink)
+		return result.sink
+	case <-time.After(timeout * 2):
+		t.Fatalf("cache.Set(%q) blocked past %s", key, timeout)
+		return nil
+	}
+}
+
+func closeSinkWithin(t *testing.T, sink daramjwee.WriteSink, timeout time.Duration) error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sink.Close()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout * 2):
+		t.Fatalf("sink.Close blocked past %s", timeout)
+		return nil
+	}
+}
+
+func deleteWithin(t *testing.T, cache daramjwee.Cache, key string, timeout time.Duration) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cache.Delete(ctx, key)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(timeout * 2):
+		t.Fatalf("cache.Delete(%q) blocked past %s", key, timeout)
+	}
+}
+
+type openFuzzStream struct {
+	resp   *daramjwee.GetResponse
+	source *blockingReadCloser
+}
+
+func beginPartialMissWithin(t *testing.T, cache daramjwee.Cache, key, tag string, timeout time.Duration) openFuzzStream {
+	t.Helper()
+
+	source := newBlockingReadCloser([]byte("origin"), []byte("-"+tag))
+	fetcher := &blockingSourceFetcher{source: source, metadata: &daramjwee.Metadata{CacheTag: tag}}
+
+	type result struct {
+		resp *daramjwee.GetResponse
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, fetcher)
+		done <- result{resp: resp, err: err}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+		require.NoError(t, got.err)
+		require.NotNil(t, got.resp)
+	case <-time.After(timeout * 2):
+		t.Fatalf("cache.Get(%q) blocked before returning miss stream", key)
+	}
+
+	buf := make([]byte, len("origin"))
+	readDone := make(chan error, 1)
+	go func() {
+		n, err := io.ReadFull(got.resp, buf)
+		if err == nil && n != len(buf) {
+			err = io.ErrUnexpectedEOF
+		}
+		readDone <- err
+	}()
+
+	select {
+	case err := <-readDone:
+		require.NoError(t, err)
+	case <-time.After(timeout * 2):
+		t.Fatalf("first read for %q blocked past %s", key, timeout)
+	}
+
+	return openFuzzStream{resp: got.resp, source: source}
+}
+
+func closeFuzzStreamWithin(t *testing.T, stream openFuzzStream, timeout time.Duration) {
+	t.Helper()
+
+	stream.source.Release()
+	done := make(chan error, 1)
+	go func() {
+		_, readErr := io.ReadAll(stream.resp)
+		closeErr := stream.resp.Close()
+		done <- errors.Join(readErr, closeErr)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, daramjwee.ErrTopWriteInvalidated) {
+			t.Fatalf("close fuzz stream: %v", err)
+		}
+	case <-time.After(timeout * 2):
+		t.Fatalf("stream close blocked past %s", timeout)
+	}
+}
+
+func requireStoreValue(t *testing.T, store daramjwee.Store, key, wantValue, wantTag string) {
+	t.Helper()
+
+	reader, meta, err := store.GetStream(context.Background(), key)
+	require.NoError(t, err)
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, wantValue, string(body))
+	require.NotNil(t, meta)
+	require.Equal(t, wantTag, meta.CacheTag)
+}

--- a/tests/top_write_liveness_test.go
+++ b/tests/top_write_liveness_test.go
@@ -97,6 +97,32 @@ func TestCache_NewerAbortedSetDoesNotInvalidateOlderSetForBuiltInStagingStores(t
 	}
 }
 
+func TestCache_OlderSetCanPublishWhileNewerSetIsStillStagedForBuiltInStagingStores(t *testing.T) {
+	for _, tc := range topWriteLivenessStores(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			cache, err := daramjwee.New(nil, daramjwee.WithTiers(tc.store), daramjwee.WithOpTimeout(2*time.Second))
+			require.NoError(t, err)
+			defer cache.Close()
+
+			older := beginSetWithin(t, cache, "same-key", "older-v1", topWriteLivenessTimeout)
+			t.Cleanup(func() { _ = older.Abort() })
+			_, err = older.Write([]byte("older-value"))
+			require.NoError(t, err)
+
+			newer := beginSetWithin(t, cache, "same-key", "newer-v2", topWriteLivenessTimeout)
+			t.Cleanup(func() { _ = newer.Abort() })
+			_, err = newer.Write([]byte("newer-value"))
+			require.NoError(t, err)
+
+			require.NoError(t, closeSinkWithin(t, older, topWriteLivenessTimeout))
+			requireStoreValue(t, tc.store, "same-key", "older-value", "older-v1")
+
+			require.NoError(t, newer.Abort())
+			requireStoreValue(t, tc.store, "same-key", "older-value", "older-v1")
+		})
+	}
+}
+
 func TestCache_StaleSetCloseReportsInvalidatedForBuiltInStagingStores(t *testing.T) {
 	for _, tc := range topWriteLivenessStores(t) {
 		t.Run(tc.name, func(t *testing.T) {

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -655,10 +655,7 @@ func (s *coordinatedTopWriteSink) Close() error {
 
 		postCloseWaitCtx, cancelPostCloseWait := newCoordinatorWaitContext(s.waitTimeout)
 		defer cancelPostCloseWait()
-		if err := s.coord.waitForNoActiveDeletes(postCloseWaitCtx); err != nil {
-			s.err = err
-			return
-		}
+		_ = s.coord.waitForNoActiveDeletes(postCloseWaitCtx)
 
 		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {
@@ -744,10 +741,7 @@ func (s *conditionalGenerationWriteSink) Close() error {
 
 		postCloseWaitCtx, cancelPostCloseWait := newCoordinatorWaitContext(s.waitTimeout)
 		defer cancelPostCloseWait()
-		if err := s.coord.waitForNoActiveDeletes(postCloseWaitCtx); err != nil {
-			s.err = err
-			return
-		}
+		_ = s.coord.waitForNoActiveDeletes(postCloseWaitCtx)
 
 		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -543,18 +543,6 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 			}
 		}()
 
-		if err := s.coord.waitForNoActiveDeletes(waitCtx); err != nil {
-			s.coord.unregisterReservation(s.generation)
-			s.coord.releaseCommit()
-			commitLocked = false
-			abortErr := s.sink.Abort()
-			s.err = err
-			if abortErr != nil {
-				s.err = errors.Join(s.err, abortErr)
-			}
-			return
-		}
-
 		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {
 			s.coord.removeReservationLocked(s.generation)
@@ -590,15 +578,6 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 		}
 		s.coord.pruneReservationsThroughLocked(s.coord.committedGeneration)
 		s.coord.stateMu.Unlock()
-
-		// The store commit may already be visible. Keep the commit lease while a
-		// racing delete finishes so invalidation cleanup cannot delete a later writer.
-		postCommitWaitCtx, cancelPostCommitWait := newCoordinatorWaitContext(s.waitTimeout)
-		defer cancelPostCommitWait()
-		if err := s.coord.waitForNoActiveDeletes(postCommitWaitCtx); err != nil {
-			s.err = err
-			return
-		}
 
 		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -21,7 +21,7 @@ type writeCoordinator struct {
 	initOnce     sync.Once
 	leaseOnce    sync.Once
 	writeLease   chan struct{}
-	commitMu     sync.Mutex
+	commitLease  chan struct{}
 	stateMu      sync.Mutex
 	stateChanged *sync.Cond
 	// committedGeneration is the latest generation visible in the top store.
@@ -192,13 +192,23 @@ func (c *writeCoordinator) reserveGenerationLocked() uint64 {
 
 func (c *writeCoordinator) advanceCommittedLocked() {
 	generation := c.reserveGenerationLocked()
-	c.removeReservationLocked(generation)
 	c.committedGeneration = generation
+	c.pruneReservationsThroughLocked(generation)
 }
 
 func (c *writeCoordinator) removeReservationLocked(generation uint64) {
 	c.ensureReservationsLocked()
 	delete(c.activeReservations, generation)
+	c.stateChanged.Broadcast()
+}
+
+func (c *writeCoordinator) pruneReservationsThroughLocked(generation uint64) {
+	c.ensureReservationsLocked()
+	for reserved := range c.activeReservations {
+		if reserved <= generation {
+			delete(c.activeReservations, reserved)
+		}
+	}
 	c.stateChanged.Broadcast()
 }
 
@@ -278,14 +288,16 @@ func (c *writeCoordinator) lockCommitWhenNoActiveDeletes(ctx context.Context) er
 		if err := c.waitForNoActiveDeletes(ctx); err != nil {
 			return err
 		}
-		c.commitMu.Lock()
+		if err := c.acquireCommit(ctx); err != nil {
+			return err
+		}
 		c.stateMu.Lock()
 		if c.activeDeletes == 0 {
 			c.stateMu.Unlock()
 			return nil
 		}
 		c.stateMu.Unlock()
-		c.commitMu.Unlock()
+		c.releaseCommit()
 	}
 }
 
@@ -321,6 +333,8 @@ func (c *writeCoordinator) initLease() {
 	c.leaseOnce.Do(func() {
 		c.writeLease = make(chan struct{}, 1)
 		c.writeLease <- struct{}{}
+		c.commitLease = make(chan struct{}, 1)
+		c.commitLease <- struct{}{}
 	})
 }
 
@@ -339,6 +353,27 @@ func (c *writeCoordinator) acquireWrite(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+func (c *writeCoordinator) acquireCommit(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.initLease()
+	select {
+	case <-c.commitLease:
+		if err := ctx.Err(); err != nil {
+			c.releaseCommit()
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *writeCoordinator) releaseCommit() {
+	c.commitLease <- struct{}{}
 }
 
 func (c *writeCoordinator) releaseWrite() {
@@ -404,11 +439,15 @@ func (c *writeCoordinator) rollbackAndUnlock(generation uint64) {
 	c.releaseWrite()
 }
 
-func (c *writeCoordinator) beginDelete() {
+func (c *writeCoordinator) beginDelete(ctx context.Context) error {
+	if err := c.acquireCommit(ctx); err != nil {
+		return err
+	}
 	c.init()
 	c.stateMu.Lock()
 	c.activeDeletes++
 	c.stateMu.Unlock()
+	return nil
 }
 
 func (c *writeCoordinator) finishDelete(success bool) {
@@ -422,6 +461,7 @@ func (c *writeCoordinator) finishDelete(success bool) {
 	}
 	c.stateChanged.Broadcast()
 	c.stateMu.Unlock()
+	c.releaseCommit()
 }
 
 func (c *DaramjweeCache) currentTopWriteGeneration(key string) uint64 {
@@ -493,23 +533,31 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 			}
 			return
 		}
-		commitMuLocked := true
+		commitLocked := true
 		defer func() {
-			if commitMuLocked {
-				s.coord.commitMu.Unlock()
+			if commitLocked {
+				s.coord.releaseCommit()
 			}
 		}()
 
-		s.coord.stateMu.Lock()
-		for s.coord.activeDeletes > 0 {
-			s.coord.stateChanged.Wait()
+		if err := s.coord.waitForNoActiveDeletes(waitCtx); err != nil {
+			s.coord.unregisterReservation(s.generation)
+			s.coord.releaseCommit()
+			commitLocked = false
+			abortErr := s.sink.Abort()
+			s.err = err
+			if abortErr != nil {
+				s.err = errors.Join(s.err, abortErr)
+			}
+			return
 		}
 
+		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {
 			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
-			s.coord.commitMu.Unlock()
-			commitMuLocked = false
+			s.coord.releaseCommit()
+			commitLocked = false
 			abortErr := s.sink.Abort()
 			s.err = ErrTopWriteInvalidated
 			if abortErr != nil {
@@ -525,19 +573,23 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.err = closeErr
+			s.coord.releaseCommit()
+			commitLocked = false
+			if abortErr := s.sink.Abort(); abortErr != nil {
+				s.err = errors.Join(s.err, abortErr)
+			}
 			return
 		}
 
 		s.coord.stateMu.Lock()
-		s.coord.removeReservationLocked(s.generation)
 		if s.coord.committedGeneration < s.generation {
 			s.coord.committedGeneration = s.generation
-			s.coord.stateChanged.Broadcast()
 		}
+		s.coord.pruneReservationsThroughLocked(s.coord.committedGeneration)
 		s.coord.stateMu.Unlock()
 
-		// The store commit may already be visible. Keep commitMu while a racing
-		// delete finishes so invalidation cleanup cannot delete a later writer.
+		// The store commit may already be visible. Keep the commit lease while a
+		// racing delete finishes so invalidation cleanup cannot delete a later writer.
 		postCommitWaitCtx, cancelPostCommitWait := newCoordinatorWaitContext(s.waitTimeout)
 		defer cancelPostCommitWait()
 		if err := s.coord.waitForNoActiveDeletes(postCommitWaitCtx); err != nil {
@@ -617,10 +669,10 @@ func (s *coordinatedTopWriteSink) Close() error {
 			}
 			return
 		}
-		s.coord.removeReservationLocked(s.generation)
 		if s.coord.committedGeneration < s.generation {
 			s.coord.committedGeneration = s.generation
 		}
+		s.coord.pruneReservationsThroughLocked(s.coord.committedGeneration)
 		s.coord.stateMu.Unlock()
 	})
 	return s.err

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -295,9 +295,7 @@ func newCoordinatorWaitContext(timeout time.Duration) (context.Context, context.
 func (c *writeCoordinator) unregisterReservation(generation uint64) {
 	c.init()
 	c.stateMu.Lock()
-	if _, ok := c.activeReservations[generation]; ok {
-		c.removeReservationLocked(generation)
-	}
+	c.removeReservationLocked(generation)
 	c.stateMu.Unlock()
 }
 

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 )
 
 var ErrTopWriteInvalidated = errors.New("daramjwee: top-tier write invalidated")
@@ -46,6 +47,7 @@ type coordinatedStagedTopWriteSink struct {
 	coord         *writeCoordinator
 	generation    uint64
 	conditional   bool
+	waitTimeout   time.Duration
 	onInvalidated func() error
 	once          sync.Once
 	err           error
@@ -236,6 +238,58 @@ func (c *writeCoordinator) reserve(ctx context.Context, expected *uint64) (uint6
 	return generation, nil
 }
 
+func (c *writeCoordinator) waitForNoActiveDeletes(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.init()
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	if c.activeDeletes > 0 {
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				c.stateMu.Lock()
+				c.stateChanged.Broadcast()
+				c.stateMu.Unlock()
+			case <-done:
+			}
+		}()
+		defer close(done)
+	}
+	for c.activeDeletes > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		c.stateChanged.Wait()
+	}
+	return ctx.Err()
+}
+
+func (c *writeCoordinator) lockCommitWhenNoActiveDeletes(ctx context.Context) error {
+	for {
+		if err := c.waitForNoActiveDeletes(ctx); err != nil {
+			return err
+		}
+		c.commitMu.Lock()
+		c.stateMu.Lock()
+		if c.activeDeletes == 0 {
+			c.stateMu.Unlock()
+			return nil
+		}
+		c.stateMu.Unlock()
+		c.commitMu.Unlock()
+	}
+}
+
+func newCoordinatorWaitContext(timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return context.Background(), func() {}
+	}
+	return context.WithTimeout(context.Background(), timeout)
+}
+
 func (c *writeCoordinator) unregisterReservation(generation uint64) {
 	c.init()
 	c.stateMu.Lock()
@@ -381,24 +435,21 @@ func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, 
 	store := c.topWriteStore()
 	coord := c.topWrites.coordinator(key)
 	if staging, ok := store.(StagingStore); ok {
-		coord.commitMu.Lock()
 		generation, err := coord.reserve(ctx, expectedGeneration)
 		if err != nil {
-			coord.commitMu.Unlock()
 			return nil, err
 		}
 		sink, err := staging.BeginStagedSet(ctx, key, metadata)
 		if err != nil {
 			coord.unregisterReservation(generation)
-			coord.commitMu.Unlock()
 			return nil, err
 		}
-		coord.commitMu.Unlock()
 		return &coordinatedStagedTopWriteSink{
 			sink:          sink,
 			coord:         coord,
 			generation:    generation,
 			conditional:   expectedGeneration != nil,
+			waitTimeout:   c.closeTimeout,
 			onInvalidated: func() error { return c.deleteTopStoreKey(key) },
 		}, nil
 	}
@@ -423,8 +474,19 @@ func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, 
 
 func (s *coordinatedStagedTopWriteSink) Close() error {
 	s.once.Do(func() {
-		ctx := context.Background()
-		s.coord.commitMu.Lock()
+		commitCtx := context.Background()
+		waitCtx, cancelWait := newCoordinatorWaitContext(s.waitTimeout)
+		defer cancelWait()
+
+		if err := s.coord.lockCommitWhenNoActiveDeletes(waitCtx); err != nil {
+			s.coord.unregisterReservation(s.generation)
+			abortErr := s.sink.Abort()
+			s.err = err
+			if abortErr != nil {
+				s.err = errors.Join(s.err, abortErr)
+			}
+			return
+		}
 		commitMuLocked := true
 		defer func() {
 			if commitMuLocked {
@@ -453,8 +515,10 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 		}
 		s.coord.stateMu.Unlock()
 
-		closeErr := s.sink.Commit(ctx)
+		closeErr := s.sink.Commit(commitCtx)
 
+		// The store commit may already be visible. Keep commitMu while a racing
+		// delete finishes so invalidation cleanup cannot delete a later writer.
 		s.coord.stateMu.Lock()
 		for s.coord.activeDeletes > 0 {
 			s.coord.stateChanged.Wait()

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -192,8 +192,14 @@ func (c *writeCoordinator) reserveGenerationLocked() uint64 {
 
 func (c *writeCoordinator) advanceCommittedLocked() {
 	generation := c.reserveGenerationLocked()
-	delete(c.activeReservations, generation)
+	c.removeReservationLocked(generation)
 	c.committedGeneration = generation
+}
+
+func (c *writeCoordinator) removeReservationLocked(generation uint64) {
+	c.ensureReservationsLocked()
+	delete(c.activeReservations, generation)
+	c.stateChanged.Broadcast()
 }
 
 func (c *writeCoordinator) reserve(ctx context.Context, expected *uint64) (uint64, error) {
@@ -294,8 +300,7 @@ func (c *writeCoordinator) unregisterReservation(generation uint64) {
 	c.init()
 	c.stateMu.Lock()
 	if _, ok := c.activeReservations[generation]; ok {
-		delete(c.activeReservations, generation)
-		c.stateChanged.Broadcast()
+		c.removeReservationLocked(generation)
 	}
 	c.stateMu.Unlock()
 }
@@ -474,7 +479,8 @@ func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, 
 
 func (s *coordinatedStagedTopWriteSink) Close() error {
 	s.once.Do(func() {
-		commitCtx := context.Background()
+		commitCtx, cancelCommit := newCoordinatorWaitContext(s.waitTimeout)
+		defer cancelCommit()
 		waitCtx, cancelWait := newCoordinatorWaitContext(s.waitTimeout)
 		defer cancelWait()
 
@@ -500,9 +506,7 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 		}
 
 		if s.coord.committedGeneration > s.generation {
-			s.coord.ensureReservationsLocked()
-			delete(s.coord.activeReservations, s.generation)
-			s.coord.stateChanged.Broadcast()
+			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.coord.commitMu.Unlock()
 			commitMuLocked = false
@@ -525,17 +529,13 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 		}
 
 		if closeErr != nil {
-			s.coord.ensureReservationsLocked()
-			delete(s.coord.activeReservations, s.generation)
-			s.coord.stateChanged.Broadcast()
+			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.err = closeErr
 			return
 		}
 		if s.coord.committedGeneration > s.generation {
-			s.coord.ensureReservationsLocked()
-			delete(s.coord.activeReservations, s.generation)
-			s.coord.stateChanged.Broadcast()
+			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated
 			if s.onInvalidated != nil {
@@ -545,10 +545,8 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 			}
 			return
 		}
-		s.coord.ensureReservationsLocked()
-		delete(s.coord.activeReservations, s.generation)
+		s.coord.removeReservationLocked(s.generation)
 		s.coord.committedGeneration = s.generation
-		s.coord.stateChanged.Broadcast()
 		s.coord.stateMu.Unlock()
 	})
 	return s.err
@@ -575,9 +573,7 @@ func (s *coordinatedTopWriteSink) Close() error {
 		}
 
 		if s.coord.committedGeneration > s.generation {
-			s.coord.ensureReservationsLocked()
-			delete(s.coord.activeReservations, s.generation)
-			s.coord.stateChanged.Broadcast()
+			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			abortErr := s.WriteSink.Abort()
 			s.err = ErrTopWriteInvalidated
@@ -596,17 +592,13 @@ func (s *coordinatedTopWriteSink) Close() error {
 		}
 
 		if closeErr != nil {
-			s.coord.ensureReservationsLocked()
-			delete(s.coord.activeReservations, s.generation)
-			s.coord.stateChanged.Broadcast()
+			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.err = closeErr
 			return
 		}
 		if s.coord.committedGeneration > s.generation {
-			s.coord.ensureReservationsLocked()
-			delete(s.coord.activeReservations, s.generation)
-			s.coord.stateChanged.Broadcast()
+			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated
 			if s.onInvalidated != nil {
@@ -616,10 +608,8 @@ func (s *coordinatedTopWriteSink) Close() error {
 			}
 			return
 		}
-		s.coord.ensureReservationsLocked()
-		delete(s.coord.activeReservations, s.generation)
+		s.coord.removeReservationLocked(s.generation)
 		s.coord.committedGeneration = s.generation
-		s.coord.stateChanged.Broadcast()
 		s.coord.stateMu.Unlock()
 	})
 	return s.err

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -18,12 +18,11 @@ type fanoutWriteManager struct {
 }
 
 type writeCoordinator struct {
-	initOnce     sync.Once
-	leaseOnce    sync.Once
-	writeLease   chan struct{}
-	commitLease  chan struct{}
-	stateMu      sync.Mutex
-	stateChanged *sync.Cond
+	initOnce    sync.Once
+	leaseOnce   sync.Once
+	writeLease  chan struct{}
+	commitLease chan struct{}
+	stateMu     sync.Mutex
 	// committedGeneration is the latest generation visible in the top store.
 	// activeReservations tracks in-flight writers so conditional fills can be
 	// invalidated without holding a same-key lock for the writer lifetime.
@@ -31,6 +30,7 @@ type writeCoordinator struct {
 	nextGeneration      uint64
 	activeReservations  map[uint64]struct{}
 	activeDeletes       int
+	activeDeletesDone   chan struct{}
 }
 
 type coordinatedTopWriteSink struct {
@@ -172,6 +172,9 @@ func (c *writeCoordinator) ensureReservationsLocked() {
 
 func (c *writeCoordinator) latestGenerationLocked() uint64 {
 	latest := c.committedGeneration
+	if len(c.activeReservations) == 0 {
+		return latest
+	}
 	for generation := range c.activeReservations {
 		if generation > latest {
 			latest = generation
@@ -201,7 +204,6 @@ func (c *writeCoordinator) advanceCommittedLocked() {
 func (c *writeCoordinator) removeReservationLocked(generation uint64) {
 	c.ensureReservationsLocked()
 	delete(c.activeReservations, generation)
-	c.stateChanged.Broadcast()
 }
 
 func (c *writeCoordinator) pruneReservationsThroughLocked(generation uint64) {
@@ -211,7 +213,6 @@ func (c *writeCoordinator) pruneReservationsThroughLocked(generation uint64) {
 			delete(c.activeReservations, reserved)
 		}
 	}
-	c.stateChanged.Broadcast()
 }
 
 func (c *writeCoordinator) reserve(ctx context.Context, expected *uint64) (uint64, error) {
@@ -223,24 +224,8 @@ func (c *writeCoordinator) reserve(ctx context.Context, expected *uint64) (uint6
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
 	if expected == nil {
-		if c.activeDeletes > 0 {
-			done := make(chan struct{})
-			go func() {
-				select {
-				case <-ctx.Done():
-					c.stateMu.Lock()
-					c.stateChanged.Broadcast()
-					c.stateMu.Unlock()
-				case <-done:
-				}
-			}()
-			defer close(done)
-		}
-		for c.activeDeletes > 0 {
-			if err := ctx.Err(); err != nil {
-				return 0, err
-			}
-			c.stateChanged.Wait()
+		if err := c.waitForNoActiveDeletesLocked(ctx); err != nil {
+			return 0, err
 		}
 	} else if c.activeDeletes > 0 {
 		return 0, ErrTopWriteInvalidated
@@ -252,7 +237,6 @@ func (c *writeCoordinator) reserve(ctx context.Context, expected *uint64) (uint6
 		return 0, ErrTopWriteInvalidated
 	}
 	generation := c.reserveGenerationLocked()
-	c.stateChanged.Broadcast()
 	return generation, nil
 }
 
@@ -263,24 +247,20 @@ func (c *writeCoordinator) waitForNoActiveDeletes(ctx context.Context) error {
 	c.init()
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
-	if c.activeDeletes > 0 {
-		done := make(chan struct{})
-		go func() {
-			select {
-			case <-ctx.Done():
-				c.stateMu.Lock()
-				c.stateChanged.Broadcast()
-				c.stateMu.Unlock()
-			case <-done:
-			}
-		}()
-		defer close(done)
-	}
+	return c.waitForNoActiveDeletesLocked(ctx)
+}
+
+func (c *writeCoordinator) waitForNoActiveDeletesLocked(ctx context.Context) error {
 	for c.activeDeletes > 0 {
-		if err := ctx.Err(); err != nil {
-			return err
+		done := c.activeDeletesDone
+		c.stateMu.Unlock()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			c.stateMu.Lock()
+			return ctx.Err()
 		}
-		c.stateChanged.Wait()
+		c.stateMu.Lock()
 	}
 	return ctx.Err()
 }
@@ -321,8 +301,11 @@ func (c *writeCoordinator) unregisterReservation(generation uint64) {
 
 func (c *writeCoordinator) init() {
 	c.initOnce.Do(func() {
-		if c.stateChanged == nil {
-			c.stateChanged = sync.NewCond(&c.stateMu)
+		if c.activeDeletesDone == nil {
+			c.activeDeletesDone = make(chan struct{})
+			if c.activeDeletes == 0 {
+				close(c.activeDeletesDone)
+			}
 		}
 		if c.activeReservations == nil {
 			c.activeReservations = make(map[uint64]struct{})
@@ -394,26 +377,10 @@ func (c *writeCoordinator) begin(ctx context.Context, expected *uint64) (uint64,
 	}
 	c.stateMu.Lock()
 	if expected == nil {
-		if c.activeDeletes > 0 {
-			done := make(chan struct{})
-			go func() {
-				select {
-				case <-ctx.Done():
-					c.stateMu.Lock()
-					c.stateChanged.Broadcast()
-					c.stateMu.Unlock()
-				case <-done:
-				}
-			}()
-			defer close(done)
-		}
-		for c.activeDeletes > 0 {
-			if err := ctx.Err(); err != nil {
-				c.stateMu.Unlock()
-				c.releaseWrite()
-				return 0, err
-			}
-			c.stateChanged.Wait()
+		if err := c.waitForNoActiveDeletesLocked(ctx); err != nil {
+			c.stateMu.Unlock()
+			c.releaseWrite()
+			return 0, err
 		}
 	} else if c.activeDeletes > 0 {
 		c.stateMu.Unlock()
@@ -431,7 +398,6 @@ func (c *writeCoordinator) begin(ctx context.Context, expected *uint64) (uint64,
 		return 0, ErrTopWriteInvalidated
 	}
 	generation := c.reserveGenerationLocked()
-	c.stateChanged.Broadcast()
 	c.stateMu.Unlock()
 	return generation, nil
 }
@@ -447,6 +413,9 @@ func (c *writeCoordinator) beginDelete(ctx context.Context) error {
 	}
 	c.init()
 	c.stateMu.Lock()
+	if c.activeDeletes == 0 {
+		c.activeDeletesDone = make(chan struct{})
+	}
 	c.activeDeletes++
 	c.stateMu.Unlock()
 	return nil
@@ -460,8 +429,10 @@ func (c *writeCoordinator) finishDelete(success bool) {
 	}
 	if c.activeDeletes > 0 {
 		c.activeDeletes--
+		if c.activeDeletes == 0 {
+			close(c.activeDeletesDone)
+		}
 	}
-	c.stateChanged.Broadcast()
 	c.stateMu.Unlock()
 	c.releaseCommit()
 }
@@ -474,7 +445,6 @@ func (c *DaramjweeCache) noteTopWriteGeneration(key string) {
 	coord := c.topWrites.coordinator(key)
 	coord.stateMu.Lock()
 	coord.advanceCommittedLocked()
-	coord.stateChanged.Broadcast()
 	coord.stateMu.Unlock()
 }
 

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -618,7 +618,9 @@ func (s *coordinatedTopWriteSink) Close() error {
 			return
 		}
 		s.coord.removeReservationLocked(s.generation)
-		s.coord.committedGeneration = s.generation
+		if s.coord.committedGeneration < s.generation {
+			s.coord.committedGeneration = s.generation
+		}
 		s.coord.stateMu.Unlock()
 	})
 	return s.err

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -47,7 +47,6 @@ type coordinatedStagedTopWriteSink struct {
 	sink          StagedWriteSink
 	coord         *writeCoordinator
 	generation    uint64
-	conditional   bool
 	waitTimeout   time.Duration
 	onInvalidated func() error
 	once          sync.Once
@@ -175,6 +174,9 @@ func (c *writeCoordinator) latestGenerationLocked() uint64 {
 	if len(c.activeReservations) == 0 {
 		return latest
 	}
+	// nextGeneration is only an assignment high-water mark. Rolled-back
+	// reservations must not invalidate conditional writes, so compare only
+	// generations that are committed or still active.
 	for generation := range c.activeReservations {
 		if generation > latest {
 			latest = generation
@@ -465,7 +467,6 @@ func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, 
 			sink:          sink,
 			coord:         coord,
 			generation:    generation,
-			conditional:   expectedGeneration != nil,
 			waitTimeout:   c.closeTimeout,
 			onInvalidated: func() error { return c.deleteTopStoreKey(key) },
 		}, nil

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -37,6 +37,7 @@ type coordinatedTopWriteSink struct {
 	WriteSink
 	coord         *writeCoordinator
 	generation    uint64
+	waitTimeout   time.Duration
 	onInvalidated func() error
 	once          sync.Once
 	err           error
@@ -57,6 +58,7 @@ type conditionalGenerationWriteSink struct {
 	WriteSink
 	coord         *writeCoordinator
 	generation    uint64
+	waitTimeout   time.Duration
 	onInvalidated func() error
 	once          sync.Once
 	err           error
@@ -513,6 +515,7 @@ func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, 
 		WriteSink:     sink,
 		coord:         coord,
 		generation:    generation,
+		waitTimeout:   c.closeTimeout,
 		onInvalidated: func() error { return c.deleteTopStoreKey(key) },
 	}, nil
 }
@@ -628,11 +631,20 @@ func (s *coordinatedStagedTopWriteSink) Abort() error {
 func (s *coordinatedTopWriteSink) Close() error {
 	s.once.Do(func() {
 		defer s.coord.releaseWrite()
-		s.coord.stateMu.Lock()
-		for s.coord.activeDeletes > 0 {
-			s.coord.stateChanged.Wait()
+		waitCtx, cancelWait := newCoordinatorWaitContext(s.waitTimeout)
+		defer cancelWait()
+
+		if err := s.coord.waitForNoActiveDeletes(waitCtx); err != nil {
+			s.coord.unregisterReservation(s.generation)
+			abortErr := s.WriteSink.Abort()
+			s.err = err
+			if abortErr != nil {
+				s.err = errors.Join(s.err, abortErr)
+			}
+			return
 		}
 
+		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {
 			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
@@ -647,19 +659,30 @@ func (s *coordinatedTopWriteSink) Close() error {
 
 		closeErr := s.WriteSink.Close()
 
-		s.coord.stateMu.Lock()
-		for s.coord.activeDeletes > 0 {
-			s.coord.stateChanged.Wait()
-		}
-
 		if closeErr != nil {
+			s.coord.stateMu.Lock()
 			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.err = closeErr
 			return
 		}
+
+		s.coord.stateMu.Lock()
+		if s.coord.committedGeneration < s.generation {
+			s.coord.committedGeneration = s.generation
+		}
+		s.coord.pruneReservationsThroughLocked(s.coord.committedGeneration)
+		s.coord.stateMu.Unlock()
+
+		postCloseWaitCtx, cancelPostCloseWait := newCoordinatorWaitContext(s.waitTimeout)
+		defer cancelPostCloseWait()
+		if err := s.coord.waitForNoActiveDeletes(postCloseWaitCtx); err != nil {
+			s.err = err
+			return
+		}
+
+		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {
-			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated
 			if s.onInvalidated != nil {
@@ -669,10 +692,6 @@ func (s *coordinatedTopWriteSink) Close() error {
 			}
 			return
 		}
-		if s.coord.committedGeneration < s.generation {
-			s.coord.committedGeneration = s.generation
-		}
-		s.coord.pruneReservationsThroughLocked(s.coord.committedGeneration)
 		s.coord.stateMu.Unlock()
 	})
 	return s.err
@@ -701,23 +720,31 @@ func (s *coordinatedTopWriteSink) Abort() error {
 	return s.err
 }
 
-func newConditionalGenerationWriteSink(sink WriteSink, coord *writeCoordinator, generation uint64, onInvalidated func() error) WriteSink {
+func newConditionalGenerationWriteSink(sink WriteSink, coord *writeCoordinator, generation uint64, waitTimeout time.Duration, onInvalidated func() error) WriteSink {
 	return &conditionalGenerationWriteSink{
 		WriteSink:     sink,
 		coord:         coord,
 		generation:    generation,
+		waitTimeout:   waitTimeout,
 		onInvalidated: onInvalidated,
 	}
 }
 
 func (s *conditionalGenerationWriteSink) Close() error {
 	s.once.Do(func() {
-		s.coord.init()
-		s.coord.stateMu.Lock()
-		for s.coord.activeDeletes > 0 {
-			s.coord.stateChanged.Wait()
+		waitCtx, cancelWait := newCoordinatorWaitContext(s.waitTimeout)
+		defer cancelWait()
+
+		if err := s.coord.waitForNoActiveDeletes(waitCtx); err != nil {
+			abortErr := s.WriteSink.Abort()
+			s.err = err
+			if abortErr != nil {
+				s.err = errors.Join(s.err, abortErr)
+			}
+			return
 		}
 
+		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {
 			s.coord.stateMu.Unlock()
 			abortErr := s.WriteSink.Abort()
@@ -731,16 +758,19 @@ func (s *conditionalGenerationWriteSink) Close() error {
 
 		closeErr := s.WriteSink.Close()
 
-		s.coord.stateMu.Lock()
-		for s.coord.activeDeletes > 0 {
-			s.coord.stateChanged.Wait()
-		}
-
 		if closeErr != nil {
-			s.coord.stateMu.Unlock()
 			s.err = closeErr
 			return
 		}
+
+		postCloseWaitCtx, cancelPostCloseWait := newCoordinatorWaitContext(s.waitTimeout)
+		defer cancelPostCloseWait()
+		if err := s.coord.waitForNoActiveDeletes(postCloseWaitCtx); err != nil {
+			s.err = err
+			return
+		}
+
+		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {
 			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -520,22 +520,33 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 		s.coord.stateMu.Unlock()
 
 		closeErr := s.sink.Commit(commitCtx)
-
-		// The store commit may already be visible. Keep commitMu while a racing
-		// delete finishes so invalidation cleanup cannot delete a later writer.
-		s.coord.stateMu.Lock()
-		for s.coord.activeDeletes > 0 {
-			s.coord.stateChanged.Wait()
-		}
-
 		if closeErr != nil {
+			s.coord.stateMu.Lock()
 			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.err = closeErr
 			return
 		}
+
+		s.coord.stateMu.Lock()
+		s.coord.removeReservationLocked(s.generation)
+		if s.coord.committedGeneration < s.generation {
+			s.coord.committedGeneration = s.generation
+			s.coord.stateChanged.Broadcast()
+		}
+		s.coord.stateMu.Unlock()
+
+		// The store commit may already be visible. Keep commitMu while a racing
+		// delete finishes so invalidation cleanup cannot delete a later writer.
+		postCommitWaitCtx, cancelPostCommitWait := newCoordinatorWaitContext(s.waitTimeout)
+		defer cancelPostCommitWait()
+		if err := s.coord.waitForNoActiveDeletes(postCommitWaitCtx); err != nil {
+			s.err = err
+			return
+		}
+
+		s.coord.stateMu.Lock()
 		if s.coord.committedGeneration > s.generation {
-			s.coord.removeReservationLocked(s.generation)
 			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated
 			if s.onInvalidated != nil {
@@ -545,8 +556,6 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 			}
 			return
 		}
-		s.coord.removeReservationLocked(s.generation)
-		s.coord.committedGeneration = s.generation
 		s.coord.stateMu.Unlock()
 	})
 	return s.err

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -437,7 +437,7 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 			s.coord.stateChanged.Wait()
 		}
 
-		if s.coord.latestGenerationLocked() != s.generation {
+		if s.coord.committedGeneration > s.generation {
 			s.coord.ensureReservationsLocked()
 			delete(s.coord.activeReservations, s.generation)
 			s.coord.stateChanged.Broadcast()
@@ -468,7 +468,7 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 			s.err = closeErr
 			return
 		}
-		if s.coord.latestGenerationLocked() != s.generation {
+		if s.coord.committedGeneration > s.generation {
 			s.coord.ensureReservationsLocked()
 			delete(s.coord.activeReservations, s.generation)
 			s.coord.stateChanged.Broadcast()
@@ -510,7 +510,7 @@ func (s *coordinatedTopWriteSink) Close() error {
 			s.coord.stateChanged.Wait()
 		}
 
-		if s.coord.latestGenerationLocked() != s.generation {
+		if s.coord.committedGeneration > s.generation {
 			s.coord.ensureReservationsLocked()
 			delete(s.coord.activeReservations, s.generation)
 			s.coord.stateChanged.Broadcast()
@@ -539,7 +539,7 @@ func (s *coordinatedTopWriteSink) Close() error {
 			s.err = closeErr
 			return
 		}
-		if s.coord.latestGenerationLocked() != s.generation {
+		if s.coord.committedGeneration > s.generation {
 			s.coord.ensureReservationsLocked()
 			delete(s.coord.activeReservations, s.generation)
 			s.coord.stateChanged.Broadcast()
@@ -601,7 +601,7 @@ func (s *conditionalGenerationWriteSink) Close() error {
 			s.coord.stateChanged.Wait()
 		}
 
-		if s.coord.latestGenerationLocked() != s.generation {
+		if s.coord.committedGeneration > s.generation {
 			s.coord.stateMu.Unlock()
 			abortErr := s.WriteSink.Abort()
 			s.err = ErrTopWriteInvalidated
@@ -624,7 +624,7 @@ func (s *conditionalGenerationWriteSink) Close() error {
 			s.err = closeErr
 			return
 		}
-		if s.coord.latestGenerationLocked() != s.generation {
+		if s.coord.committedGeneration > s.generation {
 			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated
 			if s.onInvalidated != nil {

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -17,10 +17,18 @@ type fanoutWriteManager struct {
 }
 
 type writeCoordinator struct {
-	writeMu             sync.Mutex
-	stateMu             sync.Mutex
-	stateChanged        *sync.Cond
+	initOnce     sync.Once
+	leaseOnce    sync.Once
+	writeLease   chan struct{}
+	commitMu     sync.Mutex
+	stateMu      sync.Mutex
+	stateChanged *sync.Cond
+	// committedGeneration is the latest generation visible in the top store.
+	// activeReservations tracks in-flight writers so conditional fills can be
+	// invalidated without holding a same-key lock for the writer lifetime.
 	committedGeneration uint64
+	nextGeneration      uint64
+	activeReservations  map[uint64]struct{}
 	activeDeletes       int
 }
 
@@ -28,6 +36,16 @@ type coordinatedTopWriteSink struct {
 	WriteSink
 	coord         *writeCoordinator
 	generation    uint64
+	onInvalidated func() error
+	once          sync.Once
+	err           error
+}
+
+type coordinatedStagedTopWriteSink struct {
+	sink          StagedWriteSink
+	coord         *writeCoordinator
+	generation    uint64
+	conditional   bool
 	onInvalidated func() error
 	once          sync.Once
 	err           error
@@ -55,12 +73,16 @@ type fanoutLockKey struct {
 
 func (m *topWriteManager) coordinator(key string) *writeCoordinator {
 	if coord, ok := m.coords.Load(key); ok {
-		return coord.(*writeCoordinator)
+		resolved := coord.(*writeCoordinator)
+		resolved.init()
+		return resolved
 	}
 	coord := &writeCoordinator{}
-	coord.stateChanged = sync.NewCond(&coord.stateMu)
+	coord.init()
 	actual, _ := m.coords.LoadOrStore(key, coord)
-	return actual.(*writeCoordinator)
+	resolved := actual.(*writeCoordinator)
+	resolved.init()
+	return resolved
 }
 
 func (m *topWriteManager) coordinatorIfPresent(key string) *writeCoordinator {
@@ -132,16 +154,148 @@ func (m *topWriteManager) currentGeneration(key string) uint64 {
 }
 
 func (c *writeCoordinator) current() uint64 {
+	c.init()
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
 	return c.committedGeneration
 }
 
-// begin serializes same-key top writes and snapshots the committed generation
-// visible to readers. Successful publish advances the committed generation only
-// after the underlying sink has been closed.
+func (c *writeCoordinator) ensureReservationsLocked() {
+	if c.activeReservations == nil {
+		c.activeReservations = make(map[uint64]struct{})
+	}
+}
+
+func (c *writeCoordinator) latestGenerationLocked() uint64 {
+	latest := c.committedGeneration
+	for generation := range c.activeReservations {
+		if generation > latest {
+			latest = generation
+		}
+	}
+	return latest
+}
+
+func (c *writeCoordinator) reserveGenerationLocked() uint64 {
+	c.ensureReservationsLocked()
+	latest := c.latestGenerationLocked()
+	if c.nextGeneration < latest {
+		c.nextGeneration = latest
+	}
+	c.nextGeneration++
+	generation := c.nextGeneration
+	c.activeReservations[generation] = struct{}{}
+	return generation
+}
+
+func (c *writeCoordinator) advanceCommittedLocked() {
+	generation := c.reserveGenerationLocked()
+	delete(c.activeReservations, generation)
+	c.committedGeneration = generation
+}
+
+func (c *writeCoordinator) reserve(ctx context.Context, expected *uint64) (uint64, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	c.init()
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	if expected == nil {
+		if c.activeDeletes > 0 {
+			done := make(chan struct{})
+			go func() {
+				select {
+				case <-ctx.Done():
+					c.stateMu.Lock()
+					c.stateChanged.Broadcast()
+					c.stateMu.Unlock()
+				case <-done:
+				}
+			}()
+			defer close(done)
+		}
+		for c.activeDeletes > 0 {
+			if err := ctx.Err(); err != nil {
+				return 0, err
+			}
+			c.stateChanged.Wait()
+		}
+	} else if c.activeDeletes > 0 {
+		return 0, ErrTopWriteInvalidated
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if expected != nil && c.latestGenerationLocked() != *expected {
+		return 0, ErrTopWriteInvalidated
+	}
+	generation := c.reserveGenerationLocked()
+	c.stateChanged.Broadcast()
+	return generation, nil
+}
+
+func (c *writeCoordinator) unregisterReservation(generation uint64) {
+	c.init()
+	c.stateMu.Lock()
+	if _, ok := c.activeReservations[generation]; ok {
+		delete(c.activeReservations, generation)
+		c.stateChanged.Broadcast()
+	}
+	c.stateMu.Unlock()
+}
+
+func (c *writeCoordinator) init() {
+	c.initOnce.Do(func() {
+		if c.stateChanged == nil {
+			c.stateChanged = sync.NewCond(&c.stateMu)
+		}
+		if c.activeReservations == nil {
+			c.activeReservations = make(map[uint64]struct{})
+		}
+	})
+}
+
+func (c *writeCoordinator) initLease() {
+	c.init()
+	c.leaseOnce.Do(func() {
+		c.writeLease = make(chan struct{}, 1)
+		c.writeLease <- struct{}{}
+	})
+}
+
+func (c *writeCoordinator) acquireWrite(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.initLease()
+	select {
+	case <-c.writeLease:
+		if err := ctx.Err(); err != nil {
+			c.releaseWrite()
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *writeCoordinator) releaseWrite() {
+	c.writeLease <- struct{}{}
+}
+
+// begin serializes same-key top writes for stores that cannot stage separately.
+// It reserves a generation while holding the write lease for the writer
+// lifetime, preserving the legacy compatibility path for external stores.
 func (c *writeCoordinator) begin(ctx context.Context, expected *uint64) (uint64, error) {
-	c.writeMu.Lock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := c.acquireWrite(ctx); err != nil {
+		return 0, err
+	}
 	c.stateMu.Lock()
 	if expected == nil {
 		if c.activeDeletes > 0 {
@@ -160,40 +314,49 @@ func (c *writeCoordinator) begin(ctx context.Context, expected *uint64) (uint64,
 		for c.activeDeletes > 0 {
 			if err := ctx.Err(); err != nil {
 				c.stateMu.Unlock()
-				c.writeMu.Unlock()
+				c.releaseWrite()
 				return 0, err
 			}
 			c.stateChanged.Wait()
 		}
 	} else if c.activeDeletes > 0 {
 		c.stateMu.Unlock()
-		c.writeMu.Unlock()
+		c.releaseWrite()
 		return 0, ErrTopWriteInvalidated
 	}
-	if expected != nil && c.committedGeneration != *expected {
+	if err := ctx.Err(); err != nil {
 		c.stateMu.Unlock()
-		c.writeMu.Unlock()
+		c.releaseWrite()
+		return 0, err
+	}
+	if expected != nil && c.latestGenerationLocked() != *expected {
+		c.stateMu.Unlock()
+		c.releaseWrite()
 		return 0, ErrTopWriteInvalidated
 	}
-	generation := c.committedGeneration
+	generation := c.reserveGenerationLocked()
+	c.stateChanged.Broadcast()
 	c.stateMu.Unlock()
 	return generation, nil
 }
 
-func (c *writeCoordinator) rollbackAndUnlock(_ uint64) {
-	c.writeMu.Unlock()
+func (c *writeCoordinator) rollbackAndUnlock(generation uint64) {
+	c.unregisterReservation(generation)
+	c.releaseWrite()
 }
 
 func (c *writeCoordinator) beginDelete() {
+	c.init()
 	c.stateMu.Lock()
 	c.activeDeletes++
 	c.stateMu.Unlock()
 }
 
 func (c *writeCoordinator) finishDelete(success bool) {
+	c.init()
 	c.stateMu.Lock()
 	if success {
-		c.committedGeneration++
+		c.advanceCommittedLocked()
 	}
 	if c.activeDeletes > 0 {
 		c.activeDeletes--
@@ -209,7 +372,7 @@ func (c *DaramjweeCache) currentTopWriteGeneration(key string) uint64 {
 func (c *DaramjweeCache) noteTopWriteGeneration(key string) {
 	coord := c.topWrites.coordinator(key)
 	coord.stateMu.Lock()
-	coord.committedGeneration++
+	coord.advanceCommittedLocked()
 	coord.stateChanged.Broadcast()
 	coord.stateMu.Unlock()
 }
@@ -217,6 +380,28 @@ func (c *DaramjweeCache) noteTopWriteGeneration(key string) {
 func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, key string, metadata *Metadata, expectedGeneration *uint64) (WriteSink, error) {
 	store := c.topWriteStore()
 	coord := c.topWrites.coordinator(key)
+	if staging, ok := store.(StagingStore); ok {
+		coord.commitMu.Lock()
+		generation, err := coord.reserve(ctx, expectedGeneration)
+		if err != nil {
+			coord.commitMu.Unlock()
+			return nil, err
+		}
+		sink, err := staging.BeginStagedSet(ctx, key, metadata)
+		if err != nil {
+			coord.unregisterReservation(generation)
+			coord.commitMu.Unlock()
+			return nil, err
+		}
+		coord.commitMu.Unlock()
+		return &coordinatedStagedTopWriteSink{
+			sink:          sink,
+			coord:         coord,
+			generation:    generation,
+			conditional:   expectedGeneration != nil,
+			onInvalidated: func() error { return c.deleteTopStoreKey(key) },
+		}, nil
+	}
 	generation, err := coord.begin(ctx, expectedGeneration)
 	if err != nil {
 		return nil, err
@@ -236,15 +421,99 @@ func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, 
 	}, nil
 }
 
-func (s *coordinatedTopWriteSink) Close() error {
+func (s *coordinatedStagedTopWriteSink) Close() error {
 	s.once.Do(func() {
-		defer s.coord.writeMu.Unlock()
+		ctx := context.Background()
+		s.coord.commitMu.Lock()
+		commitMuLocked := true
+		defer func() {
+			if commitMuLocked {
+				s.coord.commitMu.Unlock()
+			}
+		}()
+
 		s.coord.stateMu.Lock()
 		for s.coord.activeDeletes > 0 {
 			s.coord.stateChanged.Wait()
 		}
 
-		if s.coord.committedGeneration != s.generation {
+		if s.coord.latestGenerationLocked() != s.generation {
+			s.coord.ensureReservationsLocked()
+			delete(s.coord.activeReservations, s.generation)
+			s.coord.stateChanged.Broadcast()
+			s.coord.stateMu.Unlock()
+			s.coord.commitMu.Unlock()
+			commitMuLocked = false
+			abortErr := s.sink.Abort()
+			s.err = ErrTopWriteInvalidated
+			if abortErr != nil {
+				s.err = errors.Join(s.err, abortErr)
+			}
+			return
+		}
+		s.coord.stateMu.Unlock()
+
+		closeErr := s.sink.Commit(ctx)
+
+		s.coord.stateMu.Lock()
+		for s.coord.activeDeletes > 0 {
+			s.coord.stateChanged.Wait()
+		}
+
+		if closeErr != nil {
+			s.coord.ensureReservationsLocked()
+			delete(s.coord.activeReservations, s.generation)
+			s.coord.stateChanged.Broadcast()
+			s.coord.stateMu.Unlock()
+			s.err = closeErr
+			return
+		}
+		if s.coord.latestGenerationLocked() != s.generation {
+			s.coord.ensureReservationsLocked()
+			delete(s.coord.activeReservations, s.generation)
+			s.coord.stateChanged.Broadcast()
+			s.coord.stateMu.Unlock()
+			s.err = ErrTopWriteInvalidated
+			if s.onInvalidated != nil {
+				if cleanupErr := s.onInvalidated(); cleanupErr != nil {
+					s.err = errors.Join(s.err, cleanupErr)
+				}
+			}
+			return
+		}
+		s.coord.ensureReservationsLocked()
+		delete(s.coord.activeReservations, s.generation)
+		s.coord.committedGeneration = s.generation
+		s.coord.stateChanged.Broadcast()
+		s.coord.stateMu.Unlock()
+	})
+	return s.err
+}
+
+func (s *coordinatedStagedTopWriteSink) Write(p []byte) (int, error) {
+	return s.sink.Write(p)
+}
+
+func (s *coordinatedStagedTopWriteSink) Abort() error {
+	s.once.Do(func() {
+		s.coord.unregisterReservation(s.generation)
+		s.err = s.sink.Abort()
+	})
+	return s.err
+}
+
+func (s *coordinatedTopWriteSink) Close() error {
+	s.once.Do(func() {
+		defer s.coord.releaseWrite()
+		s.coord.stateMu.Lock()
+		for s.coord.activeDeletes > 0 {
+			s.coord.stateChanged.Wait()
+		}
+
+		if s.coord.latestGenerationLocked() != s.generation {
+			s.coord.ensureReservationsLocked()
+			delete(s.coord.activeReservations, s.generation)
+			s.coord.stateChanged.Broadcast()
 			s.coord.stateMu.Unlock()
 			abortErr := s.WriteSink.Abort()
 			s.err = ErrTopWriteInvalidated
@@ -258,16 +527,23 @@ func (s *coordinatedTopWriteSink) Close() error {
 		closeErr := s.WriteSink.Close()
 
 		s.coord.stateMu.Lock()
-		defer s.coord.stateMu.Unlock()
 		for s.coord.activeDeletes > 0 {
 			s.coord.stateChanged.Wait()
 		}
 
 		if closeErr != nil {
+			s.coord.ensureReservationsLocked()
+			delete(s.coord.activeReservations, s.generation)
+			s.coord.stateChanged.Broadcast()
+			s.coord.stateMu.Unlock()
 			s.err = closeErr
 			return
 		}
-		if s.coord.committedGeneration != s.generation {
+		if s.coord.latestGenerationLocked() != s.generation {
+			s.coord.ensureReservationsLocked()
+			delete(s.coord.activeReservations, s.generation)
+			s.coord.stateChanged.Broadcast()
+			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated
 			if s.onInvalidated != nil {
 				if cleanupErr := s.onInvalidated(); cleanupErr != nil {
@@ -276,8 +552,11 @@ func (s *coordinatedTopWriteSink) Close() error {
 			}
 			return
 		}
-		s.coord.committedGeneration++
+		s.coord.ensureReservationsLocked()
+		delete(s.coord.activeReservations, s.generation)
+		s.coord.committedGeneration = s.generation
 		s.coord.stateChanged.Broadcast()
+		s.coord.stateMu.Unlock()
 	})
 	return s.err
 }
@@ -298,8 +577,9 @@ func (c *DaramjweeCache) deleteTopStoreKey(key string) error {
 
 func (s *coordinatedTopWriteSink) Abort() error {
 	s.once.Do(func() {
-		defer s.coord.writeMu.Unlock()
+		defer s.coord.releaseWrite()
 		s.err = s.WriteSink.Abort()
+		s.coord.unregisterReservation(s.generation)
 	})
 	return s.err
 }
@@ -315,12 +595,13 @@ func newConditionalGenerationWriteSink(sink WriteSink, coord *writeCoordinator, 
 
 func (s *conditionalGenerationWriteSink) Close() error {
 	s.once.Do(func() {
+		s.coord.init()
 		s.coord.stateMu.Lock()
 		for s.coord.activeDeletes > 0 {
 			s.coord.stateChanged.Wait()
 		}
 
-		if s.coord.committedGeneration != s.generation {
+		if s.coord.latestGenerationLocked() != s.generation {
 			s.coord.stateMu.Unlock()
 			abortErr := s.WriteSink.Abort()
 			s.err = ErrTopWriteInvalidated
@@ -334,16 +615,17 @@ func (s *conditionalGenerationWriteSink) Close() error {
 		closeErr := s.WriteSink.Close()
 
 		s.coord.stateMu.Lock()
-		defer s.coord.stateMu.Unlock()
 		for s.coord.activeDeletes > 0 {
 			s.coord.stateChanged.Wait()
 		}
 
 		if closeErr != nil {
+			s.coord.stateMu.Unlock()
 			s.err = closeErr
 			return
 		}
-		if s.coord.committedGeneration != s.generation {
+		if s.coord.latestGenerationLocked() != s.generation {
+			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated
 			if s.onInvalidated != nil {
 				if cleanupErr := s.onInvalidated(); cleanupErr != nil {
@@ -353,6 +635,7 @@ func (s *conditionalGenerationWriteSink) Close() error {
 			return
 		}
 		s.err = nil
+		s.coord.stateMu.Unlock()
 	})
 	return s.err
 }

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -57,6 +57,185 @@ func TestSetStreamToStoreWithTopGenerationRestoresGenerationOnBeginSetFailure(t 
 	}
 }
 
+func TestSetStreamToTopStoreDoesNotExposeStagedCommitBypass(t *testing.T) {
+	store := &stubStagingStore{}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: time.Second,
+	}
+
+	writer, err := cache.setStreamToTopStoreWithGeneration(context.Background(), "key", &Metadata{CacheTag: "v1"}, nil)
+	if err != nil {
+		t.Fatalf("expected staged writer, got %v", err)
+	}
+	defer writer.Abort()
+
+	if _, ok := writer.(StagedWriteSink); ok {
+		t.Fatal("top-write coordinator exposed StagedWriteSink and allowed direct Commit bypass")
+	}
+}
+
+func TestLaterStagedBeginFailureDoesNotInvalidateOlderWriter(t *testing.T) {
+	beginErr := errors.New("begin staged failed")
+	store := &blockingSecondBeginStagingStore{
+		secondBeginStarted: make(chan struct{}),
+		releaseSecondBegin: make(chan struct{}),
+		secondBeginErr:     beginErr,
+	}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: time.Second,
+	}
+
+	older, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "older"})
+	if err != nil {
+		t.Fatalf("older Set failed: %v", err)
+	}
+	defer older.Abort()
+
+	secondDone := make(chan error, 1)
+	go func() {
+		second, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "newer"})
+		if second != nil {
+			_ = second.Abort()
+		}
+		secondDone <- err
+	}()
+
+	select {
+	case <-store.secondBeginStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second staged begin did not start")
+	}
+
+	olderDone := make(chan error, 1)
+	go func() {
+		olderDone <- older.Close()
+	}()
+
+	select {
+	case err := <-olderDone:
+		t.Fatalf("older Close completed while later BeginStagedSet was still pending: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(store.releaseSecondBegin)
+	if err := <-secondDone; !errors.Is(err, beginErr) {
+		t.Fatalf("expected second BeginStagedSet error, got %v", err)
+	}
+	if err := <-olderDone; err != nil {
+		t.Fatalf("older Close should publish after later begin failure, got %v", err)
+	}
+}
+
+func TestLaterStagedAbortCleanupDoesNotInvalidateOlderWriter(t *testing.T) {
+	store := &blockingSecondAbortStagingStore{
+		abortStarted: make(chan struct{}),
+		releaseAbort: make(chan struct{}),
+	}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: time.Second,
+	}
+
+	older, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "older"})
+	if err != nil {
+		t.Fatalf("older Set failed: %v", err)
+	}
+	defer older.Abort()
+
+	newer, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "newer"})
+	if err != nil {
+		t.Fatalf("newer Set failed: %v", err)
+	}
+
+	abortDone := make(chan error, 1)
+	go func() {
+		abortDone <- newer.Abort()
+	}()
+
+	select {
+	case <-store.abortStarted:
+	case <-time.After(time.Second):
+		t.Fatal("newer Abort did not reach store cleanup")
+	}
+
+	olderDone := make(chan error, 1)
+	go func() {
+		olderDone <- older.Close()
+	}()
+
+	select {
+	case err := <-olderDone:
+		if err != nil {
+			t.Fatalf("older Close should not be invalidated by aborting later writer, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("older Close blocked behind later abort cleanup")
+	}
+
+	close(store.releaseAbort)
+	if err := <-abortDone; err != nil {
+		t.Fatalf("newer Abort failed: %v", err)
+	}
+}
+
+func TestStaleStagedCloseAbortCleanupDoesNotBlockNewerCommit(t *testing.T) {
+	store := &blockingFirstAbortStagingStore{
+		abortStarted: make(chan struct{}),
+		releaseAbort: make(chan struct{}),
+	}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: time.Second,
+	}
+
+	older, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "older"})
+	if err != nil {
+		t.Fatalf("older Set failed: %v", err)
+	}
+	defer older.Abort()
+
+	newer, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "newer"})
+	if err != nil {
+		t.Fatalf("newer Set failed: %v", err)
+	}
+
+	olderDone := make(chan error, 1)
+	go func() {
+		olderDone <- older.Close()
+	}()
+
+	select {
+	case <-store.abortStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stale older Close did not reach store abort cleanup")
+	}
+
+	newerDone := make(chan error, 1)
+	go func() {
+		newerDone <- newer.Close()
+	}()
+
+	select {
+	case err := <-newerDone:
+		if err != nil {
+			t.Fatalf("newer Close should not be blocked by stale abort cleanup, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("newer Close blocked behind stale abort cleanup")
+	}
+
+	close(store.releaseAbort)
+	if err := <-olderDone; !errors.Is(err, ErrTopWriteInvalidated) {
+		t.Fatalf("expected older Close to be invalidated, got %v", err)
+	}
+}
+
 func TestCurrentTopWriteGenerationDoesNotCreateCoordinatorForMissingKey(t *testing.T) {
 	cache := &DaramjweeCache{}
 
@@ -96,6 +275,109 @@ func TestSetStreamToTopStoreWithGenerationHonorsCanceledContextWhileDeleteInProg
 		}
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("setStreamToTopStoreWithGeneration did not return after context cancellation")
+	}
+}
+
+func TestSetWithAbandonedTopWriteSinkReturnsWhenContextExpires(t *testing.T) {
+	store := &countingBeginSetStore{}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: time.Second,
+	}
+
+	first, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "first"})
+	if err != nil {
+		t.Fatalf("first Set failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		second, err := cache.Set(ctx, "key", &Metadata{CacheTag: "second"})
+		if second != nil {
+			_ = second.Abort()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation from second Set, got %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		_ = first.Abort()
+		err := <-done
+		t.Fatalf("second Set blocked past its context deadline; eventually returned %v", err)
+	}
+
+	if err := first.Abort(); err != nil {
+		t.Fatalf("first Abort failed: %v", err)
+	}
+}
+
+func TestInvalidatedCleanupDoesNotHoldStateMu(t *testing.T) {
+	coord := &writeCoordinator{}
+	coord.stateChanged = sync.NewCond(&coord.stateMu)
+	coord.committedGeneration = 1
+
+	closeStarted := make(chan struct{})
+	releaseClose := make(chan struct{})
+	cleanupStarted := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+
+	sink := newConditionalGenerationWriteSink(&testWriteSink{
+		closeFn: func() error {
+			close(closeStarted)
+			<-releaseClose
+			return nil
+		},
+	}, coord, 1, func() error {
+		close(cleanupStarted)
+		<-releaseCleanup
+		return nil
+	})
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- sink.Close()
+	}()
+
+	<-closeStarted
+	coord.stateMu.Lock()
+	coord.committedGeneration = 2
+	coord.stateMu.Unlock()
+	close(releaseClose)
+
+	select {
+	case <-cleanupStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("invalidated cleanup did not start")
+	}
+
+	stateMuAcquired := make(chan struct{})
+	go func() {
+		coord.stateMu.Lock()
+		close(stateMuAcquired)
+		coord.stateMu.Unlock()
+	}()
+
+	select {
+	case <-stateMuAcquired:
+	case <-time.After(100 * time.Millisecond):
+		close(releaseCleanup)
+		if err := <-closeDone; !errors.Is(err, ErrTopWriteInvalidated) {
+			t.Fatalf("expected invalidated close after blocked stateMu acquisition, got %v", err)
+		}
+		t.Fatal("cleanup held coordinator stateMu while it was blocked")
+	}
+
+	close(releaseCleanup)
+	if err := <-closeDone; !errors.Is(err, ErrTopWriteInvalidated) {
+		t.Fatalf("expected invalidated close, got %v", err)
 	}
 }
 
@@ -328,11 +610,191 @@ func (s *failingBeginSetStore) Stat(ctx context.Context, key string) (*Metadata,
 	return nil, ErrNotFound
 }
 
+type countingBeginSetStore struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *countingBeginSetStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *countingBeginSetStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	return &stubWriteSink{}, nil
+}
+
+func (s *countingBeginSetStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *countingBeginSetStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
 type stubWriteSink struct{}
 
 func (s *stubWriteSink) Write(p []byte) (int, error) { return len(p), nil }
 func (s *stubWriteSink) Close() error                { return nil }
 func (s *stubWriteSink) Abort() error                { return nil }
+
+type stubStagingStore struct{}
+
+func (s *stubStagingStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *stubStagingStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	return &stubWriteSink{}, nil
+}
+
+func (s *stubStagingStore) BeginStagedSet(ctx context.Context, key string, metadata *Metadata) (StagedWriteSink, error) {
+	return &stubStagedWriteSink{}, nil
+}
+
+func (s *stubStagingStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *stubStagingStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type stubStagedWriteSink struct{}
+
+func (s *stubStagedWriteSink) Write(p []byte) (int, error) { return len(p), nil }
+func (s *stubStagedWriteSink) Commit(ctx context.Context) error {
+	return nil
+}
+func (s *stubStagedWriteSink) Abort() error { return nil }
+
+type blockingSecondBeginStagingStore struct {
+	mu                 sync.Mutex
+	calls              int
+	secondBeginStarted chan struct{}
+	releaseSecondBegin chan struct{}
+	secondBeginErr     error
+}
+
+func (s *blockingSecondBeginStagingStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *blockingSecondBeginStagingStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	return &stubWriteSink{}, nil
+}
+
+func (s *blockingSecondBeginStagingStore) BeginStagedSet(ctx context.Context, key string, metadata *Metadata) (StagedWriteSink, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+	if call == 2 {
+		close(s.secondBeginStarted)
+		<-s.releaseSecondBegin
+		return nil, s.secondBeginErr
+	}
+	return &stubStagedWriteSink{}, nil
+}
+
+func (s *blockingSecondBeginStagingStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *blockingSecondBeginStagingStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type blockingSecondAbortStagingStore struct {
+	mu           sync.Mutex
+	calls        int
+	abortStarted chan struct{}
+	releaseAbort chan struct{}
+}
+
+func (s *blockingSecondAbortStagingStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *blockingSecondAbortStagingStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	return &stubWriteSink{}, nil
+}
+
+func (s *blockingSecondAbortStagingStore) BeginStagedSet(ctx context.Context, key string, metadata *Metadata) (StagedWriteSink, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+	if call == 2 {
+		return &blockingAbortStagedWriteSink{
+			abortStarted: s.abortStarted,
+			releaseAbort: s.releaseAbort,
+		}, nil
+	}
+	return &stubStagedWriteSink{}, nil
+}
+
+func (s *blockingSecondAbortStagingStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *blockingSecondAbortStagingStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type blockingFirstAbortStagingStore struct {
+	mu           sync.Mutex
+	calls        int
+	abortStarted chan struct{}
+	releaseAbort chan struct{}
+}
+
+func (s *blockingFirstAbortStagingStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *blockingFirstAbortStagingStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	return &stubWriteSink{}, nil
+}
+
+func (s *blockingFirstAbortStagingStore) BeginStagedSet(ctx context.Context, key string, metadata *Metadata) (StagedWriteSink, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+	if call == 1 {
+		return &blockingAbortStagedWriteSink{
+			abortStarted: s.abortStarted,
+			releaseAbort: s.releaseAbort,
+		}, nil
+	}
+	return &stubStagedWriteSink{}, nil
+}
+
+func (s *blockingFirstAbortStagingStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *blockingFirstAbortStagingStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type blockingAbortStagedWriteSink struct {
+	abortStarted chan struct{}
+	releaseAbort chan struct{}
+}
+
+func (s *blockingAbortStagedWriteSink) Write(p []byte) (int, error) { return len(p), nil }
+func (s *blockingAbortStagedWriteSink) Commit(ctx context.Context) error {
+	return nil
+}
+func (s *blockingAbortStagedWriteSink) Abort() error {
+	close(s.abortStarted)
+	<-s.releaseAbort
+	return nil
+}
 
 type testWriteSink struct {
 	closeFn func() error

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -57,6 +57,25 @@ func TestSetStreamToStoreWithTopGenerationRestoresGenerationOnBeginSetFailure(t 
 	}
 }
 
+func TestRolledBackReservationDoesNotInvalidateConditionalWrite(t *testing.T) {
+	coord := &writeCoordinator{}
+	generation, err := coord.reserve(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("reserve failed: %v", err)
+	}
+	coord.unregisterReservation(generation)
+
+	expected := uint64(0)
+	next, err := coord.reserve(context.Background(), &expected)
+	if err != nil {
+		t.Fatalf("rolled-back unpublished generation should not invalidate conditional reserve: %v", err)
+	}
+	if next <= generation {
+		t.Fatalf("next generation should keep monotonic assignment, got %d after %d", next, generation)
+	}
+	coord.unregisterReservation(next)
+}
+
 func TestSetStreamToTopStoreDoesNotExposeStagedCommitBypass(t *testing.T) {
 	store := &stubStagingStore{}
 	cache := &DaramjweeCache{

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -259,7 +259,9 @@ func TestStagedCloseWaitingForDeleteTimesOutAndReleasesReservation(t *testing.T)
 	defer writer.Abort()
 
 	coord := cache.topWrites.coordinator("key")
-	coord.beginDelete()
+	if err := coord.beginDelete(context.Background()); err != nil {
+		t.Fatalf("beginDelete failed: %v", err)
+	}
 
 	closeErr := writer.Close()
 	if !errors.Is(closeErr, context.DeadlineExceeded) {
@@ -273,6 +275,178 @@ func TestStagedCloseWaitingForDeleteTimesOutAndReleasesReservation(t *testing.T)
 	}
 	if err := next.Close(); err != nil {
 		t.Fatalf("next Close should succeed, got %v", err)
+	}
+}
+
+func TestStagedCloseWaitingForCommitLeaseTimesOutAndReleasesReservation(t *testing.T) {
+	store := &blockingFirstCommitStagingStore{
+		commitStarted: make(chan struct{}),
+		releaseCommit: make(chan struct{}),
+	}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: 25 * time.Millisecond,
+	}
+
+	first, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v1"})
+	if err != nil {
+		t.Fatalf("first Set failed: %v", err)
+	}
+	second, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v2"})
+	if err != nil {
+		t.Fatalf("second Set failed: %v", err)
+	}
+	defer second.Abort()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- first.Close()
+	}()
+
+	select {
+	case <-store.commitStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first Commit did not start")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- second.Close()
+	}()
+
+	select {
+	case err := <-secondDone:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected second Close to time out waiting for commit lease, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		close(store.releaseCommit)
+		<-firstDone
+		t.Fatal("second Close blocked past close timeout while commit lease was held")
+	}
+
+	close(store.releaseCommit)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Close should finish after release, got %v", err)
+	}
+
+	third, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v3"})
+	if err != nil {
+		t.Fatalf("third Set should not be poisoned by timed-out second close, got %v", err)
+	}
+	if err := third.Close(); err != nil {
+		t.Fatalf("third Close should succeed, got %v", err)
+	}
+}
+
+func TestCommittedStagedWritePrunesOlderAbandonedReservations(t *testing.T) {
+	store := &stubStagingStore{}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: time.Second,
+	}
+
+	abandoned, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v1"})
+	if err != nil {
+		t.Fatalf("abandoned Set failed: %v", err)
+	}
+	defer abandoned.Abort()
+
+	newer, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v2"})
+	if err != nil {
+		t.Fatalf("newer Set failed: %v", err)
+	}
+	if err := newer.Close(); err != nil {
+		t.Fatalf("newer Close failed: %v", err)
+	}
+
+	coord := cache.topWrites.coordinator("key")
+	coord.stateMu.Lock()
+	defer coord.stateMu.Unlock()
+	if _, ok := coord.activeReservations[1]; ok {
+		t.Fatal("older abandoned reservation remained after a newer generation committed")
+	}
+}
+
+func TestStagedCloseAbortsUnderlyingSinkAfterCommitFailure(t *testing.T) {
+	commitErr := errors.New("commit failed")
+	store := &failingCommitStagingStore{commitErr: commitErr}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: time.Second,
+	}
+
+	writer, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v1"})
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+	closeErr := writer.Close()
+	if !errors.Is(closeErr, commitErr) {
+		t.Fatalf("expected commit failure, got %v", closeErr)
+	}
+	if !store.sink.aborted {
+		t.Fatal("expected failed staged commit to abort underlying sink")
+	}
+}
+
+func TestFailedStagedCommitAbortCleanupDoesNotHoldCommitLease(t *testing.T) {
+	commitErr := errors.New("commit failed")
+	store := &blockingAbortAfterCommitFailureStagingStore{
+		commitErr:    commitErr,
+		abortStarted: make(chan struct{}),
+		releaseAbort: make(chan struct{}),
+	}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: 25 * time.Millisecond,
+	}
+
+	first, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v1"})
+	if err != nil {
+		t.Fatalf("first Set failed: %v", err)
+	}
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- first.Close()
+	}()
+
+	select {
+	case <-store.abortStarted:
+	case <-time.After(time.Second):
+		t.Fatal("failed commit did not start abort cleanup")
+	}
+
+	second, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v2"})
+	if err != nil {
+		close(store.releaseAbort)
+		<-firstDone
+		t.Fatalf("second Set failed: %v", err)
+	}
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- second.Close()
+	}()
+
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			close(store.releaseAbort)
+			<-firstDone
+			t.Fatalf("second Close should not wait for failed commit abort cleanup, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		close(store.releaseAbort)
+		<-firstDone
+		t.Fatal("second Close blocked behind failed commit abort cleanup")
+	}
+
+	close(store.releaseAbort)
+	if err := <-firstDone; !errors.Is(err, commitErr) {
+		t.Fatalf("expected first Close commit failure, got %v", err)
 	}
 }
 
@@ -296,7 +470,9 @@ func TestSetStreamToTopStoreWithGenerationHonorsCanceledContextWhileDeleteInProg
 	}
 
 	coord := cache.topWrites.coordinator("key")
-	coord.beginDelete()
+	if err := coord.beginDelete(context.Background()); err != nil {
+		t.Fatalf("beginDelete failed: %v", err)
+	}
 	defer coord.finishDelete(false)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -831,6 +1007,151 @@ func (s *blockingAbortStagedWriteSink) Commit(ctx context.Context) error {
 	return nil
 }
 func (s *blockingAbortStagedWriteSink) Abort() error {
+	close(s.abortStarted)
+	<-s.releaseAbort
+	return nil
+}
+
+type blockingFirstCommitStagingStore struct {
+	mu            sync.Mutex
+	calls         int
+	commitStarted chan struct{}
+	releaseCommit chan struct{}
+}
+
+func (s *blockingFirstCommitStagingStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *blockingFirstCommitStagingStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	return &stubWriteSink{}, nil
+}
+
+func (s *blockingFirstCommitStagingStore) BeginStagedSet(ctx context.Context, key string, metadata *Metadata) (StagedWriteSink, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+	if call == 1 {
+		return &blockingCommitStagedWriteSink{
+			commitStarted: s.commitStarted,
+			releaseCommit: s.releaseCommit,
+		}, nil
+	}
+	return &stubStagedWriteSink{}, nil
+}
+
+func (s *blockingFirstCommitStagingStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *blockingFirstCommitStagingStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type blockingCommitStagedWriteSink struct {
+	commitStarted chan struct{}
+	releaseCommit chan struct{}
+}
+
+func (s *blockingCommitStagedWriteSink) Write(p []byte) (int, error) { return len(p), nil }
+func (s *blockingCommitStagedWriteSink) Commit(ctx context.Context) error {
+	close(s.commitStarted)
+	<-s.releaseCommit
+	return nil
+}
+func (s *blockingCommitStagedWriteSink) Abort() error { return nil }
+
+type failingCommitStagingStore struct {
+	commitErr error
+	sink      *failingCommitStagedWriteSink
+}
+
+func (s *failingCommitStagingStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *failingCommitStagingStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	return &stubWriteSink{}, nil
+}
+
+func (s *failingCommitStagingStore) BeginStagedSet(ctx context.Context, key string, metadata *Metadata) (StagedWriteSink, error) {
+	s.sink = &failingCommitStagedWriteSink{commitErr: s.commitErr}
+	return s.sink, nil
+}
+
+func (s *failingCommitStagingStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *failingCommitStagingStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type failingCommitStagedWriteSink struct {
+	commitErr error
+	aborted   bool
+}
+
+func (s *failingCommitStagedWriteSink) Write(p []byte) (int, error) { return len(p), nil }
+func (s *failingCommitStagedWriteSink) Commit(ctx context.Context) error {
+	return s.commitErr
+}
+func (s *failingCommitStagedWriteSink) Abort() error {
+	s.aborted = true
+	return nil
+}
+
+type blockingAbortAfterCommitFailureStagingStore struct {
+	mu           sync.Mutex
+	calls        int
+	commitErr    error
+	abortStarted chan struct{}
+	releaseAbort chan struct{}
+}
+
+func (s *blockingAbortAfterCommitFailureStagingStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *blockingAbortAfterCommitFailureStagingStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	return &stubWriteSink{}, nil
+}
+
+func (s *blockingAbortAfterCommitFailureStagingStore) BeginStagedSet(ctx context.Context, key string, metadata *Metadata) (StagedWriteSink, error) {
+	s.mu.Lock()
+	s.calls++
+	call := s.calls
+	s.mu.Unlock()
+	if call == 1 {
+		return &blockingAbortAfterCommitFailureSink{
+			commitErr:    s.commitErr,
+			abortStarted: s.abortStarted,
+			releaseAbort: s.releaseAbort,
+		}, nil
+	}
+	return &stubStagedWriteSink{}, nil
+}
+
+func (s *blockingAbortAfterCommitFailureStagingStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *blockingAbortAfterCommitFailureStagingStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type blockingAbortAfterCommitFailureSink struct {
+	commitErr    error
+	abortStarted chan struct{}
+	releaseAbort chan struct{}
+}
+
+func (s *blockingAbortAfterCommitFailureSink) Write(p []byte) (int, error) { return len(p), nil }
+func (s *blockingAbortAfterCommitFailureSink) Commit(ctx context.Context) error {
+	return s.commitErr
+}
+func (s *blockingAbortAfterCommitFailureSink) Abort() error {
 	close(s.abortStarted)
 	<-s.releaseAbort
 	return nil

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -315,6 +315,37 @@ func TestLegacyTopWriteCloseWaitingForDeleteTimesOut(t *testing.T) {
 	coord.finishDelete(false)
 }
 
+func TestLegacyTopWriteCloseDoesNotReturnTimeoutAfterSuccessfulCommit(t *testing.T) {
+	coord := &writeCoordinator{}
+	if err := coord.acquireWrite(context.Background()); err != nil {
+		t.Fatalf("acquireWrite failed: %v", err)
+	}
+
+	deleteStarted := false
+	sink := &coordinatedTopWriteSink{
+		WriteSink: &testWriteSink{
+			closeFn: func() error {
+				if err := coord.beginDelete(context.Background()); err != nil {
+					return err
+				}
+				deleteStarted = true
+				return nil
+			},
+		},
+		coord:       coord,
+		generation:  1,
+		waitTimeout: 25 * time.Millisecond,
+	}
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("successful legacy top write should not be reported as a timeout, got %v", err)
+	}
+	if !deleteStarted {
+		t.Fatal("test did not start the racing delete")
+	}
+	coord.finishDelete(false)
+}
+
 func TestStagedCloseWaitingForCommitLeaseTimesOutAndReleasesReservation(t *testing.T) {
 	store := &blockingFirstCommitStagingStore{
 		commitStarted: make(chan struct{}),
@@ -554,6 +585,29 @@ func TestConditionalGenerationWriteSinkWaitingForDeleteTimesOut(t *testing.T) {
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("conditional generation Close blocked past close timeout while delete was active")
 	}
+}
+
+func TestConditionalGenerationWriteSinkDoesNotReturnTimeoutAfterSuccessfulClose(t *testing.T) {
+	coord := &writeCoordinator{}
+
+	deleteStarted := false
+	sink := newConditionalGenerationWriteSink(&testWriteSink{
+		closeFn: func() error {
+			if err := coord.beginDelete(context.Background()); err != nil {
+				return err
+			}
+			deleteStarted = true
+			return nil
+		},
+	}, coord, 1, 25*time.Millisecond, nil)
+
+	if err := sink.Close(); err != nil {
+		t.Fatalf("successful conditional close should not be reported as a timeout, got %v", err)
+	}
+	if !deleteStarted {
+		t.Fatal("test did not start the racing delete")
+	}
+	coord.finishDelete(false)
 }
 
 func TestSetWithAbandonedTopWriteSinkReturnsWhenContextExpires(t *testing.T) {

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -204,6 +204,9 @@ func TestStaleStagedCloseAbortCleanupDoesNotBlockNewerCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newer Set failed: %v", err)
 	}
+	if err := newer.Close(); err != nil {
+		t.Fatalf("newer Close failed: %v", err)
+	}
 
 	olderDone := make(chan error, 1)
 	go func() {
@@ -216,18 +219,23 @@ func TestStaleStagedCloseAbortCleanupDoesNotBlockNewerCommit(t *testing.T) {
 		t.Fatal("stale older Close did not reach store abort cleanup")
 	}
 
-	newerDone := make(chan error, 1)
+	third, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "third"})
+	if err != nil {
+		t.Fatalf("third Set failed: %v", err)
+	}
+
+	thirdDone := make(chan error, 1)
 	go func() {
-		newerDone <- newer.Close()
+		thirdDone <- third.Close()
 	}()
 
 	select {
-	case err := <-newerDone:
+	case err := <-thirdDone:
 		if err != nil {
-			t.Fatalf("newer Close should not be blocked by stale abort cleanup, got %v", err)
+			t.Fatalf("third Close should not be blocked by stale abort cleanup, got %v", err)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("newer Close blocked behind stale abort cleanup")
+		t.Fatal("third Close blocked behind stale abort cleanup")
 	}
 
 	close(store.releaseAbort)

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -653,7 +653,6 @@ func TestSetWithAbandonedTopWriteSinkReturnsWhenContextExpires(t *testing.T) {
 
 func TestInvalidatedCleanupDoesNotHoldStateMu(t *testing.T) {
 	coord := &writeCoordinator{}
-	coord.stateChanged = sync.NewCond(&coord.stateMu)
 	coord.committedGeneration = 1
 
 	closeStarted := make(chan struct{})
@@ -815,7 +814,6 @@ func TestFanoutWriteManagerReleasesIdleLocksAfterConcurrentUse(t *testing.T) {
 func TestFanoutWriteManagerOrdersStaleCleanupBeforeNewerWrite(t *testing.T) {
 	var manager fanoutWriteManager
 	coord := &writeCoordinator{}
-	coord.stateChanged = sync.NewCond(&coord.stateMu)
 	coord.committedGeneration = 1
 
 	firstCloseStarted := make(chan struct{})

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -117,16 +117,16 @@ func TestLaterStagedBeginFailureDoesNotInvalidateOlderWriter(t *testing.T) {
 
 	select {
 	case err := <-olderDone:
-		t.Fatalf("older Close completed while later BeginStagedSet was still pending: %v", err)
-	case <-time.After(50 * time.Millisecond):
+		if err != nil {
+			t.Fatalf("older Close should publish while later BeginStagedSet is still pending, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("older Close blocked behind later BeginStagedSet")
 	}
 
 	close(store.releaseSecondBegin)
 	if err := <-secondDone; !errors.Is(err, beginErr) {
 		t.Fatalf("expected second BeginStagedSet error, got %v", err)
-	}
-	if err := <-olderDone; err != nil {
-		t.Fatalf("older Close should publish after later begin failure, got %v", err)
 	}
 }
 
@@ -241,6 +241,38 @@ func TestStaleStagedCloseAbortCleanupDoesNotBlockNewerCommit(t *testing.T) {
 	close(store.releaseAbort)
 	if err := <-olderDone; !errors.Is(err, ErrTopWriteInvalidated) {
 		t.Fatalf("expected older Close to be invalidated, got %v", err)
+	}
+}
+
+func TestStagedCloseWaitingForDeleteTimesOutAndReleasesReservation(t *testing.T) {
+	store := &stubStagingStore{}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: 25 * time.Millisecond,
+	}
+
+	writer, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v1"})
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+	defer writer.Abort()
+
+	coord := cache.topWrites.coordinator("key")
+	coord.beginDelete()
+
+	closeErr := writer.Close()
+	if !errors.Is(closeErr, context.DeadlineExceeded) {
+		t.Fatalf("expected close wait timeout, got %v", closeErr)
+	}
+
+	coord.finishDelete(false)
+	next, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v2"})
+	if err != nil {
+		t.Fatalf("next Set should not be poisoned by timed-out close, got %v", err)
+	}
+	if err := next.Close(); err != nil {
+		t.Fatalf("next Close should succeed, got %v", err)
 	}
 }
 

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -278,6 +278,43 @@ func TestStagedCloseWaitingForDeleteTimesOutAndReleasesReservation(t *testing.T)
 	}
 }
 
+func TestLegacyTopWriteCloseWaitingForDeleteTimesOut(t *testing.T) {
+	store := &countingBeginSetStore{}
+	cache := &DaramjweeCache{
+		tiers:        []Store{store},
+		opTimeout:    time.Second,
+		closeTimeout: 25 * time.Millisecond,
+	}
+
+	writer, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "v1"})
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+	defer writer.Abort()
+
+	coord := cache.topWrites.coordinator("key")
+	if err := coord.beginDelete(context.Background()); err != nil {
+		t.Fatalf("beginDelete failed: %v", err)
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- writer.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected close wait timeout, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		coord.finishDelete(false)
+		t.Fatal("legacy top write Close blocked past close timeout while delete was active")
+	}
+
+	coord.finishDelete(false)
+}
+
 func TestStagedCloseWaitingForCommitLeaseTimesOutAndReleasesReservation(t *testing.T) {
 	store := &blockingFirstCommitStagingStore{
 		commitStarted: make(chan struct{}),
@@ -494,6 +531,31 @@ func TestSetStreamToTopStoreWithGenerationHonorsCanceledContextWhileDeleteInProg
 	}
 }
 
+func TestConditionalGenerationWriteSinkWaitingForDeleteTimesOut(t *testing.T) {
+	coord := &writeCoordinator{}
+	coord.init()
+	if err := coord.beginDelete(context.Background()); err != nil {
+		t.Fatalf("beginDelete failed: %v", err)
+	}
+	defer coord.finishDelete(false)
+
+	sink := newConditionalGenerationWriteSink(&testWriteSink{}, coord, 1, 25*time.Millisecond, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sink.Close()
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected conditional close wait timeout, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("conditional generation Close blocked past close timeout while delete was active")
+	}
+}
+
 func TestSetWithAbandonedTopWriteSinkReturnsWhenContextExpires(t *testing.T) {
 	store := &countingBeginSetStore{}
 	cache := &DaramjweeCache{
@@ -551,7 +613,7 @@ func TestInvalidatedCleanupDoesNotHoldStateMu(t *testing.T) {
 			<-releaseClose
 			return nil
 		},
-	}, coord, 1, func() error {
+	}, coord, 1, time.Second, func() error {
 		close(cleanupStarted)
 		<-releaseCleanup
 		return nil
@@ -719,7 +781,7 @@ func TestFanoutWriteManagerOrdersStaleCleanupBeforeNewerWrite(t *testing.T) {
 				<-releaseFirstClose
 				return nil
 			},
-		}, coord, 1, func() error {
+		}, coord, 1, time.Second, func() error {
 			close(firstCleanupDone)
 			return nil
 		})
@@ -743,7 +805,7 @@ func TestFanoutWriteManagerOrdersStaleCleanupBeforeNewerWrite(t *testing.T) {
 				close(secondWriteDone)
 				return nil
 			},
-		}, coord, 2, nil)
+		}, coord, 2, time.Second, nil)
 		secondSinkDone <- sink.Close()
 	}()
 


### PR DESCRIPTION
## Summary
- replace writer-lifetime top write ownership with staged top-store commits for built-in staging stores
- track active top-write reservations so abort/failure/stale writers cannot poison later conditional fills
- preserve visible commit ordering while avoiding cache-level same-key locks across caller-controlled write lifetimes
- add liveness/fuzz coverage for abandoned writers, partial miss streams, stale writers, cancelation, and lock contention

## Pre-review checklist
Analyzed all past PR review comments before requesting remote review. Repeated themes checked against this diff:
- generation/stale ordering and silent discard behavior
- cleanup, abort, close, and rollback error paths
- context cancellation semantics for context-sensitive stores
- lock/deadlock/orphan resource behavior
- public API/store contract compatibility
- regression, race, and fuzz coverage

## Verification
- `git diff --check`
- `go test ./... -count=1 -timeout=180s`
- `DJ_LIVENESS_FUZZTIME=10s DJ_LIVENESS_TIMEOUT=90s DJ_LIVENESS_RACE=1 bash scripts/run_top_write_liveness_fuzz.sh`
- `DJ_RACE_COUNT=3 DJ_RACE_TIMEOUT=3m bash scripts/run_lock_contention_race.sh`

Note: `go vet ./...` currently reports an existing unrelated test issue in `constructor_validation_external_test.go` where `reflect.TypeOf` copies `DaramjweeCache` containing `atomic.Bool`; this branch did not introduce it.
