### PR TITLE
fix cache fill lock invalidation

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -38,6 +38,7 @@ type DaramjweeCache struct {
 	runtimeQueueLimit      int
 	opTimeout              time.Duration
 	closeTimeout           time.Duration
+	fillLeaseTimeout       time.Duration
 	positiveFreshness      time.Duration
 	negativeFreshness      time.Duration
 	tierFreshnessOverrides map[int]TierFreshnessOverride
@@ -61,6 +62,7 @@ func (c *DaramjweeCache) Get(ctx context.Context, key string, req GetRequest, fe
 	}
 	setupCtx, cancel := c.newCtxWithTimeout(ctx)
 	topGenerationAtStart := c.currentTopWriteGeneration(key)
+	higherTiersClean := true
 
 	for i, tier := range c.tiers {
 		tierStream, tierMeta, err := c.getStreamFromStore(c.getStreamContextForStore(ctx, setupCtx, tier), tier, key)
@@ -73,7 +75,7 @@ func (c *DaramjweeCache) Get(ctx context.Context, key string, req GetRequest, fe
 				}
 				return resp, nil
 			}
-			resp, respErr := c.handleLowerTierHit(ctx, setupCtx, key, i, req, fetcher, tierStream, tierMeta, cancel, topGenerationAtStart)
+			resp, respErr := c.handleLowerTierHit(ctx, setupCtx, key, i, req, fetcher, tierStream, tierMeta, cancel, topGenerationAtStart, higherTiersClean)
 			if respErr != nil {
 				cancel()
 				return nil, respErr
@@ -86,11 +88,12 @@ func (c *DaramjweeCache) Get(ctx context.Context, key string, req GetRequest, fe
 		}
 		if !errors.Is(err, ErrNotFound) {
 			c.errorLog("msg", "tier get failed", "key", key, "tier_index", i, "err", err)
+			higherTiersClean = false
 		}
 	}
 
 	// 3. Fetch from Origin
-	resp, respErr := c.handleMiss(ctx, setupCtx, key, req, fetcher, cancel, topGenerationAtStart)
+	resp, respErr := c.handleMiss(ctx, setupCtx, key, req, fetcher, cancel, topGenerationAtStart, higherTiersClean)
 	if respErr != nil {
 		cancel()
 		return nil, respErr
@@ -134,7 +137,9 @@ func (c *DaramjweeCache) Delete(ctx context.Context, key string) error {
 		return err
 	}
 	coord := c.topWrites.coordinator(key)
-	coord.beginDelete()
+	if err := coord.beginDelete(ctx); err != nil {
+		return err
+	}
 	topDeleteSucceeded := false
 	defer func() {
 		coord.finishDelete(topDeleteSucceeded)
@@ -211,7 +216,9 @@ func newSafeCloser(rc io.ReadCloser, cb func()) *safeCloser {
 func (c *safeCloser) Read(p []byte) (n int, err error) {
 	n, err = c.ReadCloser.Read(p)
 	if err == io.EOF {
-		c.Close() // 자동으로 닫기
+		if closeErr := c.Close(); closeErr != nil {
+			return n, closeErr
+		}
 	}
 	return n, err
 }

--- a/cache_context.go
+++ b/cache_context.go
@@ -2,6 +2,7 @@ package daramjwee
 
 import (
 	"context"
+	"errors"
 	"io"
 	"time"
 )
@@ -169,7 +170,17 @@ func (c *DaramjweeCache) statFromStore(ctx context.Context, store Store, key str
 }
 
 func (c *DaramjweeCache) fetchFromOrigin(ctx context.Context, fetcher Fetcher, oldMetadata *Metadata) (*FetchResult, error) {
-	return fetcher.Fetch(ctx, oldMetadata)
+	result, err := fetcher.Fetch(ctx, oldMetadata)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, errors.New("daramjwee: fetcher returned nil result")
+	}
+	if result.Body == nil {
+		return nil, errors.New("daramjwee: fetcher returned nil body")
+	}
+	return result, nil
 }
 
 func hasRealStore(store Store) bool {

--- a/cache_persist.go
+++ b/cache_persist.go
@@ -1,6 +1,9 @@
 package daramjwee
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 func (c *DaramjweeCache) persistDestinationsAfterTop() []tierDestination {
 	if len(c.tiers) <= 1 {
@@ -58,7 +61,11 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 			c.infoLog("msg", "starting background set", "key", key, "dest_tier", destTierIndex)
 			srcStream, meta, err := c.getStreamFromStore(persistCtx, srcStore, key)
 			if err != nil {
-				c.errorLog("msg", "failed to get stream from top store for background set", "key", key, "err", err)
+				if errors.Is(err, ErrNotFound) {
+					c.infoLog("msg", "skipping background set because top-tier entry is gone", "key", key, "dest_tier", destTierIndex)
+				} else {
+					c.errorLog("msg", "failed to get stream from top store for background set", "key", key, "err", err)
+				}
 				return
 			}
 			unlockFanout := c.fanoutWrites.lock(destTierIndex, key)
@@ -79,7 +86,11 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 			})
 
 			if persistErr := copyCloseSourceThenCommit(destWriter, srcStream); persistErr != nil {
-				c.errorLog("msg", "failed background set", "key", key, "dest_tier", destTierIndex, "err", persistErr)
+				if errors.Is(persistErr, ErrTopWriteInvalidated) {
+					c.infoLog("msg", "skipping background set because top-tier state changed", "key", key, "dest_tier", destTierIndex)
+				} else {
+					c.errorLog("msg", "failed background set", "key", key, "dest_tier", destTierIndex, "err", persistErr)
+				}
 				return
 			}
 			c.infoLog("msg", "background set successful", "key", key, "dest_tier", destTierIndex)

--- a/cache_persist.go
+++ b/cache_persist.go
@@ -1,9 +1,6 @@
 package daramjwee
 
-import (
-	"context"
-	"io"
-)
+import "context"
 
 func (c *DaramjweeCache) persistDestinationsAfterTop() []tierDestination {
 	if len(c.tiers) <= 1 {
@@ -64,13 +61,14 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 				c.errorLog("msg", "failed to get stream from top store for background set", "key", key, "err", err)
 				return
 			}
-			defer srcStream.Close()
-
 			unlockFanout := c.fanoutWrites.lock(destTierIndex, key)
 			defer unlockFanout()
 
 			destWriter, err := c.setStreamToStore(persistCtx, dest, key, meta)
 			if err != nil {
+				if closeErr := srcStream.Close(); closeErr != nil {
+					c.errorLog("msg", "failed to close source stream after destination writer failure", "key", key, "dest_tier", destTierIndex, "err", closeErr)
+				}
 				c.errorLog("msg", "failed to get writer for destination store", "key", key, "dest_tier", destTierIndex, "err", err)
 				return
 			}
@@ -80,16 +78,8 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 				return c.deleteFromStore(cleanupCtx, dest, key)
 			})
 
-			_, copyErr := io.Copy(destWriter, srcStream)
-			var closeErr error
-			if copyErr != nil {
-				closeErr = destWriter.Abort()
-			} else {
-				closeErr = destWriter.Close()
-			}
-
-			if copyErr != nil || closeErr != nil {
-				c.errorLog("msg", "failed background set", "key", key, "dest_tier", destTierIndex, "copyErr", copyErr, "closeErr", closeErr)
+			if persistErr := copyCloseSourceThenCommit(destWriter, srcStream); persistErr != nil {
+				c.errorLog("msg", "failed background set", "key", key, "dest_tier", destTierIndex, "err", persistErr)
 				return
 			}
 			c.infoLog("msg", "background set successful", "key", key, "dest_tier", destTierIndex)

--- a/cache_read.go
+++ b/cache_read.go
@@ -164,7 +164,7 @@ func (c *DaramjweeCache) promoteNegativeLowerTierHit(requestCtx, setupCtx contex
 		closeErr := src.Close()
 		if closeErr != nil {
 			cancel()
-			return nil, closeErr
+			return nil, errors.Join(err, closeErr)
 		}
 		if errors.Is(err, ErrTopWriteInvalidated) {
 			cancel()
@@ -223,10 +223,8 @@ func (c *DaramjweeCache) promoteLowerTierHitToTop(requestCtx, setupCtx context.C
 		if errors.Is(err, ErrTopWriteInvalidated) {
 			return lowerTierPromotionInvalidatedError{preserveBody: true}
 		}
-		if !errors.Is(err, ErrTopWriteInvalidated) {
-			_ = src.Close()
-		}
-		return err
+		closeErr := src.Close()
+		return errors.Join(err, closeErr)
 	}
 	if _, copyErr := io.Copy(writer, src); copyErr != nil {
 		abortErr := writer.Abort()
@@ -239,11 +237,11 @@ func (c *DaramjweeCache) promoteLowerTierHitToTop(requestCtx, setupCtx context.C
 		return errors.Join(srcErr, abortErr)
 	}
 	closeErr := writer.Close()
-	if closeErr != nil || srcErr != nil {
+	if closeErr != nil {
 		if errors.Is(closeErr, ErrTopWriteInvalidated) {
-			return errors.Join(lowerTierPromotionInvalidatedError{preserveBody: false}, closeErr, srcErr)
+			return errors.Join(lowerTierPromotionInvalidatedError{preserveBody: false}, closeErr)
 		}
-		return errors.Join(closeErr, srcErr)
+		return closeErr
 	}
 	if destinations := c.regularFanoutDestinations(tierIndex); len(destinations) > 0 {
 		c.schedulePersistFromCurrentTop(requestCtx, key, destinations...)

--- a/cache_read.go
+++ b/cache_read.go
@@ -188,7 +188,11 @@ func (c *DaramjweeCache) promoteNegativeLowerTierHit(requestCtx, setupCtx contex
 	}
 	cancel()
 	if closeErr != nil {
-		c.warnLog("msg", "failed to publish negative entry to top tier", "key", key, "err", closeErr)
+		if errors.Is(closeErr, ErrTopWriteInvalidated) {
+			c.infoLog("msg", "skipping negative promotion because top-tier state changed", "key", key)
+		} else {
+			c.warnLog("msg", "failed to publish negative entry to top tier", "key", key, "err", closeErr)
+		}
 	}
 	return newGetResponse(GetStatusNotFound, nil, meta), nil
 }

--- a/cache_read.go
+++ b/cache_read.go
@@ -20,7 +20,9 @@ func (c *DaramjweeCache) handleTopTierHit(requestCtx context.Context, key string
 	streamCloser := newSafeCloser(stream, callback)
 
 	if meta.IsNegative {
-		streamCloser.Close()
+		if err := streamCloser.Close(); err != nil {
+			return nil, err
+		}
 		return newGetResponse(GetStatusNotFound, nil, meta), nil
 	}
 
@@ -53,7 +55,7 @@ func (c *DaramjweeCache) topTierCloseCallback(requestCtx context.Context, key st
 }
 
 // handleLowerTierHit processes the logic when an object is found in a lower tier.
-func (c *DaramjweeCache) handleLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, req GetRequest, fetcher Fetcher, src io.ReadCloser, meta *Metadata, cancel context.CancelFunc, expectedGeneration uint64) (*GetResponse, error) {
+func (c *DaramjweeCache) handleLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, req GetRequest, fetcher Fetcher, src io.ReadCloser, meta *Metadata, cancel context.CancelFunc, expectedGeneration uint64, higherTiersClean bool) (*GetResponse, error) {
 	c.debugLog("msg", "lower tier hit, promoting to top tier", "key", key, "tier_index", tierIndex)
 
 	metaToPromote := cloneMetadata(meta)
@@ -63,23 +65,42 @@ func (c *DaramjweeCache) handleLowerTierHit(requestCtx, setupCtx context.Context
 
 	isStale := c.isTierCachedStale(meta, tierIndex)
 	if c.isConditionalRequestSatisfied(req, meta) {
+		if !higherTiersClean {
+			return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(src, cancel), meta), nil
+		}
 		return c.handleConditionalLowerTierHit(requestCtx, setupCtx, key, tierIndex, fetcher, src, meta, metaToPromote, cancel, isStale, expectedGeneration)
 	}
-	if isStale {
-		return c.handleStaleLowerTierHit(requestCtx, key, tierIndex, fetcher, src, meta, cancel, expectedGeneration), nil
-	}
 	if meta.IsNegative {
-		return c.promoteNegativeLowerTierHit(requestCtx, setupCtx, key, tierIndex, src, meta, metaToPromote, cancel, expectedGeneration), nil
+		if !higherTiersClean {
+			if err := src.Close(); err != nil {
+				cancel()
+				return nil, err
+			}
+			cancel()
+			return newGetResponse(GetStatusNotFound, nil, meta), nil
+		}
+		if isStale {
+			return c.handleStaleLowerTierHit(requestCtx, key, tierIndex, fetcher, src, meta, cancel, expectedGeneration)
+		}
+		return c.promoteNegativeLowerTierHit(requestCtx, setupCtx, key, tierIndex, src, meta, metaToPromote, cancel, expectedGeneration)
+	}
+	if isStale {
+		if !higherTiersClean {
+			return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(src, cancel), meta), nil
+		}
+		return c.handleStaleLowerTierHit(requestCtx, key, tierIndex, fetcher, src, meta, cancel, expectedGeneration)
+	}
+	if !higherTiersClean {
+		return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(src, cancel), meta), nil
 	}
 	return c.promotePositiveLowerTierHit(requestCtx, setupCtx, key, tierIndex, src, meta, metaToPromote, cancel, expectedGeneration), nil
 }
 
-func (c *DaramjweeCache) handleConditionalLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, fetcher Fetcher, src io.ReadCloser, meta, metaToPromote *Metadata, cancel context.CancelFunc, isStale bool, expectedGeneration uint64) (*GetResponse, error) {
-	if !isStale {
-		if err := c.promoteLowerTierHitToTop(requestCtx, setupCtx, key, tierIndex, src, metaToPromote, expectedGeneration); err != nil {
-			return c.handleConditionalLowerTierPromotionError(key, tierIndex, err, src, meta, cancel), nil
-		}
-	} else if err := src.Close(); err != nil {
+func (c *DaramjweeCache) handleConditionalLowerTierHit(requestCtx, _ context.Context, key string, tierIndex int, fetcher Fetcher, src io.ReadCloser, meta, _ *Metadata, cancel context.CancelFunc, isStale bool, expectedGeneration uint64) (*GetResponse, error) {
+	if !c.canServeConditionalLowerHit(key, expectedGeneration) {
+		return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(src, cancel), meta), nil
+	}
+	if err := src.Close(); err != nil {
 		cancel()
 		return nil, err
 	}
@@ -92,6 +113,18 @@ func (c *DaramjweeCache) handleConditionalLowerTierHit(requestCtx, setupCtx cont
 	}
 	cancel()
 	return newGetResponse(GetStatusNotModified, nil, meta), nil
+}
+
+func (c *DaramjweeCache) canServeConditionalLowerHit(key string, expectedGeneration uint64) bool {
+	return c.canAttemptExpectedTopWrite(key, expectedGeneration)
+}
+
+func (c *DaramjweeCache) canAttemptExpectedTopWrite(key string, expectedGeneration uint64) bool {
+	coord := c.topWrites.coordinatorIfPresent(key)
+	if coord == nil {
+		return expectedGeneration == 0
+	}
+	return coord.canAttemptExpectedTopWrite(expectedGeneration)
 }
 
 func (c *DaramjweeCache) handleConditionalLowerTierPromotionError(key string, tierIndex int, err error, src io.ReadCloser, meta *Metadata, cancel context.CancelFunc) *GetResponse {
@@ -111,33 +144,42 @@ func (c *DaramjweeCache) handleConditionalLowerTierPromotionError(key string, ti
 	return newGetResponse(GetStatusNotModified, nil, meta)
 }
 
-func (c *DaramjweeCache) handleStaleLowerTierHit(requestCtx context.Context, key string, tierIndex int, fetcher Fetcher, src io.ReadCloser, meta *Metadata, cancel context.CancelFunc, expectedGeneration uint64) *GetResponse {
+func (c *DaramjweeCache) handleStaleLowerTierHit(requestCtx context.Context, key string, tierIndex int, fetcher Fetcher, src io.ReadCloser, meta *Metadata, cancel context.CancelFunc, expectedGeneration uint64) (*GetResponse, error) {
 	c.debugLog("msg", "lower tier is stale, serving stale and scheduling refresh", "key", key, "tier_index", tierIndex)
 	source := tierDestination{tierIndex: tierIndex, store: c.tiers[tierIndex]}
 	streamCloser := newSafeCloser(src, c.lowerTierRefreshOnCloseCallback(requestCtx, key, fetcher, cancel, meta, source, expectedGeneration))
 	if meta.IsNegative {
-		streamCloser.Close()
-		return newGetResponse(GetStatusNotFound, nil, meta)
+		if err := streamCloser.Close(); err != nil {
+			return nil, err
+		}
+		return newGetResponse(GetStatusNotFound, nil, meta), nil
 	}
-	return newGetResponse(GetStatusOK, streamCloser, meta)
+	return newGetResponse(GetStatusOK, streamCloser, meta), nil
 }
 
-func (c *DaramjweeCache) promoteNegativeLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, meta, metaToPromote *Metadata, cancel context.CancelFunc, expectedGeneration uint64) *GetResponse {
+func (c *DaramjweeCache) promoteNegativeLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, meta, metaToPromote *Metadata, cancel context.CancelFunc, expectedGeneration uint64) (*GetResponse, error) {
 	target := c.topWriteStore()
-	writer, err := c.setStreamToTopStoreWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, target), key, metaToPromote, &expectedGeneration)
+	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, target), key, metaToPromote, &expectedGeneration)
 	if err != nil {
-		if errors.Is(err, ErrTopWriteInvalidated) {
-			_ = src.Close()
+		closeErr := src.Close()
+		if closeErr != nil {
 			cancel()
-			return newGetResponse(GetStatusNotFound, nil, meta)
+			return nil, closeErr
+		}
+		if errors.Is(err, ErrTopWriteInvalidated) {
+			cancel()
+			return newGetResponse(GetStatusNotFound, nil, meta), nil
 		}
 		c.warnLog("msg", "failed to acquire top-tier sink for negative promotion", "key", key, "err", err)
-		_ = src.Close()
 		cancel()
-		return newGetResponse(GetStatusNotFound, nil, meta)
+		return newGetResponse(GetStatusNotFound, nil, meta), nil
 	}
 
-	_ = src.Close()
+	if closeErr := src.Close(); closeErr != nil {
+		abortErr := writer.Abort()
+		cancel()
+		return nil, errors.Join(closeErr, abortErr)
+	}
 	closeErr := writer.Close()
 	if closeErr == nil {
 		if destinations := c.regularFanoutDestinations(tierIndex); len(destinations) > 0 {
@@ -148,12 +190,12 @@ func (c *DaramjweeCache) promoteNegativeLowerTierHit(requestCtx, setupCtx contex
 	if closeErr != nil {
 		c.warnLog("msg", "failed to publish negative entry to top tier", "key", key, "err", closeErr)
 	}
-	return newGetResponse(GetStatusNotFound, nil, meta)
+	return newGetResponse(GetStatusNotFound, nil, meta), nil
 }
 
 func (c *DaramjweeCache) promotePositiveLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, meta, metaToPromote *Metadata, cancel context.CancelFunc, expectedGeneration uint64) *GetResponse {
 	target := c.topWriteStore()
-	writer, err := c.setStreamToTopStoreWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, target), key, metaToPromote, &expectedGeneration)
+	writer, err := c.setStreamToTopStoreForFill(c.beginSetContextForStore(requestCtx, setupCtx, target), key, metaToPromote, expectedGeneration)
 	if err != nil {
 		if errors.Is(err, ErrTopWriteInvalidated) {
 			return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(src, cancel), meta)
@@ -169,7 +211,9 @@ func (c *DaramjweeCache) promotePositiveLowerTierHit(requestCtx, setupCtx contex
 			c.schedulePersistFromCurrentTop(requestCtx, key, destinations...)
 		}
 	}
-	return newGetResponse(GetStatusOK, streamThrough(src, writer, cancel, onPublish), meta)
+	return newGetResponse(GetStatusOK, streamThroughWithTrace(src, writer, cancel, onPublish, func(event string, keyvals ...any) {
+		c.diagnosticLog(event, key, expectedGeneration, keyvals...)
+	}), meta)
 }
 
 func (c *DaramjweeCache) promoteLowerTierHitToTop(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, metadata *Metadata, expectedGeneration uint64) error {
@@ -189,8 +233,12 @@ func (c *DaramjweeCache) promoteLowerTierHitToTop(requestCtx, setupCtx context.C
 		closeErr := src.Close()
 		return errors.Join(copyErr, abortErr, closeErr)
 	}
-	closeErr := writer.Close()
 	srcErr := src.Close()
+	if srcErr != nil {
+		abortErr := writer.Abort()
+		return errors.Join(srcErr, abortErr)
+	}
+	closeErr := writer.Close()
 	if closeErr != nil || srcErr != nil {
 		if errors.Is(closeErr, ErrTopWriteInvalidated) {
 			return errors.Join(lowerTierPromotionInvalidatedError{preserveBody: false}, closeErr, srcErr)
@@ -204,7 +252,7 @@ func (c *DaramjweeCache) promoteLowerTierHitToTop(requestCtx, setupCtx context.C
 }
 
 // handleMiss processes the logic when an object is not found in any tier.
-func (c *DaramjweeCache) handleMiss(requestCtx, setupCtx context.Context, key string, req GetRequest, fetcher Fetcher, cancel context.CancelFunc, expectedGeneration uint64) (*GetResponse, error) {
+func (c *DaramjweeCache) handleMiss(requestCtx, setupCtx context.Context, key string, req GetRequest, fetcher Fetcher, cancel context.CancelFunc, expectedGeneration uint64, higherTiersClean bool) (*GetResponse, error) {
 	c.debugLog("msg", "full cache miss, fetching from origin", "key", key)
 
 	var oldMetadata *Metadata
@@ -214,7 +262,7 @@ func (c *DaramjweeCache) handleMiss(requestCtx, setupCtx context.Context, key st
 
 	result, err := c.fetchFromOrigin(c.fetchContextForFetcher(requestCtx, setupCtx, fetcher), fetcher, oldMetadata)
 	if err != nil {
-		return c.handleMissFetchError(requestCtx, setupCtx, key, req, cancel, fetcher, err, expectedGeneration)
+		return c.handleMissFetchError(requestCtx, setupCtx, key, req, cancel, fetcher, err, expectedGeneration, higherTiersClean)
 	}
 
 	if result.Metadata == nil {
@@ -222,14 +270,25 @@ func (c *DaramjweeCache) handleMiss(requestCtx, setupCtx context.Context, key st
 	}
 	result.Metadata.CachedAt = time.Now()
 
+	if !higherTiersClean {
+		return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(result.Body, cancel), result.Metadata), nil
+	}
 	return c.publishMissResult(requestCtx, setupCtx, key, result, cancel, expectedGeneration), nil
 }
 
-func (c *DaramjweeCache) handleMissFetchError(requestCtx, setupCtx context.Context, key string, req GetRequest, cancel context.CancelFunc, fetcher Fetcher, fetchErr error, expectedGeneration uint64) (*GetResponse, error) {
+func (c *DaramjweeCache) handleMissFetchError(requestCtx, setupCtx context.Context, key string, req GetRequest, cancel context.CancelFunc, fetcher Fetcher, fetchErr error, expectedGeneration uint64, higherTiersClean bool) (*GetResponse, error) {
 	if errors.Is(fetchErr, ErrCacheableNotFound) {
+		if !higherTiersClean {
+			cancel()
+			return newGetResponse(GetStatusNotFound, nil, &Metadata{IsNegative: true, CachedAt: time.Now()}), nil
+		}
 		return c.handleNegativeCacheWithGeneration(requestCtx, setupCtx, key, cancel, &expectedGeneration)
 	}
 	if errors.Is(fetchErr, ErrNotModified) {
+		if !higherTiersClean {
+			cancel()
+			return nil, errors.New("daramjwee: origin returned not modified after unreadable cache tier")
+		}
 		return c.replayTopTierAfterNotModified(requestCtx, setupCtx, key, req, cancel)
 	}
 	return nil, fetchErr
@@ -242,12 +301,18 @@ func (c *DaramjweeCache) replayTopTierAfterNotModified(requestCtx, setupCtx cont
 		if errors.Is(err, ErrNilMetadata) {
 			return nil, err
 		}
-		c.warnLog("msg", "hot cache entry not found after 304 from origin", "key", key, "err", err)
+		if !errors.Is(err, ErrNotFound) {
+			cancel()
+			return nil, err
+		}
 		cancel()
-		return newGetResponse(GetStatusNotFound, nil, nil), nil
+		return nil, errors.New("daramjwee: origin returned not modified but cached body is unavailable")
 	}
 	if meta.IsNegative {
-		stream.Close()
+		if err := stream.Close(); err != nil {
+			cancel()
+			return nil, err
+		}
 		cancel()
 		return newGetResponse(GetStatusNotFound, nil, meta), nil
 	}
@@ -264,7 +329,7 @@ func (c *DaramjweeCache) replayTopTierAfterNotModified(requestCtx, setupCtx cont
 
 func (c *DaramjweeCache) publishMissResult(requestCtx, setupCtx context.Context, key string, result *FetchResult, cancel context.CancelFunc, expectedGeneration uint64) *GetResponse {
 	target := c.topWriteStore()
-	writer, err := c.setStreamToTopStoreWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, target), key, result.Metadata, &expectedGeneration)
+	writer, err := c.setStreamToTopStoreForFill(c.beginSetContextForStore(requestCtx, setupCtx, target), key, result.Metadata, expectedGeneration)
 	if err != nil {
 		if errors.Is(err, ErrTopWriteInvalidated) {
 			return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(result.Body, cancel), result.Metadata)
@@ -273,8 +338,10 @@ func (c *DaramjweeCache) publishMissResult(requestCtx, setupCtx context.Context,
 		return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(result.Body, cancel), result.Metadata)
 	}
 
-	return newGetResponse(GetStatusOK, streamThrough(result.Body, writer, cancel, func() {
+	return newGetResponse(GetStatusOK, streamThroughWithTrace(result.Body, writer, cancel, func() {
 		c.schedulePersistFromCurrentTop(requestCtx, key, c.persistDestinationsAfterTop()...)
+	}, func(event string, keyvals ...any) {
+		c.diagnosticLog(event, key, expectedGeneration, keyvals...)
 	}), result.Metadata)
 }
 

--- a/cache_read_test.go
+++ b/cache_read_test.go
@@ -31,6 +31,59 @@ func TestHandleConditionalLowerTierPromotionError_CancelsOnGenericPromotionFailu
 	require.Equal(t, "cache-v1", resp.Metadata.CacheTag)
 }
 
+func TestPromoteNegativeLowerTierHitJoinsWriterSetupAndSourceCloseErrors(t *testing.T) {
+	writerSetupErr := errors.New("writer setup failed")
+	sourceCloseErr := errors.New("source close failed")
+	cache := &DaramjweeCache{
+		tiers:  []Store{&cacheReadFailingBeginSetStore{err: writerSetupErr}},
+		logger: log.NewNopLogger(),
+	}
+	src := &closeErrorReadCloser{err: sourceCloseErr}
+	canceled := false
+
+	resp, err := cache.promoteNegativeLowerTierHit(
+		context.Background(),
+		context.Background(),
+		"key",
+		1,
+		src,
+		&Metadata{IsNegative: true},
+		&Metadata{IsNegative: true},
+		func() { canceled = true },
+		0,
+	)
+
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, writerSetupErr)
+	require.ErrorIs(t, err, sourceCloseErr)
+	require.True(t, canceled)
+	require.True(t, src.closed)
+}
+
+func TestPromoteLowerTierHitToTopJoinsWriterSetupAndSourceCloseErrors(t *testing.T) {
+	writerSetupErr := errors.New("writer setup failed")
+	sourceCloseErr := errors.New("source close failed")
+	cache := &DaramjweeCache{
+		tiers:  []Store{&cacheReadFailingBeginSetStore{err: writerSetupErr}},
+		logger: log.NewNopLogger(),
+	}
+	src := &closeErrorReadCloser{err: sourceCloseErr}
+
+	err := cache.promoteLowerTierHitToTop(
+		context.Background(),
+		context.Background(),
+		"key",
+		1,
+		src,
+		&Metadata{},
+		0,
+	)
+
+	require.ErrorIs(t, err, writerSetupErr)
+	require.ErrorIs(t, err, sourceCloseErr)
+	require.True(t, src.closed)
+}
+
 func TestFetchFromOriginRejectsNilResult(t *testing.T) {
 	cache := &DaramjweeCache{}
 
@@ -50,6 +103,38 @@ func TestFetchFromOriginRejectsNilBody(t *testing.T) {
 type noopReader struct{}
 
 func (noopReader) Read(p []byte) (int, error) { return 0, io.EOF }
+
+type cacheReadFailingBeginSetStore struct {
+	err error
+}
+
+func (s *cacheReadFailingBeginSetStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *cacheReadFailingBeginSetStore) BeginSet(context.Context, string, *Metadata) (WriteSink, error) {
+	return nil, s.err
+}
+
+func (s *cacheReadFailingBeginSetStore) Delete(context.Context, string) error {
+	return nil
+}
+
+func (s *cacheReadFailingBeginSetStore) Stat(context.Context, string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type closeErrorReadCloser struct {
+	err    error
+	closed bool
+}
+
+func (r *closeErrorReadCloser) Read(p []byte) (int, error) { return 0, io.EOF }
+
+func (r *closeErrorReadCloser) Close() error {
+	r.closed = true
+	return r.err
+}
 
 type nilResultFetcher struct{}
 

--- a/cache_read_test.go
+++ b/cache_read_test.go
@@ -1,6 +1,7 @@
 package daramjwee
 
 import (
+	"context"
 	"errors"
 	"io"
 	"testing"
@@ -30,6 +31,34 @@ func TestHandleConditionalLowerTierPromotionError_CancelsOnGenericPromotionFailu
 	require.Equal(t, "cache-v1", resp.Metadata.CacheTag)
 }
 
+func TestFetchFromOriginRejectsNilResult(t *testing.T) {
+	cache := &DaramjweeCache{}
+
+	_, err := cache.fetchFromOrigin(context.Background(), nilResultFetcher{}, nil)
+
+	require.ErrorContains(t, err, "fetcher returned nil result")
+}
+
+func TestFetchFromOriginRejectsNilBody(t *testing.T) {
+	cache := &DaramjweeCache{}
+
+	_, err := cache.fetchFromOrigin(context.Background(), nilBodyFetcher{}, nil)
+
+	require.ErrorContains(t, err, "fetcher returned nil body")
+}
+
 type noopReader struct{}
 
 func (noopReader) Read(p []byte) (int, error) { return 0, io.EOF }
+
+type nilResultFetcher struct{}
+
+func (nilResultFetcher) Fetch(context.Context, *Metadata) (*FetchResult, error) {
+	return nil, nil
+}
+
+type nilBodyFetcher struct{}
+
+func (nilBodyFetcher) Fetch(context.Context, *Metadata) (*FetchResult, error) {
+	return &FetchResult{Metadata: &Metadata{}}, nil
+}

--- a/cache_read_test.go
+++ b/cache_read_test.go
@@ -1,6 +1,7 @@
 package daramjwee
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -84,6 +85,71 @@ func TestPromoteLowerTierHitToTopJoinsWriterSetupAndSourceCloseErrors(t *testing
 	require.True(t, src.closed)
 }
 
+func TestPromoteRefreshFallbackToTopPreservesInvalidationOnSourceCloseSuccess(t *testing.T) {
+	meta := &Metadata{CacheTag: "v1"}
+	cache := &DaramjweeCache{
+		tiers: []Store{
+			&cacheReadFailingBeginSetStore{err: ErrTopWriteInvalidated},
+			&cacheReadSourceStore{metadata: meta, body: []byte("value")},
+		},
+		logger: log.NewNopLogger(),
+	}
+
+	err := cache.promoteRefreshFallbackToTop(
+		context.Background(),
+		"key",
+		tierDestination{tierIndex: 1, store: cache.tiers[1]},
+		meta,
+		0,
+	)
+
+	require.ErrorIs(t, err, ErrTopWriteInvalidated)
+}
+
+func TestPromoteRefreshFallbackToTopJoinsInvalidationAndSourceCloseError(t *testing.T) {
+	sourceCloseErr := errors.New("source close failed")
+	meta := &Metadata{CacheTag: "v1"}
+	cache := &DaramjweeCache{
+		tiers: []Store{
+			&cacheReadFailingBeginSetStore{err: ErrTopWriteInvalidated},
+			&cacheReadSourceStore{metadata: meta, body: []byte("value"), closeErr: sourceCloseErr},
+		},
+		logger: log.NewNopLogger(),
+	}
+
+	err := cache.promoteRefreshFallbackToTop(
+		context.Background(),
+		"key",
+		tierDestination{tierIndex: 1, store: cache.tiers[1]},
+		meta,
+		0,
+	)
+
+	require.ErrorIs(t, err, ErrTopWriteInvalidated)
+	require.ErrorIs(t, err, sourceCloseErr)
+}
+
+func TestPromoteRefreshFallbackToTopPreservesNegativeInvalidation(t *testing.T) {
+	meta := &Metadata{CacheTag: "v1", IsNegative: true}
+	cache := &DaramjweeCache{
+		tiers: []Store{
+			&cacheReadFailingBeginSetStore{err: ErrTopWriteInvalidated},
+			&cacheReadSourceStore{metadata: meta},
+		},
+		logger: log.NewNopLogger(),
+	}
+
+	err := cache.promoteRefreshFallbackToTop(
+		context.Background(),
+		"key",
+		tierDestination{tierIndex: 1, store: cache.tiers[1]},
+		meta,
+		0,
+	)
+
+	require.ErrorIs(t, err, ErrTopWriteInvalidated)
+}
+
 func TestFetchFromOriginRejectsNilResult(t *testing.T) {
 	cache := &DaramjweeCache{}
 
@@ -134,6 +200,31 @@ func (r *closeErrorReadCloser) Read(p []byte) (int, error) { return 0, io.EOF }
 func (r *closeErrorReadCloser) Close() error {
 	r.closed = true
 	return r.err
+}
+
+type cacheReadSourceStore struct {
+	metadata *Metadata
+	body     []byte
+	closeErr error
+}
+
+func (s *cacheReadSourceStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	if s.closeErr != nil {
+		return &closeErrorReadCloser{err: s.closeErr}, cloneMetadata(s.metadata), nil
+	}
+	return io.NopCloser(bytes.NewReader(s.body)), cloneMetadata(s.metadata), nil
+}
+
+func (s *cacheReadSourceStore) BeginSet(context.Context, string, *Metadata) (WriteSink, error) {
+	return nil, errors.New("unexpected BeginSet")
+}
+
+func (s *cacheReadSourceStore) Delete(context.Context, string) error {
+	return nil
+}
+
+func (s *cacheReadSourceStore) Stat(context.Context, string) (*Metadata, error) {
+	return cloneMetadata(s.metadata), nil
 }
 
 type nilResultFetcher struct{}

--- a/cache_read_test.go
+++ b/cache_read_test.go
@@ -150,6 +150,48 @@ func TestPromoteRefreshFallbackToTopPreservesNegativeInvalidation(t *testing.T) 
 	require.ErrorIs(t, err, ErrTopWriteInvalidated)
 }
 
+func TestPromoteRefreshFallbackToTopSkipsMissingNegativeSource(t *testing.T) {
+	meta := &Metadata{CacheTag: "v1", IsNegative: true}
+	cache := &DaramjweeCache{
+		tiers: []Store{
+			&cacheReadFailingBeginSetStore{err: errors.New("unexpected BeginSet")},
+			&cacheReadSourceStore{metadata: meta, statErr: ErrNotFound},
+		},
+		logger: log.NewNopLogger(),
+	}
+
+	err := cache.promoteRefreshFallbackToTop(
+		context.Background(),
+		"key",
+		tierDestination{tierIndex: 1, store: cache.tiers[1]},
+		meta,
+		0,
+	)
+
+	require.NoError(t, err)
+}
+
+func TestPromoteRefreshFallbackToTopSkipsMissingSourceStream(t *testing.T) {
+	meta := &Metadata{CacheTag: "v1"}
+	cache := &DaramjweeCache{
+		tiers: []Store{
+			&cacheReadFailingBeginSetStore{err: errors.New("unexpected BeginSet")},
+			&cacheReadSourceStore{metadata: meta, getErr: ErrNotFound},
+		},
+		logger: log.NewNopLogger(),
+	}
+
+	err := cache.promoteRefreshFallbackToTop(
+		context.Background(),
+		"key",
+		tierDestination{tierIndex: 1, store: cache.tiers[1]},
+		meta,
+		0,
+	)
+
+	require.NoError(t, err)
+}
+
 func TestFetchFromOriginRejectsNilResult(t *testing.T) {
 	cache := &DaramjweeCache{}
 
@@ -206,9 +248,14 @@ type cacheReadSourceStore struct {
 	metadata *Metadata
 	body     []byte
 	closeErr error
+	getErr   error
+	statErr  error
 }
 
 func (s *cacheReadSourceStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	if s.getErr != nil {
+		return nil, nil, s.getErr
+	}
 	if s.closeErr != nil {
 		return &closeErrorReadCloser{err: s.closeErr}, cloneMetadata(s.metadata), nil
 	}
@@ -224,6 +271,9 @@ func (s *cacheReadSourceStore) Delete(context.Context, string) error {
 }
 
 func (s *cacheReadSourceStore) Stat(context.Context, string) (*Metadata, error) {
+	if s.statErr != nil {
+		return nil, s.statErr
+	}
 	return cloneMetadata(s.metadata), nil
 }
 

--- a/cache_refresh.go
+++ b/cache_refresh.go
@@ -46,7 +46,7 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 			oldMetadata = &copied
 		}
 
-		result, err := fetcher.Fetch(refreshCtx, oldMetadata)
+		result, err := c.fetchFromOrigin(refreshCtx, fetcher, oldMetadata)
 		if err != nil {
 			if errors.Is(err, ErrCacheableNotFound) {
 				c.debugLog("msg", "re-caching as negative entry during background refresh", "key", key)

--- a/cache_refresh.go
+++ b/cache_refresh.go
@@ -155,9 +155,6 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 		}
 		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, metaToPromote, &expectedGeneration)
 		if err != nil {
-			if errors.Is(err, ErrTopWriteInvalidated) {
-				return nil
-			}
 			return err
 		}
 		if err := writer.Close(); err != nil {
@@ -180,9 +177,6 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, metaToPromote, &expectedGeneration)
 	if err != nil {
 		closeErr := srcStream.Close()
-		if errors.Is(err, ErrTopWriteInvalidated) {
-			return closeErr
-		}
 		return errors.Join(err, closeErr)
 	}
 

--- a/cache_refresh.go
+++ b/cache_refresh.go
@@ -148,6 +148,9 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 	if metaToPromote.IsNegative {
 		sourceMeta, err := c.statFromStore(ctx, source.store, key)
 		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return nil
+			}
 			return err
 		}
 		if !sameCacheEntry(sourceMeta, fallbackMetadata) {
@@ -168,6 +171,9 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 
 	srcStream, sourceMeta, err := c.getStreamFromStore(ctx, source.store, key)
 	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil
+		}
 		return err
 	}
 	if !sameCacheEntry(sourceMeta, fallbackMetadata) {

--- a/cache_refresh.go
+++ b/cache_refresh.go
@@ -65,33 +65,27 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 			}
 			return
 		}
-		defer result.Body.Close()
-
 		if result.Metadata == nil {
 			result.Metadata = &Metadata{}
 		}
 		result.Metadata.CachedAt = time.Now()
 
-		writer, err := c.setStreamToTopStoreWithGeneration(refreshCtx, key, result.Metadata, &expectedGeneration)
+		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(refreshCtx, key, result.Metadata, &expectedGeneration)
 		if err != nil {
+			closeErr := result.Body.Close()
 			if errors.Is(err, ErrTopWriteInvalidated) {
+				if closeErr != nil {
+					c.warnLog("msg", "failed to close skipped refresh body", "key", key, "err", closeErr)
+				}
 				c.infoLog("msg", "skipping background refresh publish because top-tier state changed", "key", key)
 				return
 			}
-			c.errorLog("msg", "failed to get cache writer for refresh", "key", key, "err", err)
+			c.errorLog("msg", "failed to get cache writer for refresh", "key", key, "err", errors.Join(err, closeErr))
 			return
 		}
 
-		_, copyErr := io.Copy(writer, result.Body)
-		var closeErr error
-		if copyErr != nil {
-			closeErr = writer.Abort()
-		} else {
-			closeErr = writer.Close()
-		}
-
-		if copyErr != nil || closeErr != nil {
-			c.errorLog("msg", "failed background set", "key", key, "copyErr", copyErr, "closeErr", closeErr)
+		if publishErr := copyCloseSourceThenCommit(writer, result.Body); publishErr != nil {
+			c.errorLog("msg", "failed background set", "key", key, "err", publishErr)
 		} else {
 			c.infoLog("msg", "background set successful", "key", key)
 			c.schedulePersistFromCurrentTop(refreshCtx, key, c.persistDestinationsAfterTop()...)
@@ -140,7 +134,14 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 	metaToPromote.CachedAt = time.Now()
 
 	if metaToPromote.IsNegative {
-		writer, err := c.setStreamToTopStoreWithGeneration(ctx, key, metaToPromote, &expectedGeneration)
+		sourceMeta, err := c.statFromStore(ctx, source.store, key)
+		if err != nil {
+			return err
+		}
+		if !sameCacheEntry(sourceMeta, fallbackMetadata) {
+			return nil
+		}
+		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, metaToPromote, &expectedGeneration)
 		if err != nil {
 			if errors.Is(err, ErrTopWriteInvalidated) {
 				return nil
@@ -156,25 +157,24 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 		return nil
 	}
 
-	srcStream, _, err := c.getStreamFromStore(ctx, source.store, key)
+	srcStream, sourceMeta, err := c.getStreamFromStore(ctx, source.store, key)
 	if err != nil {
 		return err
 	}
-	defer srcStream.Close()
+	if !sameCacheEntry(sourceMeta, fallbackMetadata) {
+		return srcStream.Close()
+	}
 
-	writer, err := c.setStreamToTopStoreWithGeneration(ctx, key, metaToPromote, &expectedGeneration)
+	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, metaToPromote, &expectedGeneration)
 	if err != nil {
+		closeErr := srcStream.Close()
 		if errors.Is(err, ErrTopWriteInvalidated) {
-			return nil
+			return closeErr
 		}
-		return err
+		return errors.Join(err, closeErr)
 	}
 
-	if _, copyErr := io.Copy(writer, srcStream); copyErr != nil {
-		abortErr := writer.Abort()
-		return errors.Join(copyErr, abortErr)
-	}
-	if err := writer.Close(); err != nil {
+	if err := copyCloseSourceThenCommit(writer, srcStream); err != nil {
 		return err
 	}
 	if destinations := c.regularFanoutDestinations(source.tierIndex); len(destinations) > 0 {
@@ -212,7 +212,7 @@ func (c *DaramjweeCache) refreshTopEntryCachedAt(ctx context.Context, key string
 	metaToRefresh.CachedAt = time.Now()
 
 	if metaToRefresh.IsNegative {
-		writer, err := c.setStreamToTopStoreWithGeneration(ctx, key, &metaToRefresh, &expectedGeneration)
+		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, &metaToRefresh, &expectedGeneration)
 		if err != nil {
 			if errors.Is(err, ErrTopWriteInvalidated) {
 				return nil
@@ -235,7 +235,7 @@ func (c *DaramjweeCache) refreshTopEntryCachedAt(ctx context.Context, key string
 		return closeErr
 	}
 
-	writer, err := c.setStreamToTopStoreWithGeneration(ctx, key, &metaToRefresh, &expectedGeneration)
+	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, &metaToRefresh, &expectedGeneration)
 	if err != nil {
 		if errors.Is(err, ErrTopWriteInvalidated) {
 			return nil
@@ -258,7 +258,7 @@ func (c *DaramjweeCache) handleNegativeCacheWithGeneration(requestCtx, setupCtx 
 		CachedAt:   time.Now(),
 	}
 
-	writer, err := c.setStreamToTopStoreWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, c.topWriteStore()), key, meta, expectedGeneration)
+	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, c.topWriteStore()), key, meta, expectedGeneration)
 	if err != nil {
 		if errors.Is(err, ErrTopWriteInvalidated) {
 			if cancel != nil {
@@ -270,10 +270,31 @@ func (c *DaramjweeCache) handleNegativeCacheWithGeneration(requestCtx, setupCtx 
 	} else {
 		if closeErr := writer.Close(); closeErr != nil {
 			c.warnLog("msg", "failed to close writer for negative cache entry", "key", key, "err", closeErr)
+		} else {
+			c.schedulePersistFromCurrentTop(requestCtx, key, c.persistDestinationsAfterTop()...)
 		}
 	}
 	if cancel != nil {
 		cancel()
 	}
 	return newGetResponse(GetStatusNotFound, nil, meta), nil
+}
+
+func copyCloseSourceThenCommit(writer WriteSink, src io.ReadCloser) error {
+	_, copyErr := io.Copy(writer, src)
+	sourceCloseErr := src.Close()
+	if copyErr != nil || sourceCloseErr != nil {
+		abortErr := writer.Abort()
+		return errors.Join(copyErr, sourceCloseErr, abortErr)
+	}
+	return writer.Close()
+}
+
+func sameCacheEntry(current, expected *Metadata) bool {
+	if current == nil || expected == nil {
+		return current == expected
+	}
+	return current.CacheTag == expected.CacheTag &&
+		current.IsNegative == expected.IsNegative &&
+		current.CachedAt.Equal(expected.CachedAt)
 }

--- a/cache_refresh.go
+++ b/cache_refresh.go
@@ -55,10 +55,18 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 				c.debugLog("msg", "background refresh: object not modified", "key", key)
 				if fallbackSource != nil {
 					if promoteErr := c.promoteRefreshFallbackToTop(refreshCtx, key, *fallbackSource, fallbackMetadata, expectedGeneration); promoteErr != nil {
-						c.warnLog("msg", "failed to promote fallback entry after not-modified refresh", "key", key, "source_tier", fallbackSource.tierIndex, "err", promoteErr)
+						if errors.Is(promoteErr, ErrTopWriteInvalidated) {
+							c.infoLog("msg", "skipping fallback promotion because top-tier state changed", "key", key, "source_tier", fallbackSource.tierIndex)
+						} else {
+							c.warnLog("msg", "failed to promote fallback entry after not-modified refresh", "key", key, "source_tier", fallbackSource.tierIndex, "err", promoteErr)
+						}
 					}
 				} else if refreshErr := c.refreshTopEntryCachedAt(refreshCtx, key, oldMetadata, expectedGeneration); refreshErr != nil {
-					c.warnLog("msg", "failed to refresh top-tier metadata after not-modified refresh", "key", key, "err", refreshErr)
+					if errors.Is(refreshErr, ErrTopWriteInvalidated) {
+						c.infoLog("msg", "skipping top-tier metadata refresh because top-tier state changed", "key", key)
+					} else {
+						c.warnLog("msg", "failed to refresh top-tier metadata after not-modified refresh", "key", key, "err", refreshErr)
+					}
 				}
 			} else {
 				c.errorLog("msg", "background fetch failed", "key", key, "err", err)
@@ -85,7 +93,11 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 		}
 
 		if publishErr := copyCloseSourceThenCommit(writer, result.Body); publishErr != nil {
-			c.errorLog("msg", "failed background set", "key", key, "err", publishErr)
+			if errors.Is(publishErr, ErrTopWriteInvalidated) {
+				c.infoLog("msg", "skipping background refresh publish because top-tier state changed", "key", key)
+			} else {
+				c.errorLog("msg", "failed background set", "key", key, "err", publishErr)
+			}
 		} else {
 			c.infoLog("msg", "background set successful", "key", key)
 			c.schedulePersistFromCurrentTop(refreshCtx, key, c.persistDestinationsAfterTop()...)
@@ -269,7 +281,11 @@ func (c *DaramjweeCache) handleNegativeCacheWithGeneration(requestCtx, setupCtx 
 		c.warnLog("msg", "failed to get writer for negative cache entry", "key", key, "err", err)
 	} else {
 		if closeErr := writer.Close(); closeErr != nil {
-			c.warnLog("msg", "failed to close writer for negative cache entry", "key", key, "err", closeErr)
+			if errors.Is(closeErr, ErrTopWriteInvalidated) {
+				c.infoLog("msg", "skipping negative cache publish because top-tier state changed", "key", key)
+			} else {
+				c.warnLog("msg", "failed to close writer for negative cache entry", "key", key, "err", closeErr)
+			}
 		} else {
 			c.schedulePersistFromCurrentTop(requestCtx, key, c.persistDestinationsAfterTop()...)
 		}

--- a/daramjwee.go
+++ b/daramjwee.go
@@ -327,17 +327,11 @@ func buildCacheConfig(mode cacheConstructionMode, groupCfg *GroupConfig, opts ..
 		PositiveFreshness: 0,
 		NegativeFreshness: 0,
 	}
-	settings := settingsForConfig(&cfg)
-	defer optionSettings.Delete(&cfg)
 
 	for _, opt := range opts {
 		if err := opt(&cfg); err != nil {
 			return Config{}, 0, err
 		}
-	}
-	fillLeaseTimeout := time.Duration(0)
-	if settings.fillLeaseTimeout != nil {
-		fillLeaseTimeout = *settings.fillLeaseTimeout
 	}
 
 	switch mode {
@@ -420,7 +414,7 @@ func buildCacheConfig(mode cacheConstructionMode, groupCfg *GroupConfig, opts ..
 		}
 	}
 
-	return cfg, fillLeaseTimeout, nil
+	return cfg, cfg.fillLeaseTimeout, nil
 }
 
 func newCacheFromConfig(logger log.Logger, runtime backgroundRuntime, cacheID string, cfg Config, fillLeaseTimeout time.Duration) (Cache, error) {

--- a/daramjwee.go
+++ b/daramjwee.go
@@ -201,6 +201,8 @@ type FetchUsesContext interface {
 // Implementations used by Store.BeginSet must not call back into Cache methods
 // from Close or Abort because cache tiers may coordinate commit ordering while
 // those terminal methods run.
+// Write must return promptly when the underlying storage rejects or stalls a
+// staged write; cache-level fill preemption cannot interrupt a blocked Write.
 type WriteSink interface {
 	io.WriteCloser
 	Abort() error
@@ -214,6 +216,8 @@ type Store interface {
 	// BeginSet returns a sink that stages data into the store.
 	// The currently readable value for key must remain unchanged until the
 	// returned sink is successfully closed or aborted.
+	// Implementations should honor ctx during setup; cache-level fill leases
+	// start only after BeginSet returns and cannot interrupt a blocked BeginSet.
 	BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error)
 	// Delete removes the last committed object from the store.
 	// It must not wait for an uncommitted BeginSet sink on the same key to
@@ -281,7 +285,7 @@ func New(logger log.Logger, opts ...Option) (Cache, error) {
 		logger = log.NewNopLogger()
 	}
 
-	cfg, err := buildCacheConfig(cacheConstructionStandalone, nil, opts...)
+	cfg, fillLeaseTimeout, err := buildCacheConfig(cacheConstructionStandalone, nil, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -293,26 +297,32 @@ func New(logger log.Logger, opts ...Option) (Cache, error) {
 
 	runtime := newStandaloneRuntime(manager)
 	cacheID := "standalone"
-	return newCacheFromConfig(logger, runtime, cacheID, cfg)
+	return newCacheFromConfig(logger, runtime, cacheID, cfg, fillLeaseTimeout)
 }
 
-func buildCacheConfig(mode cacheConstructionMode, groupCfg *GroupConfig, opts ...Option) (Config, error) {
+func buildCacheConfig(mode cacheConstructionMode, groupCfg *GroupConfig, opts ...Option) (Config, time.Duration, error) {
 	cfg := Config{
 		OpTimeout:         30 * time.Second,
 		PositiveFreshness: 0,
 		NegativeFreshness: 0,
 	}
+	settings := settingsForConfig(&cfg)
+	defer optionSettings.Delete(&cfg)
 
 	for _, opt := range opts {
 		if err := opt(&cfg); err != nil {
-			return Config{}, err
+			return Config{}, 0, err
 		}
+	}
+	fillLeaseTimeout := time.Duration(0)
+	if settings.fillLeaseTimeout != nil {
+		fillLeaseTimeout = *settings.fillLeaseTimeout
 	}
 
 	switch mode {
 	case cacheConstructionStandalone:
 		if cfg.Weight > 0 || cfg.QueueLimit > 0 {
-			return Config{}, &ConfigError{"group-attached cache option cannot be used with New"}
+			return Config{}, 0, &ConfigError{"group-attached cache option cannot be used with New"}
 		}
 		if cfg.WorkerStrategy == "" {
 			cfg.WorkerStrategy = "pool"
@@ -332,16 +342,16 @@ func buildCacheConfig(mode cacheConstructionMode, groupCfg *GroupConfig, opts ..
 	case cacheConstructionGroup:
 		if groupCfg != nil {
 			if cfg.WorkerStrategy != "" {
-				return Config{}, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
+				return Config{}, 0, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
 			}
 			if cfg.Workers != 0 {
-				return Config{}, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
+				return Config{}, 0, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
 			}
 			if cfg.WorkerQueue != 0 {
-				return Config{}, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
+				return Config{}, 0, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
 			}
 			if cfg.WorkerTimeout != 0 {
-				return Config{}, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
+				return Config{}, 0, &ConfigError{"standalone worker option cannot be used with CacheGroup.NewCache"}
 			}
 			if cfg.Workers == 0 {
 				cfg.Workers = groupCfg.Workers
@@ -365,34 +375,34 @@ func buildCacheConfig(mode cacheConstructionMode, groupCfg *GroupConfig, opts ..
 	}
 
 	if len(cfg.Tiers) == 0 {
-		return Config{}, &ConfigError{"at least one tier is required"}
+		return Config{}, 0, &ConfigError{"at least one tier is required"}
 	}
 
 	seen := make([]Store, 0, len(cfg.Tiers))
 	for idx, tier := range cfg.Tiers {
 		if isNilStore(tier) {
-			return Config{}, &ConfigError{"tier cannot be nil"}
+			return Config{}, 0, &ConfigError{"tier cannot be nil"}
 		}
 		if containsSameStore(seen, tier) {
-			return Config{}, &ConfigError{"duplicate tier store instance"}
+			return Config{}, 0, &ConfigError{"duplicate tier store instance"}
 		}
 		if validator, ok := tier.(TierValidator); ok {
 			if err := validator.ValidateTier(idx); err != nil {
-				return Config{}, &ConfigError{fmt.Sprintf("tier %d %s", idx, err.Error())}
+				return Config{}, 0, &ConfigError{fmt.Sprintf("tier %d %s", idx, err.Error())}
 			}
 		}
 		seen = append(seen, tier)
 	}
 	for idx := range cfg.TierFreshnessOverrides {
 		if idx < 0 || idx >= len(cfg.Tiers) {
-			return Config{}, &ConfigError{fmt.Sprintf("tier freshness override index %d is out of range", idx)}
+			return Config{}, 0, &ConfigError{fmt.Sprintf("tier freshness override index %d is out of range", idx)}
 		}
 	}
 
-	return cfg, nil
+	return cfg, fillLeaseTimeout, nil
 }
 
-func newCacheFromConfig(logger log.Logger, runtime backgroundRuntime, cacheID string, cfg Config) (Cache, error) {
+func newCacheFromConfig(logger log.Logger, runtime backgroundRuntime, cacheID string, cfg Config, fillLeaseTimeout time.Duration) (Cache, error) {
 	cache := &DaramjweeCache{
 		logger:                 logger,
 		runtime:                runtime,
@@ -402,6 +412,7 @@ func newCacheFromConfig(logger log.Logger, runtime backgroundRuntime, cacheID st
 		runtimeQueueLimit:      cfg.QueueLimit,
 		opTimeout:              cfg.OpTimeout,
 		closeTimeout:           cfg.CloseTimeout,
+		fillLeaseTimeout:       fillLeaseTimeout,
 		positiveFreshness:      cfg.PositiveFreshness,
 		negativeFreshness:      cfg.NegativeFreshness,
 		tierFreshnessOverrides: cloneTierFreshnessOverrides(cfg.TierFreshnessOverrides),

--- a/evals/codex-principal-team/cache-stuck-oracle-fix-2026-05-12.json
+++ b/evals/codex-principal-team/cache-stuck-oracle-fix-2026-05-12.json
@@ -1,0 +1,62 @@
+{
+  "task": "fix file-cache stuck keys with repeated principal-team, subagent, and oracle review",
+  "large_model_actions": 8,
+  "small_model_actions": 12,
+  "oracle_calls": 5,
+  "oracle_adopted": 16,
+  "skills_used": [
+    "codex-principal-team",
+    "remote-review",
+    "review-loop",
+    "oracle",
+    "writing-go"
+  ],
+  "new_skills": [],
+  "scripts_used": [],
+  "new_scripts": [],
+  "manual_activities": [
+    "parent integration of active fill preemption and fill lease behavior",
+    "parent integration of conditional lower-tier no-sync-promotion behavior",
+    "parent integration of group NewCache/Close constructor barrier",
+    "parent integration of negative-cache best-effort writes",
+    "parent integration of higher-tier read-error clean-miss separation",
+    "final verification orchestration"
+  ],
+  "failures": [
+    "initial review found active-fill registration race",
+    "initial review found exported Config field compatibility issue",
+    "review found fill lease timer install/preempt race",
+    "review found conditional lower-tier promotion blocking behind unconsumed fill",
+    "review found CacheGroup Close racing in-flight NewCache construction",
+    "review found negative-cache writes blocking behind active fill",
+    "review found preempted fill BeginSet failure leaking writeMu",
+    "oracle found higher-tier read error treated as clean miss",
+    "subagent found stale negative lower-tier returned as OK after top read error"
+  ],
+  "rework_items": [
+    "register active fill before Store.BeginSet returns",
+    "remove exported FillLeaseTimeout field from Config while preserving option API",
+    "start fill lease only after BeginSet returns",
+    "use activeFill TryLock/pass-through for fill paths",
+    "skip synchronous top promotion for conditional lower-tier NotModified",
+    "add constructor/registration barrier for CacheGroup Close",
+    "make negative expected writes best-effort to avoid active-fill blocking",
+    "always unlock writeMu on fill BeginSet failure even after preempted close",
+    "separate clean ErrNotFound miss from higher-tier read failures",
+    "preserve negative NotFound semantics before stale positive serving"
+  ],
+  "tests_run": [
+    "go test ./...",
+    "go test -race ./...",
+    "git diff --check",
+    "DJ_REPRO_CACHE_STUCK=1 go test ./tests targeted cache-stuck loop for 60s",
+    "targeted conditional lower-tier, negative-cache, BeginSet failure, group lifecycle, and higher-tier read-error tests"
+  ],
+  "follow_up_candidates": [
+    "consider documenting WithFillLeaseTimeout in README",
+    "consider keeping a dedicated deterministic script for the 60s cache-stuck regression loop"
+  ],
+  "parent_patch_count": 10,
+  "worker_patch_count": 0,
+  "user_requested_delegation": true
+}

--- a/group.go
+++ b/group.go
@@ -80,27 +80,28 @@ func (g *cacheGroup) NewCache(name string, opts ...Option) (Cache, error) {
 	g.caches[name] = nil
 	g.constructing++
 	g.mu.Unlock()
-
-	cfg, fillLeaseTimeout, err := buildCacheConfig(cacheConstructionGroup, &g.cfg, opts...)
-	if err != nil {
+	cleanupConstruction := true
+	defer func() {
+		if !cleanupConstruction {
+			return
+		}
 		g.mu.Lock()
-		if g.caches[name] == nil {
+		if current, exists := g.caches[name]; exists && current == nil {
 			delete(g.caches, name)
 		}
 		g.constructing--
 		g.cond.Broadcast()
 		g.mu.Unlock()
+	}()
+
+	cfg, fillLeaseTimeout, err := buildCacheConfig(cacheConstructionGroup, &g.cfg, opts...)
+	if err != nil {
 		return nil, err
 	}
 
 	g.registrationMu.Lock()
 	g.mu.Lock()
 	if g.closed.Load() {
-		if g.caches[name] == nil {
-			delete(g.caches, name)
-		}
-		g.constructing--
-		g.cond.Broadcast()
 		g.mu.Unlock()
 		g.registrationMu.Unlock()
 		return nil, &ConfigError{"cache group is closed"}
@@ -109,25 +110,11 @@ func (g *cacheGroup) NewCache(name string, opts ...Option) (Cache, error) {
 	cache, err := newCacheFromConfig(g.logger, g.rt, name, cfg, fillLeaseTimeout)
 	g.registrationMu.Unlock()
 	if err != nil {
-		g.mu.Lock()
-		if g.caches[name] == nil {
-			delete(g.caches, name)
-		}
-		g.constructing--
-		g.cond.Broadcast()
-		g.mu.Unlock()
 		return nil, err
 	}
 
 	typed, ok := cache.(*DaramjweeCache)
 	if !ok {
-		g.mu.Lock()
-		if g.caches[name] == nil {
-			delete(g.caches, name)
-		}
-		g.constructing--
-		g.cond.Broadcast()
-		g.mu.Unlock()
 		return nil, &ConfigError{"unexpected cache implementation"}
 	}
 	typed.closeHook = func() {
@@ -142,28 +129,15 @@ func (g *cacheGroup) NewCache(name string, opts ...Option) (Cache, error) {
 	if g.closed.Load() {
 		g.mu.Unlock()
 		typed.Close()
-		g.mu.Lock()
-		if g.caches[name] == nil {
-			delete(g.caches, name)
-		}
-		g.constructing--
-		g.cond.Broadcast()
-		g.mu.Unlock()
 		return nil, &ConfigError{"cache group is closed"}
 	}
 	if current, exists := g.caches[name]; !exists || current != nil {
 		g.mu.Unlock()
 		typed.Close()
-		g.mu.Lock()
-		if current, exists := g.caches[name]; exists && current == nil {
-			delete(g.caches, name)
-		}
-		g.constructing--
-		g.cond.Broadcast()
-		g.mu.Unlock()
 		return nil, &ConfigError{fmt.Sprintf("duplicate cache name %q", name)}
 	}
 	g.caches[name] = typed
+	cleanupConstruction = false
 	g.constructing--
 	g.cond.Broadcast()
 	g.mu.Unlock()

--- a/group.go
+++ b/group.go
@@ -21,9 +21,12 @@ type cacheGroup struct {
 	cfg    GroupConfig
 	rt     *groupRuntime
 
-	closed atomic.Bool
-	mu     sync.Mutex
-	caches map[string]*DaramjweeCache
+	closed         atomic.Bool
+	registrationMu sync.Mutex
+	mu             sync.Mutex
+	cond           *sync.Cond
+	constructing   int
+	caches         map[string]*DaramjweeCache
 }
 
 var _ CacheGroup = (*cacheGroup)(nil)
@@ -47,12 +50,14 @@ func NewGroup(logger log.Logger, opts ...GroupOption) (CacheGroup, error) {
 		}
 	}
 
-	return &cacheGroup{
+	group := &cacheGroup{
 		logger: logger,
 		cfg:    cfg,
 		rt:     newGroupRuntime(logger, cfg.Workers, cfg.WorkerTimeout),
 		caches: make(map[string]*DaramjweeCache),
-	}, nil
+	}
+	group.cond = sync.NewCond(&group.mu)
+	return group, nil
 }
 
 func (g *cacheGroup) NewCache(name string, opts ...Option) (Cache, error) {
@@ -64,29 +69,72 @@ func (g *cacheGroup) NewCache(name string, opts ...Option) (Cache, error) {
 	}
 
 	g.mu.Lock()
+	if g.closed.Load() {
+		g.mu.Unlock()
+		return nil, &ConfigError{"cache group is closed"}
+	}
 	if _, exists := g.caches[name]; exists {
 		g.mu.Unlock()
 		return nil, &ConfigError{fmt.Sprintf("duplicate cache name %q", name)}
 	}
+	g.caches[name] = nil
+	g.constructing++
 	g.mu.Unlock()
 
-	cfg, err := buildCacheConfig(cacheConstructionGroup, &g.cfg, opts...)
+	cfg, fillLeaseTimeout, err := buildCacheConfig(cacheConstructionGroup, &g.cfg, opts...)
 	if err != nil {
+		g.mu.Lock()
+		if g.caches[name] == nil {
+			delete(g.caches, name)
+		}
+		g.constructing--
+		g.cond.Broadcast()
+		g.mu.Unlock()
 		return nil, err
 	}
 
-	cache, err := newCacheFromConfig(g.logger, g.rt, name, cfg)
+	g.registrationMu.Lock()
+	g.mu.Lock()
+	if g.closed.Load() {
+		if g.caches[name] == nil {
+			delete(g.caches, name)
+		}
+		g.constructing--
+		g.cond.Broadcast()
+		g.mu.Unlock()
+		g.registrationMu.Unlock()
+		return nil, &ConfigError{"cache group is closed"}
+	}
+	g.mu.Unlock()
+	cache, err := newCacheFromConfig(g.logger, g.rt, name, cfg, fillLeaseTimeout)
+	g.registrationMu.Unlock()
 	if err != nil {
+		g.mu.Lock()
+		if g.caches[name] == nil {
+			delete(g.caches, name)
+		}
+		g.constructing--
+		g.cond.Broadcast()
+		g.mu.Unlock()
 		return nil, err
 	}
 
 	typed, ok := cache.(*DaramjweeCache)
 	if !ok {
+		g.mu.Lock()
+		if g.caches[name] == nil {
+			delete(g.caches, name)
+		}
+		g.constructing--
+		g.cond.Broadcast()
+		g.mu.Unlock()
 		return nil, &ConfigError{"unexpected cache implementation"}
 	}
 	typed.closeHook = func() {
 		g.mu.Lock()
-		delete(g.caches, name)
+		if g.caches[name] == typed {
+			delete(g.caches, name)
+		}
 		g.mu.Unlock()
 	}
 
@@ -94,21 +142,50 @@ func (g *cacheGroup) NewCache(name string, opts ...Option) (Cache, error) {
 	if g.closed.Load() {
 		g.mu.Unlock()
 		typed.Close()
+		g.mu.Lock()
+		if g.caches[name] == nil {
+			delete(g.caches, name)
+		}
+		g.constructing--
+		g.cond.Broadcast()
+		g.mu.Unlock()
 		return nil, &ConfigError{"cache group is closed"}
 	}
+	if current, exists := g.caches[name]; !exists || current != nil {
+		g.mu.Unlock()
+		typed.Close()
+		g.mu.Lock()
+		if current, exists := g.caches[name]; exists && current == nil {
+			delete(g.caches, name)
+		}
+		g.constructing--
+		g.cond.Broadcast()
+		g.mu.Unlock()
+		return nil, &ConfigError{fmt.Sprintf("duplicate cache name %q", name)}
+	}
 	g.caches[name] = typed
+	g.constructing--
+	g.cond.Broadcast()
 	g.mu.Unlock()
 	return cache, nil
 }
 
 func (g *cacheGroup) Close() {
+	g.registrationMu.Lock()
 	if g.closed.Swap(true) {
+		g.registrationMu.Unlock()
 		return
 	}
+	g.registrationMu.Unlock()
 	g.mu.Lock()
+	for g.constructing > 0 {
+		g.cond.Wait()
+	}
 	caches := make([]*DaramjweeCache, 0, len(g.caches))
 	for _, cache := range g.caches {
-		caches = append(caches, cache)
+		if cache != nil {
+			caches = append(caches, cache)
+		}
 	}
 	g.mu.Unlock()
 

--- a/logging.go
+++ b/logging.go
@@ -1,6 +1,7 @@
 package daramjwee
 
 import (
+	"os"
 	"reflect"
 
 	"github.com/go-kit/log"
@@ -16,29 +17,47 @@ func isNoopLogger(logger log.Logger) bool {
 }
 
 func (c *DaramjweeCache) debugLog(keyvals ...any) {
-	if c.loggingDisabled {
+	if c.loggingDisabled || c.logger == nil {
 		return
 	}
 	_ = level.Debug(c.logger).Log(keyvals...)
 }
 
 func (c *DaramjweeCache) infoLog(keyvals ...any) {
-	if c.loggingDisabled {
+	if c.loggingDisabled || c.logger == nil {
 		return
 	}
 	_ = level.Info(c.logger).Log(keyvals...)
 }
 
 func (c *DaramjweeCache) warnLog(keyvals ...any) {
-	if c.loggingDisabled {
+	if c.loggingDisabled || c.logger == nil {
 		return
 	}
 	_ = level.Warn(c.logger).Log(keyvals...)
 }
 
 func (c *DaramjweeCache) errorLog(keyvals ...any) {
-	if c.loggingDisabled {
+	if c.loggingDisabled || c.logger == nil {
 		return
 	}
 	_ = level.Error(c.logger).Log(keyvals...)
+}
+
+func (c *DaramjweeCache) diagnosticLog(event, key string, generation uint64, keyvals ...any) {
+	if c.loggingDisabled || c.logger == nil || !cacheDiagnosticsEnabled() {
+		return
+	}
+	diagnostic := []any{
+		"msg", "cache diagnostic",
+		"event", event,
+		"key", key,
+		"generation", generation,
+	}
+	diagnostic = append(diagnostic, keyvals...)
+	c.debugLog(diagnostic...)
+}
+
+func cacheDiagnosticsEnabled() bool {
+	return os.Getenv("DJ_CACHE_DIAGNOSTICS") == "1" || os.Getenv("DJ_REPRO_CACHE_STUCK") == "1"
 }

--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package daramjwee
 
 import (
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -46,6 +47,12 @@ type TierFreshnessOverride struct {
 
 // Option is a function type that modifies the Config.
 type Option func(cfg *Config) error
+
+var optionSettings sync.Map
+
+type optionSetting struct {
+	fillLeaseTimeout *time.Duration
+}
 
 // WithTiers sets the regular cache tiers in top-to-bottom order.
 // It replaces the entire tier chain, so any WithTierFreshness override indices
@@ -138,6 +145,23 @@ func WithOpTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithFillLeaseTimeout bounds how long a cache miss or lower-tier promotion
+// response may hold the top-tier write lock while the caller consumes the body.
+// The lease can preempt only after the target store's BeginSet has returned a
+// sink; BeginSet setup time is bounded by the operation context instead.
+// A timeout of 0 disables the lease timer; negative values are rejected.
+func WithFillLeaseTimeout(timeout time.Duration) Option {
+	return func(cfg *Config) error {
+		if timeout < 0 {
+			return &ConfigError{"fill lease timeout cannot be negative"}
+		}
+		settings := settingsForConfig(cfg)
+		value := timeout
+		settings.fillLeaseTimeout = &value
+		return nil
+	}
+}
+
 // WithCloseTimeout sets the timeout for graceful shutdown of the cache.
 func WithCloseTimeout(timeout time.Duration) Option {
 	return func(cfg *Config) error {
@@ -193,4 +217,13 @@ func validateFreshness(positive, negative time.Duration) error {
 		return &ConfigError{"negative freshness cannot be a negative value"}
 	}
 	return nil
+}
+
+func settingsForConfig(cfg *Config) *optionSetting {
+	if settings, ok := optionSettings.Load(cfg); ok {
+		return settings.(*optionSetting)
+	}
+	settings := &optionSetting{}
+	actual, _ := optionSettings.LoadOrStore(cfg, settings)
+	return actual.(*optionSetting)
 }

--- a/options.go
+++ b/options.go
@@ -2,7 +2,6 @@ package daramjwee
 
 import (
 	"fmt"
-	"sync"
 	"time"
 )
 
@@ -38,6 +37,7 @@ type Config struct {
 	PositiveFreshness      time.Duration
 	NegativeFreshness      time.Duration
 	TierFreshnessOverrides map[int]TierFreshnessOverride
+	fillLeaseTimeout       time.Duration
 }
 
 type TierFreshnessOverride struct {
@@ -47,12 +47,6 @@ type TierFreshnessOverride struct {
 
 // Option is a function type that modifies the Config.
 type Option func(cfg *Config) error
-
-var optionSettings sync.Map
-
-type optionSetting struct {
-	fillLeaseTimeout *time.Duration
-}
 
 // WithTiers sets the regular cache tiers in top-to-bottom order.
 // It replaces the entire tier chain, so any WithTierFreshness override indices
@@ -155,9 +149,7 @@ func WithFillLeaseTimeout(timeout time.Duration) Option {
 		if timeout < 0 {
 			return &ConfigError{"fill lease timeout cannot be negative"}
 		}
-		settings := settingsForConfig(cfg)
-		value := timeout
-		settings.fillLeaseTimeout = &value
+		cfg.fillLeaseTimeout = timeout
 		return nil
 	}
 }
@@ -217,13 +209,4 @@ func validateFreshness(positive, negative time.Duration) error {
 		return &ConfigError{"negative freshness cannot be a negative value"}
 	}
 	return nil
-}
-
-func settingsForConfig(cfg *Config) *optionSetting {
-	if settings, ok := optionSettings.Load(cfg); ok {
-		return settings.(*optionSetting)
-	}
-	settings := &optionSetting{}
-	actual, _ := optionSettings.LoadOrStore(cfg, settings)
-	return actual.(*optionSetting)
 }

--- a/options_test.go
+++ b/options_test.go
@@ -184,6 +184,7 @@ func TestNew_OptionValidation(t *testing.T) {
 				WithWorkerQueue(100),
 				WithWorkerTimeout(5 * time.Second),
 				WithOpTimeout(10 * time.Second),
+				WithFillLeaseTimeout(30 * time.Second),
 				WithCloseTimeout(20 * time.Second),
 				WithFreshness(time.Minute, 5*time.Minute),
 				WithTierFreshness(1, 2*time.Minute, 3*time.Minute),
@@ -261,6 +262,15 @@ func TestNew_OptionValidation(t *testing.T) {
 			},
 			expectErr:   true,
 			expectedMsg: "close timeout must be positive",
+		},
+		{
+			name: "failure with negative fill lease timeout",
+			options: []Option{
+				WithTiers(regularA),
+				WithFillLeaseTimeout(-time.Second),
+			},
+			expectErr:   true,
+			expectedMsg: "fill lease timeout cannot be negative",
 		},
 	}
 
@@ -353,6 +363,107 @@ func TestGroupNewCache_RejectsStandaloneWorkerOptions(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.msg)
 		})
 	}
+}
+
+func TestNewGroup_NewCacheReservesNameDuringConstruction(t *testing.T) {
+	group, err := NewGroup(nil, WithGroupWorkers(1))
+	require.NoError(t, err)
+	defer group.Close()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	blockConstruction := func(cfg *Config) error {
+		close(started)
+		<-release
+		return nil
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		cache, err := group.NewCache("reserved", WithTiers(&optionsTestMockStore{id: 1}), blockConstruction)
+		if err == nil {
+			cache.Close()
+		}
+		firstDone <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first NewCache did not reach the blocking option")
+	}
+
+	_, err = group.NewCache("reserved", WithTiers(&optionsTestMockStore{id: 2}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate cache name")
+
+	close(release)
+	select {
+	case err := <-firstDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("first NewCache did not complete after release")
+	}
+}
+
+func TestNewGroup_CloseWaitsForInFlightCacheConstruction(t *testing.T) {
+	group, err := NewGroup(nil, WithGroupWorkers(1))
+	require.NoError(t, err)
+	typedGroup := group.(*cacheGroup)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	blockConstruction := func(cfg *Config) error {
+		close(started)
+		<-release
+		return nil
+	}
+
+	newCacheDone := make(chan error, 1)
+	go func() {
+		cache, err := group.NewCache("closing-reserved", WithTiers(&optionsTestMockStore{id: 1}), blockConstruction)
+		if err == nil {
+			cache.Close()
+		}
+		newCacheDone <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("NewCache did not reach the blocking option")
+	}
+
+	closeDone := make(chan struct{})
+	go func() {
+		group.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+		t.Fatal("group Close returned while NewCache construction was still in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case err := <-newCacheDone:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cache group is closed")
+	case <-time.After(time.Second):
+		t.Fatal("NewCache did not unwind after construction was released")
+	}
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("group Close did not complete after in-flight construction unwound")
+	}
+
+	typedGroup.mu.Lock()
+	assert.Empty(t, typedGroup.caches)
+	typedGroup.mu.Unlock()
 }
 
 func TestNewGroup_CloseClosesCreatedCaches(t *testing.T) {

--- a/streaming.go
+++ b/streaming.go
@@ -452,8 +452,8 @@ func (r *fillReadCloser) WriteTo(dst io.Writer) (int64, error) {
 	if tee.sinkErr != nil {
 		r.sinkErr = tee.sinkErr
 		r.traceEvent("stream_through_write_to_sink_error", "bytes", written, "err", tee.sinkErr)
-		if !errors.Is(err, tee.sinkErr) {
-			r.readErr = err
+		if readErr := withoutError(err, tee.sinkErr); readErr != nil {
+			r.readErr = readErr
 		}
 	} else {
 		r.readErr = err
@@ -527,11 +527,11 @@ func (r *fillReadCloser) readAfterClosedErrorLocked() error {
 	if r.sawEOF && r.readErr == nil {
 		return io.EOF
 	}
+	if r.readErr != nil {
+		return errors.Join(r.readErr, r.closeErr)
+	}
 	if r.closeErr != nil {
 		return r.closeErr
-	}
-	if r.readErr != nil {
-		return r.readErr
 	}
 	return io.ErrClosedPipe
 }

--- a/streaming.go
+++ b/streaming.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"sync"
+	"time"
 )
 
 var streamCopyBufferPool = sync.Pool{
@@ -37,13 +38,27 @@ type fillReadCloser struct {
 	sink      WriteSink
 	onPublish func()
 	cancel    func()
+	trace     func(event string, keyvals ...any)
 
-	mu       sync.Mutex
-	sawEOF   bool
-	readErr  error
-	sinkErr  error
-	closeErr error
-	closed   bool
+	mu        sync.Mutex
+	sawEOF    bool
+	readErr   error
+	sinkErr   error
+	closeErr  error
+	closed    bool
+	closeDone chan struct{}
+}
+
+type topFillSink struct {
+	sink  *coordinatedTopWriteSink
+	coord *writeCoordinator
+	timer *time.Timer
+
+	mu         sync.Mutex
+	done       bool
+	preempted  bool
+	registered bool
+	err        error
 }
 
 type streamTeeWriter struct {
@@ -65,42 +80,275 @@ func (w *streamTeeWriter) Write(p []byte) (int, error) {
 }
 
 func streamThrough(src io.ReadCloser, sink WriteSink, cancel func(), onPublish func()) io.ReadCloser {
-	return newStreamingReadCloser(src, sink, cancel, onPublish)
+	return newStreamingReadCloser(src, sink, cancel, onPublish, nil)
 }
 
-func newStreamingReadCloser(src io.ReadCloser, sink WriteSink, cancel func(), onPublish func()) io.ReadCloser {
+func streamThroughWithTrace(src io.ReadCloser, sink WriteSink, cancel func(), onPublish func(), trace func(event string, keyvals ...any)) io.ReadCloser {
+	return newStreamingReadCloser(src, sink, cancel, onPublish, trace)
+}
+
+func newStreamingReadCloser(src io.ReadCloser, sink WriteSink, cancel func(), onPublish func(), trace func(event string, keyvals ...any)) io.ReadCloser {
 	return &fillReadCloser{
 		src:       src,
 		sink:      sink,
 		cancel:    cancel,
 		onPublish: onPublish,
+		trace:     trace,
+	}
+}
+
+func newPendingTopFillSink(coord *writeCoordinator) *topFillSink {
+	return &topFillSink{coord: coord}
+}
+
+func (s *topFillSink) startLease(timeout time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done || s.preempted {
+		return
+	}
+	if timeout > 0 {
+		s.timer = time.AfterFunc(timeout, func() {
+			_ = s.Preempt()
+		})
+	}
+}
+
+func (s *topFillSink) attach(sink *coordinatedTopWriteSink) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done || s.preempted {
+		return false
+	}
+	s.sink = sink
+	return true
+}
+
+func (s *topFillSink) failBeginSet(err error) {
+	s.mu.Lock()
+	if s.err != nil {
+		s.err = errors.Join(s.err, err)
+	} else {
+		s.err = err
+	}
+	s.done = true
+	s.stopTimerLocked()
+	s.unregisterLocked()
+	s.mu.Unlock()
+	s.coord.writeMu.Unlock()
+}
+
+func (s *topFillSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done || s.preempted {
+		return len(p), nil
+	}
+	if s.sink == nil {
+		return len(p), nil
+	}
+	n, err := writeAllCount(s.sink, p)
+	if err != nil {
+		s.err = err
+		return n, err
+	}
+	return len(p), nil
+}
+
+func (s *topFillSink) Close() error {
+	s.mu.Lock()
+	if s.done {
+		if s.preempted {
+			s.mu.Unlock()
+			return nil
+		}
+		err := s.err
+		s.mu.Unlock()
+		return err
+	}
+	if s.preempted {
+		s.done = true
+		s.mu.Unlock()
+		return nil
+	}
+	s.done = true
+	s.stopTimerLocked()
+	s.unregisterLocked()
+	if s.sink == nil {
+		err := s.err
+		s.mu.Unlock()
+		return err
+	}
+	sink := s.sink
+	s.mu.Unlock()
+
+	err := sink.Close()
+	s.mu.Lock()
+	s.err = err
+	s.mu.Unlock()
+	return err
+}
+
+func (s *topFillSink) Abort() error {
+	s.mu.Lock()
+	if s.done {
+		if s.preempted {
+			s.mu.Unlock()
+			return nil
+		}
+		err := s.err
+		s.mu.Unlock()
+		return err
+	}
+	if s.preempted {
+		s.done = true
+		s.mu.Unlock()
+		return nil
+	}
+	s.done = true
+	s.stopTimerLocked()
+	s.unregisterLocked()
+	if s.sink == nil {
+		err := s.err
+		s.mu.Unlock()
+		return err
+	}
+	sink := s.sink
+	s.mu.Unlock()
+
+	err := sink.Abort()
+	s.mu.Lock()
+	s.err = err
+	s.mu.Unlock()
+	return err
+}
+
+func (s *topFillSink) Preempt() error {
+	s.mu.Lock()
+	if s.done {
+		err := s.err
+		s.mu.Unlock()
+		return err
+	}
+	s.preempted = true
+	s.stopTimerLocked()
+	s.unregisterLocked()
+	if s.sink == nil {
+		err := s.err
+		s.mu.Unlock()
+		return err
+	}
+	s.done = true
+	sink := s.sink
+	s.mu.Unlock()
+
+	err := sink.Abort()
+	s.mu.Lock()
+	s.err = err
+	s.mu.Unlock()
+	return err
+}
+
+func (s *topFillSink) finishPreemptedAttach(sink *coordinatedTopWriteSink) error {
+	err := sink.Abort()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done {
+		return s.err
+	}
+	s.done = true
+	s.err = errors.Join(s.err, err)
+	return s.err
+}
+
+func (s *topFillSink) Preempted() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.preempted
+}
+
+func (s *topFillSink) stopTimerLocked() {
+	if s.timer != nil {
+		s.timer.Stop()
+		s.timer = nil
+	}
+}
+
+func (s *topFillSink) unregisterLocked() {
+	if s.registered {
+		s.registered = false
+		s.coord.unregisterActiveFill(s)
 	}
 }
 
 func (r *fillReadCloser) Read(p []byte) (int, error) {
+	r.mu.Lock()
+	if r.closed {
+		closeDone := r.closeDone
+		if closeDone != nil {
+			r.mu.Unlock()
+			<-closeDone
+			r.mu.Lock()
+		}
+		err := r.readAfterClosedErrorLocked()
+		r.mu.Unlock()
+		return 0, err
+	}
+	r.mu.Unlock()
+
 	n, err := r.src.Read(p)
 	if n > 0 {
 		if writeErr := writeAll(r.sink, p[:n]); writeErr != nil {
 			r.mu.Lock()
 			r.sinkErr = writeErr
+			var readErr error
+			if err != nil && !errors.Is(err, io.EOF) {
+				r.readErr = err
+				readErr = err
+				r.traceEvent("stream_through_read_error", "err", err)
+			}
 			r.mu.Unlock()
-			return n, writeErr
+			closeErr := r.Close()
+			return n, errors.Join(readErr, writeErr, closeErr)
 		}
 	}
 
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if errors.Is(err, io.EOF) {
 		r.sawEOF = true
+		r.traceEvent("stream_through_read_eof")
+		r.mu.Unlock()
+		if reportErr := autoFinalizeError(r.Close()); reportErr != nil {
+			return n, reportErr
+		}
 		return n, err
 	}
 	if err != nil {
 		r.readErr = err
+		r.traceEvent("stream_through_read_error", "err", err)
+		r.mu.Unlock()
+		closeErr := r.Close()
+		return n, errors.Join(err, closeErr)
 	}
+	r.mu.Unlock()
 	return n, err
 }
 
 func (r *fillReadCloser) WriteTo(dst io.Writer) (int64, error) {
+	r.mu.Lock()
+	if r.closed {
+		closeDone := r.closeDone
+		if closeDone != nil {
+			r.mu.Unlock()
+			<-closeDone
+			r.mu.Lock()
+		}
+		err := r.readAfterClosedErrorLocked()
+		r.mu.Unlock()
+		return 0, err
+	}
+	r.mu.Unlock()
+
 	tee := &streamTeeWriter{dst: dst, sink: r.sink}
 
 	var (
@@ -120,7 +368,11 @@ func (r *fillReadCloser) WriteTo(dst io.Writer) (int64, error) {
 				nw, writeErr := tee.Write(buf[:nr])
 				written += int64(nw)
 				if writeErr != nil {
-					err = writeErr
+					if readErr != nil && !errors.Is(readErr, io.EOF) {
+						err = errors.Join(readErr, writeErr)
+					} else {
+						err = writeErr
+					}
 					break
 				}
 			}
@@ -134,50 +386,150 @@ func (r *fillReadCloser) WriteTo(dst io.Writer) (int64, error) {
 			}
 		}
 	}
+	if err == nil && tee.sinkErr != nil {
+		err = tee.sinkErr
+	}
 
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if err == nil {
 		r.sawEOF = true
-		return written, nil
+		r.traceEvent("stream_through_write_to_eof", "bytes", written)
+		r.mu.Unlock()
+		return written, autoFinalizeError(r.Close())
 	}
 	if tee.sinkErr != nil {
 		r.sinkErr = tee.sinkErr
+		r.traceEvent("stream_through_write_to_sink_error", "bytes", written, "err", tee.sinkErr)
+		if !errors.Is(err, tee.sinkErr) {
+			r.readErr = err
+		}
 	} else {
 		r.readErr = err
+		r.traceEvent("stream_through_write_to_read_error", "bytes", written, "err", err)
 	}
-	return written, err
+	r.mu.Unlock()
+	closeErr := r.Close()
+	return written, errors.Join(err, closeErr)
 }
 
 func (r *fillReadCloser) Close() error {
 	r.mu.Lock()
 	if r.closed {
+		closeDone := r.closeDone
+		if closeDone == nil {
+			err := r.closeErr
+			r.mu.Unlock()
+			return err
+		}
+		r.mu.Unlock()
+		<-closeDone
+		r.mu.Lock()
 		err := r.closeErr
 		r.mu.Unlock()
 		return err
 	}
 	r.closed = true
+	closeDone := make(chan struct{})
+	r.closeDone = closeDone
 	publish := r.sawEOF && r.readErr == nil && r.sinkErr == nil
+	r.traceEvent("stream_through_close_start", "publish", publish, "saw_eof", r.sawEOF, "read_err", r.readErr, "sink_err", r.sinkErr)
 	r.mu.Unlock()
 
 	var err error
 	if publish {
-		err = r.sink.Close()
-		if err == nil && r.onPublish != nil {
-			r.onPublish()
+		srcErr := r.src.Close()
+		if srcErr != nil {
+			r.traceEvent("stream_through_sink_abort_start")
+			abortErr := r.sink.Abort()
+			r.traceEvent("stream_through_sink_abort_done", "err", abortErr)
+			err = errors.Join(abortErr, srcErr)
+		} else {
+			r.traceEvent("stream_through_sink_close_start")
+			err = r.sink.Close()
+			r.traceEvent("stream_through_sink_close_done", "err", err)
+			if err == nil && r.onPublish != nil && !sinkPreempted(r.sink) {
+				r.traceEvent("stream_through_on_publish_start")
+				r.onPublish()
+				r.traceEvent("stream_through_on_publish_done")
+			}
 		}
 	} else {
+		r.traceEvent("stream_through_sink_abort_start")
 		err = r.sink.Abort()
+		r.traceEvent("stream_through_sink_abort_done", "err", err)
+		err = errors.Join(err, r.src.Close())
 	}
-	err = errors.Join(err, r.src.Close())
 	if r.cancel != nil {
 		r.cancel()
 	}
 
 	r.mu.Lock()
 	r.closeErr = err
+	close(closeDone)
 	r.mu.Unlock()
+	r.traceEvent("stream_through_close_done", "err", err)
 	return err
+}
+
+func (r *fillReadCloser) readAfterClosedErrorLocked() error {
+	if r.sawEOF && r.readErr == nil {
+		return io.EOF
+	}
+	if r.closeErr != nil {
+		return r.closeErr
+	}
+	if r.readErr != nil {
+		return r.readErr
+	}
+	return io.ErrClosedPipe
+}
+
+func sinkPreempted(sink WriteSink) bool {
+	preempted, ok := sink.(interface{ Preempted() bool })
+	return ok && preempted.Preempted()
+}
+
+func (r *fillReadCloser) traceEvent(event string, keyvals ...any) {
+	if r.trace == nil {
+		return
+	}
+	r.trace(event, keyvals...)
+}
+
+func autoFinalizeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrTopWriteInvalidated) {
+		return withoutError(err, ErrTopWriteInvalidated)
+	}
+	return err
+}
+
+func withoutError(err, target error) error {
+	if err == nil {
+		return nil
+	}
+	switch unwrapped := err.(type) {
+	case interface{ Unwrap() []error }:
+		remaining := make([]error, 0, len(unwrapped.Unwrap()))
+		for _, child := range unwrapped.Unwrap() {
+			if childErr := withoutError(child, target); childErr != nil {
+				remaining = append(remaining, childErr)
+			}
+		}
+		return errors.Join(remaining...)
+	case interface{ Unwrap() error }:
+		if childErr := withoutError(unwrapped.Unwrap(), target); childErr != nil {
+			return childErr
+		}
+		return nil
+	default:
+		if errors.Is(err, target) {
+			return nil
+		}
+		return err
+	}
 }
 
 type cancelOnCloseReadCloser struct {

--- a/streaming.go
+++ b/streaming.go
@@ -558,6 +558,8 @@ func autoFinalizeError(err error) error {
 	return err
 }
 
+// withoutError recursively unwraps err and removes target from joined errors.
+// Custom wrapper context around target may be discarded when only child errors remain.
 func withoutError(err, target error) error {
 	if err == nil {
 		return nil

--- a/streaming.go
+++ b/streaming.go
@@ -146,6 +146,12 @@ func (s *topFillSink) failBeginSet(err error) {
 	}
 }
 
+func (s *topFillSink) isPreempted() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.preempted
+}
+
 func (s *topFillSink) Write(p []byte) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -213,6 +219,10 @@ func (s *topFillSink) Close() error {
 func (s *topFillSink) Abort() error {
 	s.mu.Lock()
 	if s.done {
+		if s.preempted {
+			s.mu.Unlock()
+			return nil
+		}
 		err := s.err
 		s.mu.Unlock()
 		return err

--- a/streaming.go
+++ b/streaming.go
@@ -424,8 +424,12 @@ func (r *fillReadCloser) WriteTo(dst io.Writer) (int64, error) {
 			}
 		}
 	}
-	if err == nil && tee.sinkErr != nil {
-		err = tee.sinkErr
+	if tee.sinkErr != nil {
+		if err != nil && !errors.Is(err, tee.sinkErr) {
+			err = errors.Join(err, tee.sinkErr)
+		} else if err == nil {
+			err = tee.sinkErr
+		}
 	}
 
 	r.mu.Lock()

--- a/streaming.go
+++ b/streaming.go
@@ -144,8 +144,11 @@ func (s *topFillSink) failBeginSet(err error) {
 	}
 	s.done = true
 	s.stopTimerLocked()
-	s.unregisterLocked()
+	cancelBegin := s.unregisterLocked()
 	s.mu.Unlock()
+	if cancelBegin != nil {
+		cancelBegin()
+	}
 	if s.release != nil {
 		s.release()
 	}
@@ -237,16 +240,22 @@ func (s *topFillSink) Close() error {
 	}
 	s.done = true
 	s.stopTimerLocked()
-	s.unregisterLocked()
+	cancelBegin := s.unregisterLocked()
 	if s.sink == nil {
 		err := s.err
 		s.mu.Unlock()
+		if cancelBegin != nil {
+			cancelBegin()
+		}
 		return err
 	}
 	sink := s.sink
 	s.mu.Unlock()
 
 	err := sink.Close()
+	if cancelBegin != nil {
+		cancelBegin()
+	}
 	s.mu.Lock()
 	s.err = err
 	s.mu.Unlock()
@@ -286,16 +295,22 @@ func (s *topFillSink) Abort() error {
 	}
 	s.done = true
 	s.stopTimerLocked()
-	s.unregisterLocked()
+	cancelBegin := s.unregisterLocked()
 	if s.sink == nil {
 		err := s.err
 		s.mu.Unlock()
+		if cancelBegin != nil {
+			cancelBegin()
+		}
 		return err
 	}
 	sink := s.sink
 	s.mu.Unlock()
 
 	err := sink.Abort()
+	if cancelBegin != nil {
+		cancelBegin()
+	}
 	s.mu.Lock()
 	s.err = err
 	s.mu.Unlock()
@@ -312,9 +327,8 @@ func (s *topFillSink) Preempt() error {
 	s.preempted = true
 	s.preemptOnce.Do(func() { close(s.preemptCh) })
 	s.stopTimerLocked()
-	s.unregisterLocked()
+	cancelBegin := s.unregisterLocked()
 	if s.sink == nil {
-		cancelBegin := s.cancelBegin
 		err := s.err
 		s.mu.Unlock()
 		if cancelBegin != nil {
@@ -324,7 +338,6 @@ func (s *topFillSink) Preempt() error {
 	}
 	s.done = true
 	sink := s.sink
-	cancelBegin := s.cancelBegin
 	s.mu.Unlock()
 
 	if cancelBegin != nil {
@@ -394,11 +407,14 @@ func (s *topFillSink) stopTimerLocked() {
 	}
 }
 
-func (s *topFillSink) unregisterLocked() {
+func (s *topFillSink) unregisterLocked() func() {
 	if s.registered {
 		s.registered = false
 		s.coord.unregisterActiveFill(s)
 	}
+	cancelBegin := s.cancelBegin
+	s.cancelBegin = nil
+	return cancelBegin
 }
 
 func (r *fillReadCloser) Read(p []byte) (int, error) {

--- a/streaming.go
+++ b/streaming.go
@@ -58,6 +58,7 @@ type topFillSink struct {
 	preemptCh   chan struct{}
 	preemptOnce sync.Once
 
+	ioMu                 sync.Mutex
 	mu                   sync.Mutex
 	done                 bool
 	preempted            bool
@@ -65,6 +66,10 @@ type topFillSink struct {
 	reportPreemptOnClose bool
 	wrote                bool
 	err                  error
+}
+
+type fillPreemptDetachedSink interface {
+	detachForFillPreempt() func() error
 }
 
 type streamTeeWriter struct {
@@ -153,17 +158,30 @@ func (s *topFillSink) isPreempted() bool {
 }
 
 func (s *topFillSink) Write(p []byte) (int, error) {
+	s.ioMu.Lock()
+	defer s.ioMu.Unlock()
+
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.done || s.preempted {
+		s.mu.Unlock()
 		return len(p), nil
 	}
 	if s.sink == nil {
+		s.mu.Unlock()
 		return len(p), nil
 	}
-	n, err := writeAllCount(s.sink, p)
+	sink := s.sink
+	s.mu.Unlock()
+
+	n, err := writeAllCount(sink, p)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if n > 0 {
 		s.wrote = true
+	}
+	if s.done || s.preempted {
+		return len(p), nil
 	}
 	if err != nil {
 		s.err = err
@@ -173,6 +191,25 @@ func (s *topFillSink) Write(p []byte) (int, error) {
 }
 
 func (s *topFillSink) Close() error {
+	s.mu.Lock()
+	if s.done {
+		if s.preempted {
+			if s.reportPreemptOnClose && s.wrote {
+				s.mu.Unlock()
+				return ErrTopWriteInvalidated
+			}
+			s.mu.Unlock()
+			return nil
+		}
+		err := s.err
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
+
+	s.ioMu.Lock()
+	defer s.ioMu.Unlock()
+
 	s.mu.Lock()
 	if s.done {
 		if s.preempted {
@@ -217,6 +254,21 @@ func (s *topFillSink) Close() error {
 }
 
 func (s *topFillSink) Abort() error {
+	s.mu.Lock()
+	if s.done {
+		if s.preempted {
+			s.mu.Unlock()
+			return nil
+		}
+		err := s.err
+		s.mu.Unlock()
+		return err
+	}
+	s.mu.Unlock()
+
+	s.ioMu.Lock()
+	defer s.ioMu.Unlock()
+
 	s.mu.Lock()
 	if s.done {
 		if s.preempted {
@@ -272,19 +324,35 @@ func (s *topFillSink) Preempt() error {
 	}
 	s.done = true
 	sink := s.sink
+	cancelBegin := s.cancelBegin
 	s.mu.Unlock()
 
-	if _, ok := sink.(*coordinatedStagedTopWriteSink); ok {
-		go func() {
-			_ = s.abortPreemptedSink(sink)
-		}()
-		return nil
+	if cancelBegin != nil {
+		cancelBegin()
 	}
-	return s.abortPreemptedSink(sink)
+	cleanup := s.preemptCleanup(sink)
+	if cleanup != nil {
+		// Detach same-key coordination immediately so Set/Delete can make
+		// progress even if the fill Write is stalled. The actual sink cleanup
+		// stays serialized with Write because WriteSink does not promise that
+		// terminal methods are safe to call concurrently with Write.
+		go s.abortPreemptedSink(cleanup)
+	}
+	return nil
 }
 
-func (s *topFillSink) abortPreemptedSink(sink WriteSink) error {
-	err := sink.Abort()
+func (s *topFillSink) preemptCleanup(sink WriteSink) func() error {
+	if detached, ok := sink.(fillPreemptDetachedSink); ok {
+		return detached.detachForFillPreempt()
+	}
+	return sink.Abort
+}
+
+func (s *topFillSink) abortPreemptedSink(cleanup func() error) error {
+	s.ioMu.Lock()
+	err := cleanup()
+	s.ioMu.Unlock()
+
 	s.mu.Lock()
 	if err != nil {
 		s.err = errors.Join(s.err, err)
@@ -298,7 +366,11 @@ func (s *topFillSink) preemptedSignal() <-chan struct{} {
 }
 
 func (s *topFillSink) finishPreemptedAttach(sink WriteSink) error {
-	err := sink.Abort()
+	cleanup := s.preemptCleanup(sink)
+	var err error
+	if cleanup != nil {
+		err = cleanup()
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.done {

--- a/streaming_reader_test.go
+++ b/streaming_reader_test.go
@@ -469,6 +469,54 @@ func TestTopFillSinkCloseDoesNotPublishDuringBlockedWrite(t *testing.T) {
 	}
 }
 
+func TestTopFillSinkTerminalMethodsCancelBeginContext(t *testing.T) {
+	t.Run("close cancels after sink close", func(t *testing.T) {
+		var cancelCalled bool
+		sink := &cancelCheckingWriteSink{
+			checkNotCanceled: func() {
+				require.False(t, cancelCalled)
+			},
+		}
+		fill := newPendingTopFillSink(&writeCoordinator{}, nil, func() { cancelCalled = true })
+		require.True(t, fill.attach(sink))
+
+		require.NoError(t, fill.Close())
+		require.True(t, cancelCalled)
+		require.True(t, sink.closed)
+	})
+
+	t.Run("abort cancels after sink abort", func(t *testing.T) {
+		var cancelCalled bool
+		sink := &cancelCheckingWriteSink{
+			checkNotCanceled: func() {
+				require.False(t, cancelCalled)
+			},
+		}
+		fill := newPendingTopFillSink(&writeCoordinator{}, nil, func() { cancelCalled = true })
+		require.True(t, fill.attach(sink))
+
+		require.NoError(t, fill.Abort())
+		require.True(t, cancelCalled)
+		require.True(t, sink.aborted)
+	})
+
+	t.Run("setup failure cancels", func(t *testing.T) {
+		var cancelCalled bool
+		fill := newPendingTopFillSink(&writeCoordinator{}, nil, func() { cancelCalled = true })
+
+		fill.failBeginSet(errors.New("begin failed"))
+		require.True(t, cancelCalled)
+	})
+
+	t.Run("preempt cancels", func(t *testing.T) {
+		var cancelCalled bool
+		fill := newPendingTopFillSink(&writeCoordinator{}, nil, func() { cancelCalled = true })
+
+		require.NoError(t, fill.Preempt())
+		require.True(t, cancelCalled)
+	})
+}
+
 type recordingWriteSink struct {
 	buf        bytes.Buffer
 	closeErr   error
@@ -625,6 +673,32 @@ func (s *blockingWriteSink) Abort() error {
 	s.abortOnce.Do(func() {
 		close(s.abortStarted)
 	})
+	return nil
+}
+
+type cancelCheckingWriteSink struct {
+	checkNotCanceled func()
+	closed           bool
+	aborted          bool
+}
+
+func (s *cancelCheckingWriteSink) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (s *cancelCheckingWriteSink) Close() error {
+	if s.checkNotCanceled != nil {
+		s.checkNotCanceled()
+	}
+	s.closed = true
+	return nil
+}
+
+func (s *cancelCheckingWriteSink) Abort() error {
+	if s.checkNotCanceled != nil {
+		s.checkNotCanceled()
+	}
+	s.aborted = true
 	return nil
 }
 

--- a/streaming_reader_test.go
+++ b/streaming_reader_test.go
@@ -209,6 +209,26 @@ func TestStreamThrough_CopyWriterToJoinsSourceAndSinkErrors(t *testing.T) {
 	require.ErrorIs(t, err, sinkErr)
 	assert.EqualValues(t, 0, n)
 	assert.True(t, sink.aborted)
+
+	_, err = stream.Read(make([]byte, 1))
+	require.ErrorIs(t, err, readErr)
+}
+
+func TestStreamThrough_CopyFallbackJoinsSourceAndSinkErrors(t *testing.T) {
+	readErr := errors.New("source read failed")
+	sinkErr := errors.New("sink write failed")
+	src := &singleReadErrorCloser{data: []byte("hello"), err: readErr}
+	sink := &recordingWriteSink{writeErr: sinkErr}
+	stream := streamThrough(src, sink, nil, nil)
+
+	n, err := io.Copy(io.Discard, stream)
+	require.ErrorIs(t, err, readErr)
+	require.ErrorIs(t, err, sinkErr)
+	assert.EqualValues(t, 5, n)
+	assert.True(t, sink.aborted)
+
+	_, err = stream.Read(make([]byte, 1))
+	require.ErrorIs(t, err, readErr)
 }
 
 func TestStreamThrough_ConcurrentCloseWaitsAndReturnsFinalError(t *testing.T) {

--- a/streaming_reader_test.go
+++ b/streaming_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ func TestStreamThrough_FullReadAndClosePublishes(t *testing.T) {
 	got, err := io.ReadAll(stream)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("hello"), got)
-	assert.False(t, sink.closed)
+	assert.True(t, sink.closed)
 	assert.False(t, sink.aborted)
 
 	require.NoError(t, stream.Close())
@@ -26,15 +27,21 @@ func TestStreamThrough_FullReadAndClosePublishes(t *testing.T) {
 	assert.Equal(t, []byte("hello"), sink.buf.Bytes())
 }
 
-func TestStreamThrough_FullReadWithoutCloseDoesNotPublish(t *testing.T) {
+func TestStreamThrough_FullReadWithoutExplicitClosePublishes(t *testing.T) {
 	sink := &recordingWriteSink{}
-	stream := streamThrough(io.NopCloser(bytes.NewReader([]byte("hello"))), sink, nil, nil)
+	src := &closeCountingReadCloser{Reader: bytes.NewReader([]byte("hello"))}
+	cancelCount := 0
+	publishCount := 0
+	stream := streamThrough(src, sink, func() { cancelCount++ }, func() { publishCount++ })
 
 	got, err := io.ReadAll(stream)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("hello"), got)
-	assert.False(t, sink.closed)
+	assert.True(t, sink.closed)
 	assert.False(t, sink.aborted)
+	assert.Equal(t, 1, src.closeCount)
+	assert.Equal(t, 1, cancelCount)
+	assert.Equal(t, 1, publishCount)
 }
 
 func TestStreamThrough_PartialReadThenCloseAborts(t *testing.T) {
@@ -60,6 +67,7 @@ func TestStreamThrough_SourceErrorAborts(t *testing.T) {
 	all, err := io.ReadAll(stream)
 	require.ErrorIs(t, err, readErr)
 	assert.Equal(t, []byte("he"), all)
+	assert.True(t, sink.aborted)
 
 	require.NoError(t, stream.Close())
 	assert.False(t, sink.closed)
@@ -74,6 +82,7 @@ func TestStreamThrough_ShortWriteReturnsErrShortWrite(t *testing.T) {
 	n, err := stream.Read(buf)
 	require.ErrorIs(t, err, io.ErrShortWrite)
 	assert.Equal(t, 5, n)
+	assert.True(t, sink.aborted)
 
 	require.NoError(t, stream.Close())
 	assert.True(t, sink.aborted)
@@ -85,10 +94,30 @@ func TestStreamThrough_CloseSurfacesPublishError(t *testing.T) {
 	stream := streamThrough(io.NopCloser(bytes.NewReader([]byte("hello"))), sink, nil, nil)
 
 	_, err := io.ReadAll(stream)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, closeErr)
 	require.ErrorIs(t, stream.Close(), closeErr)
 	assert.True(t, sink.closed)
 	assert.False(t, sink.aborted)
+}
+
+func TestStreamThrough_AutoCloseSuppressesPureInvalidation(t *testing.T) {
+	sink := &recordingWriteSink{closeErr: ErrTopWriteInvalidated}
+	stream := streamThrough(io.NopCloser(bytes.NewReader([]byte("hello"))), sink, nil, nil)
+
+	_, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	require.ErrorIs(t, stream.Close(), ErrTopWriteInvalidated)
+}
+
+func TestStreamThrough_AutoCloseReportsInvalidationCleanupError(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	sink := &recordingWriteSink{closeErr: errors.Join(ErrTopWriteInvalidated, cleanupErr)}
+	stream := streamThrough(io.NopCloser(bytes.NewReader([]byte("hello"))), sink, nil, nil)
+
+	_, err := io.ReadAll(stream)
+	require.ErrorIs(t, err, cleanupErr)
+	require.ErrorIs(t, stream.Close(), cleanupErr)
+	require.ErrorIs(t, stream.Close(), ErrTopWriteInvalidated)
 }
 
 func TestStreamThrough_CopyUsesSourceWriterTo(t *testing.T) {
@@ -100,12 +129,36 @@ func TestStreamThrough_CopyUsesSourceWriterTo(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, 5, n)
 	assert.True(t, src.writeToCalled, "streamThrough should preserve the source WriterTo fast path")
-	assert.False(t, sink.closed)
+	assert.True(t, sink.closed)
 	assert.False(t, sink.aborted)
 
 	require.NoError(t, stream.Close())
 	assert.True(t, sink.closed)
 	assert.Equal(t, []byte("hello"), sink.buf.Bytes())
+}
+
+func TestStreamThrough_CopyAutoCloseSuppressesPureInvalidation(t *testing.T) {
+	src := &writerToSpyReadCloser{Reader: bytes.NewReader([]byte("hello"))}
+	sink := &recordingWriteSink{closeErr: ErrTopWriteInvalidated}
+	stream := streamThrough(src, sink, nil, nil)
+
+	n, err := io.Copy(io.Discard, stream)
+	require.NoError(t, err)
+	assert.EqualValues(t, 5, n)
+	require.ErrorIs(t, stream.Close(), ErrTopWriteInvalidated)
+}
+
+func TestStreamThrough_CopyAutoCloseReportsInvalidationCleanupError(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	src := &writerToSpyReadCloser{Reader: bytes.NewReader([]byte("hello"))}
+	sink := &recordingWriteSink{closeErr: errors.Join(ErrTopWriteInvalidated, cleanupErr)}
+	stream := streamThrough(src, sink, nil, nil)
+
+	n, err := io.Copy(io.Discard, stream)
+	require.ErrorIs(t, err, cleanupErr)
+	assert.EqualValues(t, 5, n)
+	require.ErrorIs(t, stream.Close(), cleanupErr)
+	require.ErrorIs(t, stream.Close(), ErrTopWriteInvalidated)
 }
 
 func TestStreamThrough_CopyShortWriteWithWriterToAborts(t *testing.T) {
@@ -116,22 +169,153 @@ func TestStreamThrough_CopyShortWriteWithWriterToAborts(t *testing.T) {
 	_, err := io.Copy(io.Discard, stream)
 	require.ErrorIs(t, err, io.ErrShortWrite)
 	assert.True(t, src.writeToCalled, "streamThrough should use the source WriterTo fast path")
+	assert.True(t, sink.aborted)
 
 	require.NoError(t, stream.Close())
 	assert.True(t, sink.aborted)
 	assert.False(t, sink.closed)
 }
 
+func TestStreamThrough_ConcurrentCloseWaitsAndReturnsFinalError(t *testing.T) {
+	closeErr := errors.New("abort failed")
+	sink := newBlockingAbortSink(closeErr)
+	stream := streamThrough(io.NopCloser(bytes.NewReader([]byte("hello"))), sink, nil, nil)
+
+	const closeCalls = 8
+	errs := make(chan error, closeCalls)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errs <- stream.Close()
+	}()
+	<-sink.abortStarted
+
+	wg.Add(closeCalls - 1)
+	for i := 1; i < closeCalls; i++ {
+		go func() {
+			defer wg.Done()
+			errs <- stream.Close()
+		}()
+	}
+
+	close(sink.releaseAbort)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.ErrorIs(t, err, closeErr)
+	}
+}
+
+func TestStreamThrough_AutoPublishClosesSourceBeforeSinkClose(t *testing.T) {
+	srcCloseErr := errors.New("source close failed")
+	sink := &recordingWriteSink{}
+	src := &closeCountingReadCloser{
+		Reader:   bytes.NewReader([]byte("hello")),
+		closeErr: srcCloseErr,
+	}
+	publishCount := 0
+	stream := streamThrough(src, sink, nil, func() { publishCount++ })
+
+	got, err := io.ReadAll(stream)
+	require.ErrorIs(t, err, srcCloseErr)
+	assert.Equal(t, []byte("hello"), got)
+	assert.Equal(t, 1, src.closeCount)
+	assert.False(t, sink.closed)
+	assert.True(t, sink.aborted)
+	assert.Equal(t, 0, publishCount)
+}
+
+func TestStreamThrough_ReadAfterAutoEOFDoesNotTouchClosedSource(t *testing.T) {
+	afterCloseErr := errors.New("read after close")
+	src := &readAfterCloseTrackingSource{Reader: bytes.NewReader([]byte("hello")), afterCloseErr: afterCloseErr}
+	sink := &recordingWriteSink{}
+	stream := streamThrough(src, sink, nil, nil)
+
+	got, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), got)
+
+	buf := make([]byte, 1)
+	n, err := stream.Read(buf)
+	require.ErrorIs(t, err, io.EOF)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, 0, src.readAfterClose)
+}
+
+func TestStreamThrough_ReadAfterPartialCloseDoesNotTouchClosedSource(t *testing.T) {
+	afterCloseErr := errors.New("read after close")
+	src := &readAfterCloseTrackingSource{Reader: bytes.NewReader([]byte("hello")), afterCloseErr: afterCloseErr}
+	sink := &recordingWriteSink{}
+	stream := streamThrough(src, sink, nil, nil)
+
+	buf := make([]byte, 2)
+	n, err := stream.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, "he", string(buf[:n]))
+
+	require.NoError(t, stream.Close())
+
+	n, err = stream.Read(buf)
+	require.ErrorIs(t, err, io.ErrClosedPipe)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, 0, src.readAfterClose)
+	assert.True(t, sink.aborted)
+	assert.False(t, sink.closed)
+}
+
+func TestStreamThrough_ReadWithDataJoinsReadAndSinkErrors(t *testing.T) {
+	readErr := errors.New("source read failed")
+	sinkErr := errors.New("sink write failed")
+	src := &singleReadErrorCloser{data: []byte("hello"), err: readErr}
+	sink := &recordingWriteSink{writeErr: sinkErr}
+	stream := streamThrough(src, sink, nil, nil)
+
+	buf := make([]byte, 8)
+	n, err := stream.Read(buf)
+	assert.Equal(t, 5, n)
+	require.ErrorIs(t, err, readErr)
+	require.ErrorIs(t, err, sinkErr)
+	assert.True(t, sink.aborted)
+}
+
+func TestStreamThrough_AutoCloseSuppressesInvalidationButReportsSourceCloseError(t *testing.T) {
+	srcCloseErr := errors.New("source close failed")
+	src := &closeCountingReadCloser{
+		Reader:   bytes.NewReader([]byte("hello")),
+		closeErr: srcCloseErr,
+	}
+	sink := &recordingWriteSink{abortErr: ErrTopWriteInvalidated}
+	stream := streamThrough(src, sink, nil, nil)
+
+	got, err := io.ReadAll(stream)
+	require.ErrorIs(t, err, srcCloseErr)
+	require.NotErrorIs(t, err, ErrTopWriteInvalidated)
+	assert.Equal(t, []byte("hello"), got)
+	assert.False(t, sink.closed)
+	assert.True(t, sink.aborted)
+
+	closeErr := stream.Close()
+	require.ErrorIs(t, closeErr, srcCloseErr)
+	require.ErrorIs(t, closeErr, ErrTopWriteInvalidated)
+}
+
 type recordingWriteSink struct {
 	buf        bytes.Buffer
 	closeErr   error
 	abortErr   error
+	writeErr   error
 	shortWrite bool
 	closed     bool
 	aborted    bool
 }
 
 func (s *recordingWriteSink) Write(p []byte) (int, error) {
+	if s.writeErr != nil {
+		return 0, s.writeErr
+	}
 	if s.shortWrite && len(p) > 0 {
 		n, err := s.buf.Write(p[:len(p)-1])
 		if err != nil {
@@ -182,5 +366,79 @@ func (r *writerToSpyReadCloser) WriteTo(w io.Writer) (int64, error) {
 }
 
 func (r *writerToSpyReadCloser) Close() error {
+	return nil
+}
+
+type closeCountingReadCloser struct {
+	io.Reader
+	closeCount int
+	closeErr   error
+}
+
+func (r *closeCountingReadCloser) Close() error {
+	r.closeCount++
+	return r.closeErr
+}
+
+type blockingAbortSink struct {
+	recordingWriteSink
+	abortErr     error
+	abortStarted chan struct{}
+	releaseAbort chan struct{}
+	once         sync.Once
+}
+
+func newBlockingAbortSink(abortErr error) *blockingAbortSink {
+	return &blockingAbortSink{
+		abortErr:     abortErr,
+		abortStarted: make(chan struct{}),
+		releaseAbort: make(chan struct{}),
+	}
+}
+
+func (s *blockingAbortSink) Abort() error {
+	s.once.Do(func() {
+		close(s.abortStarted)
+	})
+	<-s.releaseAbort
+	s.aborted = true
+	return s.abortErr
+}
+
+type readAfterCloseTrackingSource struct {
+	*bytes.Reader
+	afterCloseErr  error
+	closed         bool
+	readAfterClose int
+}
+
+func (r *readAfterCloseTrackingSource) Read(p []byte) (int, error) {
+	if r.closed {
+		r.readAfterClose++
+		return 0, r.afterCloseErr
+	}
+	return r.Reader.Read(p)
+}
+
+func (r *readAfterCloseTrackingSource) Close() error {
+	r.closed = true
+	return nil
+}
+
+type singleReadErrorCloser struct {
+	data []byte
+	err  error
+	read bool
+}
+
+func (r *singleReadErrorCloser) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+	r.read = true
+	return copy(p, r.data), r.err
+}
+
+func (r *singleReadErrorCloser) Close() error {
 	return nil
 }

--- a/streaming_reader_test.go
+++ b/streaming_reader_test.go
@@ -197,6 +197,20 @@ func TestStreamThrough_CopyShortWriteWithWriterToAborts(t *testing.T) {
 	assert.False(t, sink.closed)
 }
 
+func TestStreamThrough_CopyWriterToJoinsSourceAndSinkErrors(t *testing.T) {
+	readErr := errors.New("source write-to failed")
+	sinkErr := errors.New("sink write failed")
+	src := &writerToErrorReadCloser{data: []byte("hello"), err: readErr}
+	sink := &recordingWriteSink{writeErr: sinkErr}
+	stream := streamThrough(src, sink, nil, nil)
+
+	n, err := io.Copy(io.Discard, stream)
+	require.ErrorIs(t, err, readErr)
+	require.ErrorIs(t, err, sinkErr)
+	assert.EqualValues(t, 0, n)
+	assert.True(t, sink.aborted)
+}
+
 func TestStreamThrough_ConcurrentCloseWaitsAndReturnsFinalError(t *testing.T) {
 	closeErr := errors.New("abort failed")
 	sink := newBlockingAbortSink(closeErr)
@@ -387,6 +401,24 @@ func (r *writerToSpyReadCloser) WriteTo(w io.Writer) (int64, error) {
 }
 
 func (r *writerToSpyReadCloser) Close() error {
+	return nil
+}
+
+type writerToErrorReadCloser struct {
+	data []byte
+	err  error
+}
+
+func (r *writerToErrorReadCloser) Read(p []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (r *writerToErrorReadCloser) WriteTo(w io.Writer) (int64, error) {
+	_, _ = w.Write(r.data)
+	return 0, r.err
+}
+
+func (r *writerToErrorReadCloser) Close() error {
 	return nil
 }
 

--- a/streaming_reader_test.go
+++ b/streaming_reader_test.go
@@ -2,11 +2,13 @@ package daramjwee
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -357,6 +359,116 @@ func TestStreamThrough_AutoCloseSuppressesInvalidationButReportsSourceCloseError
 	require.ErrorIs(t, closeErr, ErrTopWriteInvalidated)
 }
 
+func TestTopFillSinkPreemptDoesNotWaitForBlockedWrite(t *testing.T) {
+	sink := newBlockingWriteSink()
+	fill := newPendingTopFillSink(&writeCoordinator{}, nil, nil)
+	require.True(t, fill.attach(sink))
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := fill.Write([]byte("partial"))
+		writeDone <- err
+	}()
+
+	<-sink.writeStarted
+
+	preemptDone := make(chan error, 1)
+	go func() {
+		preemptDone <- fill.Preempt()
+	}()
+
+	select {
+	case err := <-preemptDone:
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+		close(sink.releaseWrite)
+		t.Fatal("preempt waited for blocked write")
+	}
+
+	close(sink.releaseWrite)
+	require.NoError(t, <-writeDone)
+	select {
+	case <-sink.abortStarted:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("preempt cleanup did not abort sink after write completed")
+	}
+}
+
+func TestTopFillSinkPreemptReleasesCoordinatorBeforeBlockedWriteFinishes(t *testing.T) {
+	sink := newBlockingWriteSink()
+	coord := &writeCoordinator{}
+	require.NoError(t, coord.acquireWrite(context.Background()))
+	coord.stateMu.Lock()
+	generation := coord.reserveGenerationLocked()
+	coord.stateMu.Unlock()
+
+	fill := newPendingTopFillSink(coord, nil, nil)
+	require.True(t, fill.attach(&coordinatedTopWriteSink{
+		WriteSink:   sink,
+		coord:       coord,
+		generation:  generation,
+		waitTimeout: time.Second,
+	}))
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := fill.Write([]byte("partial"))
+		writeDone <- err
+	}()
+
+	<-sink.writeStarted
+	require.NoError(t, fill.Preempt())
+
+	acquireCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	require.NoError(t, coord.acquireWrite(acquireCtx))
+	coord.releaseWrite()
+
+	close(sink.releaseWrite)
+	require.NoError(t, <-writeDone)
+	select {
+	case <-sink.abortStarted:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("preempt cleanup did not abort sink after write completed")
+	}
+}
+
+func TestTopFillSinkCloseDoesNotPublishDuringBlockedWrite(t *testing.T) {
+	sink := newBlockingWriteSink()
+	fill := newPendingTopFillSink(&writeCoordinator{}, nil, nil)
+	require.True(t, fill.attach(sink))
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := fill.Write([]byte("partial"))
+		writeDone <- err
+	}()
+
+	<-sink.writeStarted
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- fill.Close()
+	}()
+
+	select {
+	case <-sink.closeStarted:
+		close(sink.releaseWrite)
+		t.Fatal("close published while write was still blocked")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(sink.releaseWrite)
+	require.NoError(t, <-writeDone)
+	require.NoError(t, <-closeDone)
+
+	select {
+	case <-sink.closeStarted:
+	default:
+		t.Fatal("close did not reach sink after write completed")
+	}
+}
+
 type recordingWriteSink struct {
 	buf        bytes.Buffer
 	closeErr   error
@@ -476,6 +588,44 @@ func (s *blockingAbortSink) Abort() error {
 	<-s.releaseAbort
 	s.aborted = true
 	return s.abortErr
+}
+
+type blockingWriteSink struct {
+	writeStarted chan struct{}
+	releaseWrite chan struct{}
+	closeStarted chan struct{}
+	abortStarted chan struct{}
+	once         sync.Once
+	abortOnce    sync.Once
+}
+
+func newBlockingWriteSink() *blockingWriteSink {
+	return &blockingWriteSink{
+		writeStarted: make(chan struct{}),
+		releaseWrite: make(chan struct{}),
+		closeStarted: make(chan struct{}),
+		abortStarted: make(chan struct{}),
+	}
+}
+
+func (s *blockingWriteSink) Write(p []byte) (int, error) {
+	s.once.Do(func() {
+		close(s.writeStarted)
+	})
+	<-s.releaseWrite
+	return len(p), nil
+}
+
+func (s *blockingWriteSink) Close() error {
+	close(s.closeStarted)
+	return nil
+}
+
+func (s *blockingWriteSink) Abort() error {
+	s.abortOnce.Do(func() {
+		close(s.abortStarted)
+	})
+	return nil
 }
 
 type readAfterCloseTrackingSource struct {

--- a/tests/background_fuzz_test.go
+++ b/tests/background_fuzz_test.go
@@ -56,6 +56,7 @@ func FuzzScheduleRefreshBackgroundStateMachine(f *testing.F) {
 			case 2:
 				require.NoError(t, cache.ScheduleRefresh(ctx, key, cacheableNotFoundFetcher{}))
 				hotState[key] = entryExpectation{present: true, negative: true}
+				coldState[key] = entryExpectation{present: true, negative: true}
 				eventuallyExpectStoreState(t, hot, key, hotState[key])
 				eventuallyExpectStoreState(t, cold, key, coldState[key])
 			case 3:

--- a/tests/cache_regression_test.go
+++ b/tests/cache_regression_test.go
@@ -121,6 +121,55 @@ func TestScheduleRefresh_DoesNotPublishPartialDataOnCopyFailure(t *testing.T) {
 	assert.Equal(t, "v0", meta.CacheTag)
 }
 
+func TestScheduleRefresh_DoesNotPublishWhenSourceCloseFails(t *testing.T) {
+	hot := newMockStore()
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	ctx := context.Background()
+	key := "refresh-close-error"
+	wc, err := cache.Set(ctx, key, &daramjwee.Metadata{CacheTag: "v0"})
+	require.NoError(t, err)
+	_, err = wc.Write([]byte("old-value"))
+	require.NoError(t, err)
+	require.NoError(t, wc.Close())
+
+	closeErr := errors.New("refresh source close failed")
+	closed := make(chan struct{})
+	fetcher := &readCloserRefreshFetcher{
+		body: &closeTrackingReadCloser{
+			Reader:   bytes.NewReader([]byte("new-value")),
+			onClose:  func() { close(closed) },
+			closeErr: closeErr,
+		},
+		meta: &daramjwee.Metadata{CacheTag: "v1"},
+	}
+
+	require.NoError(t, cache.ScheduleRefresh(ctx, key, fetcher))
+	require.Eventually(t, func() bool {
+		select {
+		case <-closed:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	reader, meta, err := hot.GetStream(ctx, key)
+	require.NoError(t, err)
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "old-value", string(body))
+	assert.Equal(t, "v0", meta.CacheTag)
+}
+
 func TestScheduleRefresh_WithoutColdStoreDoesNotPanicWorker(t *testing.T) {
 	logBuf := &lockedBuffer{}
 	logger := log.NewLogfmtLogger(logBuf)
@@ -1096,6 +1145,18 @@ type failingRefreshFetcher struct {
 }
 
 func (f *failingRefreshFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	return &daramjwee.FetchResult{
+		Body:     f.body,
+		Metadata: f.meta,
+	}, nil
+}
+
+type readCloserRefreshFetcher struct {
+	body io.ReadCloser
+	meta *daramjwee.Metadata
+}
+
+func (f *readCloserRefreshFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
 	return &daramjwee.FetchResult{
 		Body:     f.body,
 		Metadata: f.meta,

--- a/tests/cache_stuck_repro_test.go
+++ b/tests/cache_stuck_repro_test.go
@@ -1,0 +1,651 @@
+package daramjwee_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee"
+	"github.com/mrchypark/daramjwee/pkg/store/filestore"
+)
+
+const cacheStuckReproEnv = "DJ_REPRO_CACHE_STUCK"
+
+func requireCacheStuckReproEnabled(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv(cacheStuckReproEnv) != "1" {
+		tb.Skipf("set %s=1 to run cache stuck reproduction", cacheStuckReproEnv)
+	}
+}
+
+func TestFileStore_UnconsumedMissBodyDoesNotBlockSameKeyUpdate(t *testing.T) {
+	store, err := filestore.New(t.TempDir(), log.NewNopLogger())
+	if err != nil {
+		t.Fatalf("new filestore: %v", err)
+	}
+	cache, err := daramjwee.New(
+		log.NewNopLogger(),
+		daramjwee.WithTiers(store),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	if err != nil {
+		t.Fatalf("new cache: %v", err)
+	}
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "filestore-unconsumed-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "origin-value",
+		etag:    "origin-v1",
+	})
+	if err != nil {
+		t.Fatalf("get miss: %v", err)
+	}
+	defer resp.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- writeCacheValue(cache, "filestore-unconsumed-key", "user-value", "user-v2")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("same-key update failed: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("same-key filestore update blocked behind an unconsumed miss body")
+	}
+
+	body, err := io.ReadAll(resp)
+	if err != nil {
+		t.Fatalf("read original response body: %v", err)
+	}
+	if string(body) != "origin-value" {
+		t.Fatalf("original response body = %q, want origin-value", body)
+	}
+
+	current, meta, err := readStoreValue(context.Background(), store, "filestore-unconsumed-key")
+	if err != nil {
+		t.Fatalf("read filestore value: %v", err)
+	}
+	if current != "user-value" {
+		t.Fatalf("filestore value = %q, want user-value", current)
+	}
+	if meta.CacheTag != "user-v2" {
+		t.Fatalf("filestore cache tag = %q, want user-v2", meta.CacheTag)
+	}
+}
+
+func TestFileStore_UnconsumedMissBodyDoesNotBlockHeldAndControlUpdates(t *testing.T) {
+	store, err := filestore.New(t.TempDir(), log.NewNopLogger())
+	if err != nil {
+		t.Fatalf("new filestore: %v", err)
+	}
+	cache, err := daramjwee.New(
+		log.NewNopLogger(),
+		daramjwee.WithTiers(store),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	if err != nil {
+		t.Fatalf("new cache: %v", err)
+	}
+	defer cache.Close()
+
+	const heldKey = "filestore-held-two-key"
+	const controlKey = "filestore-control-two-key"
+	heldResp, err := cache.Get(context.Background(), heldKey, daramjwee.GetRequest{}, &mockFetcher{
+		content: "held-origin",
+		etag:    "held-origin-v1",
+	})
+	if err != nil {
+		t.Fatalf("get held miss: %v", err)
+	}
+	defer heldResp.Close()
+
+	done := make(chan reproWriteResult, 2)
+	go func() {
+		done <- reproWriteResult{index: 0, err: writeCacheValue(cache, heldKey, "held-user", "held-user-v2")}
+	}()
+	go func() {
+		done <- reproWriteResult{index: 1, err: writeCacheValue(cache, controlKey, "control-user", "control-user-v2")}
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case result := <-done:
+			if result.err != nil {
+				t.Fatalf("update %d failed: %v", result.index, result.err)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("filestore updates blocked behind one unconsumed miss body")
+		}
+	}
+
+	body, err := io.ReadAll(heldResp)
+	if err != nil {
+		t.Fatalf("read held response body: %v", err)
+	}
+	if string(body) != "held-origin" {
+		t.Fatalf("held response body = %q, want held-origin", body)
+	}
+	if err := heldResp.Close(); err != nil {
+		t.Fatalf("close held response: %v", err)
+	}
+
+	got, meta, err := readStoreValue(context.Background(), store, heldKey)
+	if err != nil {
+		t.Fatalf("read held filestore value: %v", err)
+	}
+	if got != "held-user" || meta.CacheTag != "held-user-v2" {
+		t.Fatalf("held filestore value=%q tag=%q, want value=held-user tag=held-user-v2", got, meta.CacheTag)
+	}
+
+	got, meta, err = readStoreValue(context.Background(), store, controlKey)
+	if err != nil {
+		t.Fatalf("read control filestore value: %v", err)
+	}
+	if got != "control-user" || meta.CacheTag != "control-user-v2" {
+		t.Fatalf("control filestore value=%q tag=%q, want value=control-user tag=control-user-v2", got, meta.CacheTag)
+	}
+}
+
+func TestRepro_UnconsumedMissBodyDoesNotBlockSameKeyUpdate(t *testing.T) {
+	requireCacheStuckReproEnabled(t)
+
+	hot := newMockStore()
+	diag := newReproDiagnosticLogger()
+	cache, err := daramjwee.New(diag, daramjwee.WithTiers(hot), daramjwee.WithOpTimeout(5*time.Second))
+	if err != nil {
+		t.Fatalf("new cache: %v", err)
+	}
+	defer cache.Close()
+
+	stuckKey := "repro-stuck-key"
+	freeKey := "repro-free-key"
+
+	stuckResp, err := cache.Get(context.Background(), stuckKey, daramjwee.GetRequest{}, &mockFetcher{
+		content: "seed",
+		etag:    "seed",
+	})
+	if err != nil {
+		t.Fatalf("get stuck key: %v", err)
+	}
+
+	sameKeyDone := make(chan error, 1)
+	go func() {
+		sameKeyDone <- writeCacheValue(cache, stuckKey, "updated", "updated")
+	}()
+
+	otherKeyDone := make(chan error, 1)
+	go func() {
+		otherKeyDone <- writeCacheValue(cache, freeKey, "other", "other")
+	}()
+
+	select {
+	case err := <-otherKeyDone:
+		if err != nil {
+			_ = stuckResp.Close()
+			t.Fatalf("other key update failed: %v\n%s", err, diag.Dump(200))
+		}
+	case <-time.After(250 * time.Millisecond):
+		_ = stuckResp.Close()
+		t.Fatalf("control update for unrelated key also blocked\n%s", diag.Dump(200))
+	}
+
+	select {
+	case err := <-sameKeyDone:
+		if err != nil {
+			_ = stuckResp.Close()
+			t.Fatalf("same-key update failed: %v\n%s", err, diag.Dump(200))
+		}
+	case <-time.After(250 * time.Millisecond):
+		_ = stuckResp.Close()
+		t.Fatalf("same-key update blocked behind the unclosed response\n%s", diag.Dump(200))
+	}
+
+	if err := stuckResp.Close(); err != nil {
+		t.Fatalf("cleanup close stuck response: %v\n%s", err, diag.Dump(200))
+	}
+	t.Logf("fixed: same-key update completed while the original cache miss response body remained unclosed\n%s", diag.Dump(200))
+}
+
+func BenchmarkRepro_UnconsumedBodiesNoLongerCauseKeySpecificUpdateStalls(b *testing.B) {
+	requireCacheStuckReproEnabled(b)
+
+	totalStalled := 0
+	for i := 0; i < b.N; i++ {
+		stalled, diag := runLargeUnclosedBodyUpdateRepro(b, 512, 128, 300*time.Millisecond)
+		totalStalled += stalled
+		if stalled > 0 {
+			b.Fatalf("%d same-key updates stalled behind unclosed response bodies\n%s", stalled, diag.Dump(120))
+		}
+	}
+	b.ReportMetric(float64(totalStalled)/float64(b.N), "stalled_keys/op")
+}
+
+func FuzzRepro_UnconsumedBodyDoesNotBlockSelectedKeys(f *testing.F) {
+	f.Add([]byte{0xff, 0x0f, 0xf0, 0x55, 0xaa})
+	f.Add([]byte{0x01})
+
+	f.Fuzz(func(t *testing.T, pattern []byte) {
+		requireCacheStuckReproEnabled(t)
+		if len(pattern) == 0 {
+			return
+		}
+
+		keyCount := 8 + int(pattern[0]%24)
+		hold := make([]bool, keyCount)
+		heldCount := 0
+		for i := 0; i < keyCount; i++ {
+			if pattern[i%len(pattern)]&(1<<uint(i%8)) != 0 {
+				hold[i] = true
+				heldCount++
+			}
+		}
+		if heldCount == 0 {
+			return
+		}
+
+		stalled, diag := runPatternUnclosedBodyUpdateRepro(t, hold, 200*time.Millisecond)
+		if stalled > 0 {
+			t.Fatalf("%d selected-key updates stalled behind unclosed response bodies; held=%d\n%s", stalled, heldCount, diag.Dump(120))
+		}
+	})
+}
+
+func TestRepro_AllClosedMissesPublishEveryFileStoreKey(t *testing.T) {
+	const keyCount = 256
+	store, err := filestore.New(t.TempDir(), log.NewNopLogger())
+	if err != nil {
+		t.Fatalf("new filestore: %v", err)
+	}
+	diag := newReproDiagnosticLogger()
+	cache, err := daramjwee.New(
+		diag,
+		daramjwee.WithTiers(store),
+		daramjwee.WithWorkers(16),
+		daramjwee.WithWorkerQueue(1024),
+		daramjwee.WithWorkerTimeout(5*time.Second),
+		daramjwee.WithOpTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("new cache: %v", err)
+	}
+	defer cache.Close()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, keyCount)
+	for i := 0; i < keyCount; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("closed-miss-key-%04d", i)
+			value := fmt.Sprintf("miss-value-%04d", i)
+			resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, staticFetcher{
+				value:    value,
+				cacheTag: value,
+			})
+			if err != nil {
+				errs <- fmt.Errorf("%s get: %w", key, err)
+				return
+			}
+			body, readErr := io.ReadAll(resp)
+			closeErr := resp.Close()
+			if readErr != nil || closeErr != nil {
+				errs <- fmt.Errorf("%s read=%v close=%v", key, readErr, closeErr)
+				return
+			}
+			if string(body) != value {
+				errs <- fmt.Errorf("%s response body=%q want=%q", key, body, value)
+				return
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("%v\n%s", err, diag.Dump(200))
+		}
+	}
+
+	for i := 0; i < keyCount; i++ {
+		key := fmt.Sprintf("closed-miss-key-%04d", i)
+		want := fmt.Sprintf("miss-value-%04d", i)
+		got, meta, err := readStoreValue(context.Background(), store, key)
+		if err != nil {
+			t.Fatalf("%s read store: %v\n%s", key, err, diag.Dump(200))
+		}
+		if got != want || meta.CacheTag != want {
+			t.Fatalf("%s store=%q tag=%q want=%q\n%s", key, got, meta.CacheTag, want, diag.Dump(200))
+		}
+	}
+}
+
+func TestRepro_AllClosedStaleRefreshesUpdateEveryFileStoreKey(t *testing.T) {
+	const keyCount = 256
+	ctx := context.Background()
+	store, err := filestore.New(t.TempDir(), log.NewNopLogger())
+	if err != nil {
+		t.Fatalf("new filestore: %v", err)
+	}
+	oldCachedAt := time.Now().Add(-2 * time.Hour)
+	for i := 0; i < keyCount; i++ {
+		key := fmt.Sprintf("closed-stale-key-%04d", i)
+		writer, err := store.BeginSet(ctx, key, &daramjwee.Metadata{
+			CacheTag: fmt.Sprintf("old-%04d", i),
+			CachedAt: oldCachedAt,
+		})
+		if err != nil {
+			t.Fatalf("%s seed begin: %v", key, err)
+		}
+		if _, err := io.WriteString(writer, fmt.Sprintf("old-value-%04d", i)); err != nil {
+			_ = writer.Abort()
+			t.Fatalf("%s seed write: %v", key, err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("%s seed close: %v", key, err)
+		}
+	}
+
+	diag := newReproDiagnosticLogger()
+	cache, err := daramjwee.New(
+		diag,
+		daramjwee.WithTiers(store),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithWorkers(16),
+		daramjwee.WithWorkerQueue(1024),
+		daramjwee.WithWorkerTimeout(5*time.Second),
+		daramjwee.WithOpTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("new cache: %v", err)
+	}
+	defer cache.Close()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, keyCount)
+	for i := 0; i < keyCount; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("closed-stale-key-%04d", i)
+			newValue := fmt.Sprintf("new-value-%04d", i)
+			resp, err := cache.Get(ctx, key, daramjwee.GetRequest{}, staticFetcher{
+				value:    newValue,
+				cacheTag: fmt.Sprintf("new-%04d", i),
+			})
+			if err != nil {
+				errs <- fmt.Errorf("%s get: %w", key, err)
+				return
+			}
+			body, readErr := io.ReadAll(resp)
+			closeErr := resp.Close()
+			if readErr != nil || closeErr != nil {
+				errs <- fmt.Errorf("%s read=%v close=%v", key, readErr, closeErr)
+				return
+			}
+			if string(body) != fmt.Sprintf("old-value-%04d", i) {
+				errs <- fmt.Errorf("%s stale body=%q", key, body)
+				return
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("%v\n%s", err, diag.Dump(200))
+		}
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		missing := firstNotRefreshedKey(t, store, keyCount)
+		if missing == "" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stale refresh did not update %s after every response was closed\n%s", missing, diag.Dump(240))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func runLargeUnclosedBodyUpdateRepro(tb testing.TB, keyCount, heldCount int, wait time.Duration) (int, *reproDiagnosticLogger) {
+	tb.Helper()
+	hold := make([]bool, keyCount)
+	for i := 0; i < heldCount && i < keyCount; i++ {
+		hold[i] = true
+	}
+	return runPatternUnclosedBodyUpdateRepro(tb, hold, wait)
+}
+
+func runPatternUnclosedBodyUpdateRepro(tb testing.TB, hold []bool, wait time.Duration) (int, *reproDiagnosticLogger) {
+	tb.Helper()
+
+	hot := newMockStore()
+	diag := newReproDiagnosticLogger()
+	cache, err := daramjwee.New(diag, daramjwee.WithTiers(hot), daramjwee.WithOpTimeout(5*time.Second))
+	if err != nil {
+		tb.Fatalf("new cache: %v", err)
+	}
+	defer cache.Close()
+
+	heldResponses := make([]*daramjwee.GetResponse, 0, len(hold))
+	for i, shouldHold := range hold {
+		if !shouldHold {
+			continue
+		}
+		key := fmt.Sprintf("repro-key-%04d", i)
+		resp, err := cache.Get(context.Background(), key, daramjwee.GetRequest{}, &mockFetcher{
+			content: "seed",
+			etag:    "seed",
+		})
+		if err != nil {
+			closeReproResponses(heldResponses)
+			tb.Fatalf("prime held response %s: %v\n%s", key, err, diag.Dump(120))
+		}
+		heldResponses = append(heldResponses, resp)
+	}
+
+	var wg sync.WaitGroup
+	started := make(chan struct{}, len(hold))
+	release := make(chan struct{})
+	results := make(chan reproWriteResult, len(hold))
+	for i := range hold {
+		i := i
+		key := fmt.Sprintf("repro-key-%04d", i)
+		wg.Add(1)
+		go func(key string) {
+			defer wg.Done()
+			started <- struct{}{}
+			<-release
+			results <- reproWriteResult{index: i, err: writeCacheValue(cache, key, "updated", "updated")}
+		}(key)
+	}
+	for range hold {
+		<-started
+	}
+	close(release)
+
+	time.Sleep(wait)
+	completed := make([]bool, len(hold))
+drainResults:
+	for {
+		select {
+		case result := <-results:
+			if result.err != nil {
+				closeReproResponses(heldResponses)
+				tb.Fatalf("write for key index %d returned error instead of blocking/completing: %v\n%s", result.index, result.err, diag.Dump(120))
+			}
+			completed[result.index] = true
+		default:
+			break drainResults
+		}
+	}
+
+	stalled := 0
+	stalledControl := 0
+	for i, shouldHold := range hold {
+		if completed[i] {
+			continue
+		}
+		if shouldHold {
+			stalled++
+		} else {
+			stalledControl++
+		}
+	}
+	if stalledControl > 0 {
+		closeReproResponses(heldResponses)
+		tb.Fatalf("%d control keys stalled without held response bodies\n%s", stalledControl, diag.Dump(120))
+	}
+
+	closeReproResponses(heldResponses)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		tb.Fatalf("cleanup timed out waiting for blocked updates to finish\n%s", diag.Dump(120))
+	}
+
+	return stalled, diag
+}
+
+type reproWriteResult struct {
+	index int
+	err   error
+}
+
+func closeReproResponses(responses []*daramjwee.GetResponse) {
+	for _, resp := range responses {
+		_ = resp.Close()
+	}
+}
+
+func writeCacheValue(cache daramjwee.Cache, key, value, tag string) error {
+	writer, err := cache.Set(context.Background(), key, &daramjwee.Metadata{CacheTag: tag})
+	if err != nil {
+		return err
+	}
+	if _, err := io.WriteString(writer, value); err != nil {
+		abortErr := writer.Abort()
+		if abortErr != nil {
+			return fmt.Errorf("write: %w; abort: %v", err, abortErr)
+		}
+		return err
+	}
+	return writer.Close()
+}
+
+type staticFetcher struct {
+	value    string
+	cacheTag string
+}
+
+func (f staticFetcher) Fetch(context.Context, *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	return &daramjwee.FetchResult{
+		Body:     io.NopCloser(strings.NewReader(f.value)),
+		Metadata: &daramjwee.Metadata{CacheTag: f.cacheTag},
+	}, nil
+}
+
+func firstNotRefreshedKey(tb testing.TB, store daramjwee.Store, keyCount int) string {
+	tb.Helper()
+	for i := 0; i < keyCount; i++ {
+		key := fmt.Sprintf("closed-stale-key-%04d", i)
+		wantValue := fmt.Sprintf("new-value-%04d", i)
+		wantTag := fmt.Sprintf("new-%04d", i)
+		got, meta, err := readStoreValue(context.Background(), store, key)
+		if err != nil {
+			return fmt.Sprintf("%s: %v", key, err)
+		}
+		if got != wantValue || meta.CacheTag != wantTag {
+			return fmt.Sprintf("%s: got value=%q tag=%q want value=%q tag=%q", key, got, meta.CacheTag, wantValue, wantTag)
+		}
+	}
+	return ""
+}
+
+func readStoreValue(ctx context.Context, store daramjwee.Store, key string) (string, *daramjwee.Metadata, error) {
+	reader, meta, err := store.GetStream(ctx, key)
+	if err != nil {
+		return "", nil, err
+	}
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return "", nil, err
+	}
+	return string(body), meta, nil
+}
+
+type reproDiagnosticLogger struct {
+	mu     sync.Mutex
+	start  time.Time
+	events []string
+}
+
+func newReproDiagnosticLogger() *reproDiagnosticLogger {
+	return &reproDiagnosticLogger{start: time.Now()}
+}
+
+func (l *reproDiagnosticLogger) Log(keyvals ...any) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "+%s", time.Since(l.start).Truncate(time.Microsecond))
+	for i := 0; i < len(keyvals); i += 2 {
+		key := keyvals[i]
+		var value any = "<missing>"
+		if i+1 < len(keyvals) {
+			value = keyvals[i+1]
+		}
+		fmt.Fprintf(&b, " %v=%v", key, value)
+	}
+	l.events = append(l.events, b.String())
+	return nil
+}
+
+func (l *reproDiagnosticLogger) Dump(limit int) string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if len(l.events) == 0 {
+		return "diagnostic events: <none>"
+	}
+
+	start := 0
+	if limit > 0 && len(l.events) > limit {
+		start = len(l.events) - limit
+	}
+
+	var b strings.Builder
+	if start > 0 {
+		fmt.Fprintf(&b, "diagnostic events: showing last %d of %d\n", len(l.events)-start, len(l.events))
+	} else {
+		fmt.Fprintf(&b, "diagnostic events: %d\n", len(l.events))
+	}
+	for _, event := range l.events[start:] {
+		b.WriteString(event)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/tests/pure_streaming_integration_test.go
+++ b/tests/pure_streaming_integration_test.go
@@ -3,6 +3,7 @@ package daramjwee_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -141,6 +142,1339 @@ func TestCache_MissBeginSetFailureFallsBackToPassthrough(t *testing.T) {
 	assert.ErrorIs(t, err, daramjwee.ErrNotFound)
 }
 
+func TestCache_MissFullReadWithoutExplicitClosePublishesAndReleasesKey(t *testing.T) {
+	hot := newMockStore()
+	fetcher := &mockFetcher{content: "fetched-value", etag: "origin-v1"}
+
+	cache, err := daramjwee.New(nil, daramjwee.WithTiers(hot), daramjwee.WithOpTimeout(2*time.Second))
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "auto-close-miss-key", daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "fetched-value", string(body))
+
+	current, meta, err := readStoreValue(context.Background(), hot, "auto-close-miss-key")
+	require.NoError(t, err)
+	assert.Equal(t, "fetched-value", current)
+	assert.Equal(t, "origin-v1", meta.CacheTag)
+
+	done := make(chan error, 1)
+	go func() {
+		writer, err := cache.Set(context.Background(), "auto-close-miss-key", &daramjwee.Metadata{CacheTag: "user-v2"})
+		if err != nil {
+			done <- err
+			return
+		}
+		if _, err := writer.Write([]byte("user-value")); err != nil {
+			_ = writer.Abort()
+			done <- err
+			return
+		}
+		done <- writer.Close()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("same-key Set blocked after miss response was fully read to EOF")
+	}
+
+	current, meta, err = readStoreValue(context.Background(), hot, "auto-close-miss-key")
+	require.NoError(t, err)
+	assert.Equal(t, "user-value", string(current))
+	assert.Equal(t, "user-v2", meta.CacheTag)
+}
+
+func TestCache_LowerTierFullReadWithoutExplicitClosePublishesAndReleasesKey(t *testing.T) {
+	hot := newMockStore()
+	cold := newMockStore()
+	cold.setData("auto-close-lower-key", "lower-value", &daramjwee.Metadata{CacheTag: "lower-v1", CachedAt: time.Now()})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, cold),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "auto-close-lower-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "lower-value", string(body))
+
+	current, meta, err := readStoreValue(context.Background(), hot, "auto-close-lower-key")
+	require.NoError(t, err)
+	assert.Equal(t, "lower-value", current)
+	assert.Equal(t, "lower-v1", meta.CacheTag)
+
+	done := make(chan error, 1)
+	go func() {
+		writer, err := cache.Set(context.Background(), "auto-close-lower-key", &daramjwee.Metadata{CacheTag: "user-v2"})
+		if err != nil {
+			done <- err
+			return
+		}
+		if _, err := writer.Write([]byte("user-value")); err != nil {
+			_ = writer.Abort()
+			done <- err
+			return
+		}
+		done <- writer.Close()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("same-key Set blocked after lower-tier response was fully read to EOF")
+	}
+
+	current, meta, err = readStoreValue(context.Background(), hot, "auto-close-lower-key")
+	require.NoError(t, err)
+	assert.Equal(t, "user-value", string(current))
+	assert.Equal(t, "user-v2", meta.CacheTag)
+}
+
+func TestCache_SameKeySetPreemptsUnconsumedMissFill(t *testing.T) {
+	hot := newMockStore()
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "preempt-miss-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "origin-value",
+		etag:    "origin-v1",
+	})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- writeCacheValue(cache, "preempt-miss-key", "user-value", "user-v2")
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("same-key Set blocked behind an unconsumed miss fill")
+	}
+
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "origin-value", string(body))
+	require.NoError(t, resp.Close())
+
+	current, meta, err := readStoreValue(context.Background(), hot, "preempt-miss-key")
+	require.NoError(t, err)
+	assert.Equal(t, "user-value", current)
+	assert.Equal(t, "user-v2", meta.CacheTag)
+}
+
+func TestCache_SecondSameKeyMissDoesNotBlockBehindUnconsumedFill(t *testing.T) {
+	hot := newMockStore()
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	first, err := cache.Get(context.Background(), "read-read-miss-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "first-origin-value",
+		etag:    "origin-v1",
+	})
+	require.NoError(t, err)
+	defer first.Close()
+
+	secondDone := make(chan getResult, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), "read-read-miss-key", daramjwee.GetRequest{}, &mockFetcher{
+			content: "second-origin-value",
+			etag:    "origin-v2",
+		})
+		secondDone <- getResult{stream: resp, err: err}
+	}()
+
+	var second getResult
+	select {
+	case second = <-secondDone:
+		require.NoError(t, second.err)
+		require.NotNil(t, second.stream)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("second same-key miss blocked behind unconsumed active fill")
+	}
+	secondBody, err := io.ReadAll(second.stream)
+	require.NoError(t, err)
+	assert.Equal(t, "second-origin-value", string(secondBody))
+	require.NoError(t, second.stream.Close())
+
+	firstBody, err := io.ReadAll(first)
+	require.NoError(t, err)
+	assert.Equal(t, "first-origin-value", string(firstBody))
+	require.NoError(t, first.Close())
+}
+
+func TestCache_SameKeySetPreemptsMissFillBeforeStoreBeginSetReturns(t *testing.T) {
+	hot := newFirstBeginSetBlockingStore()
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	getDone := make(chan getResult, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), "preempt-before-register-key", daramjwee.GetRequest{}, &mockFetcher{
+			content: "origin-value",
+			etag:    "origin-v1",
+		})
+		getDone <- getResult{stream: resp, err: err}
+	}()
+
+	select {
+	case <-hot.firstBeginSetStarted:
+	case <-time.After(time.Second):
+		t.Fatal("miss fill did not enter the first BeginSet")
+	}
+
+	setDone := make(chan error, 1)
+	go func() {
+		setDone <- writeCacheValue(cache, "preempt-before-register-key", "user-value", "user-v2")
+	}()
+
+	select {
+	case <-hot.secondBeginSetStarted:
+		t.Fatal("same-key Set entered a second BeginSet before the abandoned fill's BeginSet returned")
+	case err := <-setDone:
+		t.Fatalf("same-key Set completed before the abandoned fill's BeginSet returned: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	assert.Equal(t, int32(1), hot.beginSetCalls.Load(), "same-key BeginSet calls must remain serialized")
+
+	hot.releaseFirstBeginSet()
+	select {
+	case err := <-setDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("same-key Set stayed blocked after the abandoned fill's BeginSet returned")
+	}
+	result := <-getDone
+	require.NoError(t, result.err)
+	require.NotNil(t, result.stream)
+	body, err := io.ReadAll(result.stream)
+	require.NoError(t, err)
+	assert.Equal(t, "origin-value", string(body))
+	require.NoError(t, result.stream.Close())
+
+	current, meta, err := readStoreValue(context.Background(), hot.mockStore, "preempt-before-register-key")
+	require.NoError(t, err)
+	assert.Equal(t, "user-value", current)
+	assert.Equal(t, "user-v2", meta.CacheTag)
+}
+
+func TestCache_FillLeaseStartsAfterBeginSetReturns(t *testing.T) {
+	hot := newFirstBeginSetBlockingStore()
+	const lease = 500 * time.Millisecond
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(lease),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	getDone := make(chan getResult, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), "lease-after-begin-key", daramjwee.GetRequest{}, &mockFetcher{
+			content: "origin-value",
+			etag:    "origin-v1",
+		})
+		getDone <- getResult{stream: resp, err: err}
+	}()
+
+	select {
+	case <-hot.firstBeginSetStarted:
+	case <-time.After(time.Second):
+		t.Fatal("miss fill did not enter the first BeginSet")
+	}
+	time.Sleep(50 * time.Millisecond)
+	hot.releaseFirstBeginSet()
+
+	result := <-getDone
+	require.NoError(t, result.err)
+	require.NotNil(t, result.stream)
+	body, err := io.ReadAll(result.stream)
+	require.NoError(t, err)
+	assert.Equal(t, "origin-value", string(body))
+	require.NoError(t, result.stream.Close())
+
+	current, meta, err := readStoreValue(context.Background(), hot.mockStore, "lease-after-begin-key")
+	require.NoError(t, err)
+	assert.Equal(t, "origin-value", current)
+	assert.Equal(t, "origin-v1", meta.CacheTag)
+}
+
+func TestCache_ConditionalLowerTierPromotionDoesNotBlockBehindUnconsumedFill(t *testing.T) {
+	hot := newMockStore()
+	cold := newMockStore()
+	cold.setData("conditional-lower-busy-key", "lower-value", &daramjwee.Metadata{CacheTag: "lower-v1", CachedAt: time.Now()})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, cold),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	first, err := cache.Get(context.Background(), "conditional-lower-busy-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+	defer first.Close()
+
+	secondDone := make(chan struct {
+		resp *daramjwee.GetResponse
+		err  error
+	}, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), "conditional-lower-busy-key", daramjwee.GetRequest{IfNoneMatch: "lower-v1"}, &mockFetcher{})
+		secondDone <- struct {
+			resp *daramjwee.GetResponse
+			err  error
+		}{resp: resp, err: err}
+	}()
+
+	var second struct {
+		resp *daramjwee.GetResponse
+		err  error
+	}
+	select {
+	case second = <-secondDone:
+		require.NoError(t, second.err)
+		require.NotNil(t, second.resp)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("conditional lower-tier promotion blocked behind unconsumed active fill")
+	}
+	assert.Equal(t, daramjwee.GetStatusNotModified, second.resp.Status)
+
+	if second.resp.Body != nil {
+		body, err := io.ReadAll(second.resp)
+		require.NoError(t, err)
+		assert.Equal(t, "lower-value", string(body))
+	}
+	require.NoError(t, second.resp.Close())
+
+	firstBody, err := io.ReadAll(first)
+	require.NoError(t, err)
+	assert.Equal(t, "lower-value", string(firstBody))
+	require.NoError(t, first.Close())
+}
+
+func TestCache_SecondSameKeyLowerTierPromotionDoesNotBlockBehindUnconsumedFill(t *testing.T) {
+	hot := newMockStore()
+	cold := newMockStore()
+	cold.setData("read-read-lower-key", "lower-value", &daramjwee.Metadata{CacheTag: "lower-v1", CachedAt: time.Now()})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, cold),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	first, err := cache.Get(context.Background(), "read-read-lower-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+	defer first.Close()
+
+	secondDone := make(chan getResult, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), "read-read-lower-key", daramjwee.GetRequest{}, &mockFetcher{})
+		secondDone <- getResult{stream: resp, err: err}
+	}()
+
+	var second getResult
+	select {
+	case second = <-secondDone:
+		require.NoError(t, second.err)
+		require.NotNil(t, second.stream)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("second same-key lower-tier promotion blocked behind unconsumed active fill")
+	}
+	secondBody, err := io.ReadAll(second.stream)
+	require.NoError(t, err)
+	assert.Equal(t, "lower-value", string(secondBody))
+	require.NoError(t, second.stream.Close())
+
+	firstBody, err := io.ReadAll(first)
+	require.NoError(t, err)
+	assert.Equal(t, "lower-value", string(firstBody))
+	require.NoError(t, first.Close())
+}
+
+func TestCache_ConditionalLowerTierHitDoesNotBlockBehindUnconsumedFill(t *testing.T) {
+	hot := newMockStore()
+	cold := newMockStore()
+	cold.setData("conditional-read-read-lower-key", "lower-value", &daramjwee.Metadata{CacheTag: "lower-v1", CachedAt: time.Now()})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, cold),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	first, err := cache.Get(context.Background(), "conditional-read-read-lower-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+	defer first.Close()
+
+	secondDone := make(chan struct {
+		resp *daramjwee.GetResponse
+		err  error
+	}, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), "conditional-read-read-lower-key", daramjwee.GetRequest{IfNoneMatch: "lower-v1"}, &mockFetcher{})
+		secondDone <- struct {
+			resp *daramjwee.GetResponse
+			err  error
+		}{resp: resp, err: err}
+	}()
+
+	var second struct {
+		resp *daramjwee.GetResponse
+		err  error
+	}
+	select {
+	case second = <-secondDone:
+		require.NoError(t, second.err)
+		require.NotNil(t, second.resp)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("conditional same-key lower-tier hit blocked behind unconsumed active fill")
+	}
+	require.Equal(t, daramjwee.GetStatusNotModified, second.resp.Status)
+	require.Nil(t, second.resp.Body)
+
+	firstBody, err := io.ReadAll(first)
+	require.NoError(t, err)
+	assert.Equal(t, "lower-value", string(firstBody))
+	require.NoError(t, first.Close())
+}
+
+func TestCache_NegativeMissDoesNotBlockBehindUnconsumedFill(t *testing.T) {
+	hot := newMockStore()
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	first, err := cache.Get(context.Background(), "negative-busy-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "origin-value",
+		etag:    "origin-v1",
+	})
+	require.NoError(t, err)
+	defer first.Close()
+
+	secondDone := make(chan getResult, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), "negative-busy-key", daramjwee.GetRequest{}, &errFetcher{err: daramjwee.ErrCacheableNotFound})
+		secondDone <- getResult{stream: resp, err: err}
+	}()
+
+	var second getResult
+	select {
+	case second = <-secondDone:
+		require.NoError(t, second.err)
+		require.NotNil(t, second.stream)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("negative miss blocked behind unconsumed active fill")
+	}
+	if resp, ok := second.stream.(*daramjwee.GetResponse); assert.True(t, ok) {
+		assert.Equal(t, daramjwee.GetStatusNotFound, resp.Status)
+	}
+	require.NoError(t, second.stream.Close())
+
+	firstBody, err := io.ReadAll(first)
+	require.NoError(t, err)
+	assert.Equal(t, "origin-value", string(firstBody))
+	require.NoError(t, first.Close())
+}
+
+func TestCache_NegativeLowerTierPromotionDoesNotBlockBehindUnconsumedFill(t *testing.T) {
+	hot := newMockStore()
+	cold := newMockStore()
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, cold),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	first, err := cache.Get(context.Background(), "negative-lower-busy-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "origin-value",
+		etag:    "origin-v1",
+	})
+	require.NoError(t, err)
+	defer first.Close()
+	cold.setData("negative-lower-busy-key", "unused", &daramjwee.Metadata{IsNegative: true, CachedAt: time.Now()})
+
+	secondDone := make(chan getResult, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), "negative-lower-busy-key", daramjwee.GetRequest{}, &mockFetcher{})
+		secondDone <- getResult{stream: resp, err: err}
+	}()
+
+	var second getResult
+	select {
+	case second = <-secondDone:
+		require.NoError(t, second.err)
+		require.NotNil(t, second.stream)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("negative lower-tier promotion blocked behind unconsumed active fill")
+	}
+	if resp, ok := second.stream.(*daramjwee.GetResponse); assert.True(t, ok) {
+		assert.Equal(t, daramjwee.GetStatusNotFound, resp.Status)
+	}
+	require.NoError(t, second.stream.Close())
+
+	firstBody, err := io.ReadAll(first)
+	require.NoError(t, err)
+	assert.Equal(t, "origin-value", string(firstBody))
+	require.NoError(t, first.Close())
+}
+
+func TestCache_PreemptedFillBeginSetFailureReleasesSameKeyWriters(t *testing.T) {
+	hot := newFirstBeginSetBlockingErrorStore(errors.New("begin set failed after preempt"))
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	getDone := make(chan getResult, 1)
+	go func() {
+		resp, err := cache.Get(context.Background(), "failed-preempt-key", daramjwee.GetRequest{}, &mockFetcher{
+			content: "origin-value",
+			etag:    "origin-v1",
+		})
+		getDone <- getResult{stream: resp, err: err}
+	}()
+
+	select {
+	case <-hot.firstBeginSetStarted:
+	case <-time.After(time.Second):
+		t.Fatal("miss fill did not enter the first BeginSet")
+	}
+
+	setDone := make(chan error, 1)
+	go func() {
+		writer, err := cache.Set(context.Background(), "failed-preempt-key", &daramjwee.Metadata{CacheTag: "user-v2"})
+		if err != nil {
+			setDone <- err
+			return
+		}
+		if _, err := writer.Write([]byte("user-value")); err != nil {
+			_ = writer.Abort()
+			setDone <- err
+			return
+		}
+		setDone <- writer.Close()
+	}()
+
+	result := <-getDone
+	require.NoError(t, result.err)
+	require.NotNil(t, result.stream)
+	require.NoError(t, result.stream.Close())
+	hot.releaseFirstBeginSet()
+
+	select {
+	case err := <-setDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("same-key Set stayed blocked after preempted fill BeginSet failed")
+	}
+
+	current, meta, err := readStoreValue(context.Background(), hot.mockStore, "failed-preempt-key")
+	require.NoError(t, err)
+	assert.Equal(t, "user-value", current)
+	assert.Equal(t, "user-v2", meta.CacheTag)
+}
+
+func TestCache_ConditionalLowerTierHitAfterTopReadErrorReturnsBody(t *testing.T) {
+	top := &getErrorStore{mockStore: newMockStore(), err: errors.New("top read failed")}
+	top.setData("top-read-error-key", "top-value-v2", &daramjwee.Metadata{CacheTag: "v2", CachedAt: time.Now()})
+	lower := newMockStore()
+	lower.setData("top-read-error-key", "lower-value-v1", &daramjwee.Metadata{CacheTag: "v1", CachedAt: time.Now()})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "top-read-error-key", daramjwee.GetRequest{IfNoneMatch: "v1"}, &mockFetcher{})
+	require.NoError(t, err)
+	require.Equal(t, daramjwee.GetStatusOK, resp.Status)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "lower-value-v1", string(body))
+	require.NoError(t, resp.Close())
+}
+
+func TestCache_LowerTierHitAfterTopReadErrorDoesNotPromoteToTop(t *testing.T) {
+	top := &getErrorStore{mockStore: newMockStore(), err: errors.New("top read failed")}
+	top.setData("top-read-error-promote-key", "top-value-v2", &daramjwee.Metadata{CacheTag: "v2", CachedAt: time.Now()})
+	lower := newMockStore()
+	lower.setData("top-read-error-promote-key", "lower-value-v1", &daramjwee.Metadata{CacheTag: "v1", CachedAt: time.Now()})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "top-read-error-promote-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+	require.Equal(t, daramjwee.GetStatusOK, resp.Status)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "lower-value-v1", string(body))
+	require.NoError(t, resp.Close())
+
+	current, meta, err := readStoreValue(context.Background(), top.mockStore, "top-read-error-promote-key")
+	require.NoError(t, err)
+	assert.Equal(t, "top-value-v2", current)
+	assert.Equal(t, "v2", meta.CacheTag)
+}
+
+func TestCache_NegativeLowerTierHitAfterTopReadErrorReturnsNotFound(t *testing.T) {
+	top := &getErrorStore{mockStore: newMockStore(), err: errors.New("top read failed")}
+	lower := newMockStore()
+	lower.setData("negative-top-read-error-key", "unused", &daramjwee.Metadata{IsNegative: true, CachedAt: time.Now().Add(-time.Hour)})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "negative-top-read-error-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+	require.Equal(t, daramjwee.GetStatusNotFound, resp.Status)
+	require.Nil(t, resp.Body)
+	require.NoError(t, resp.Close())
+}
+
+func TestCache_NotModifiedAfterTopReadErrorReturnsError(t *testing.T) {
+	top := &getErrorStore{mockStore: newMockStore(), err: errors.New("top read failed")}
+	top.setData("not-modified-top-error-key", "top-value", &daramjwee.Metadata{CacheTag: "v1", CachedAt: time.Now()})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "not-modified-top-error-key", daramjwee.GetRequest{}, &errFetcher{err: daramjwee.ErrNotModified})
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestCache_NotModifiedReplayMissReturnsError(t *testing.T) {
+	top := &statOnlyMissingStore{meta: &daramjwee.Metadata{CacheTag: "v1", CachedAt: time.Now()}}
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "not-modified-replay-miss-key", daramjwee.GetRequest{}, &errFetcher{err: daramjwee.ErrNotModified})
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestCache_NegativeMissFansOutToLowerTier(t *testing.T) {
+	top := newMockStore()
+	lower := newMockStore()
+	lower.setData("negative-fanout-key", "old-positive", &daramjwee.Metadata{CacheTag: "old", CachedAt: time.Now().Add(-time.Hour)})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "negative-fanout-key", daramjwee.GetRequest{}, &errFetcher{err: daramjwee.ErrCacheableNotFound})
+	require.NoError(t, err)
+	require.Equal(t, daramjwee.GetStatusOK, resp.Status)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "old-positive", string(body))
+	require.NoError(t, resp.Close())
+
+	require.Eventually(t, func() bool {
+		meta, err := lower.Stat(context.Background(), "negative-fanout-key")
+		return err == nil && meta.IsNegative
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestScheduleRefreshSameKeyActiveFillDoesNotBlockWorkerAndClosesBody(t *testing.T) {
+	hot := newMockStore()
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	active, err := cache.Get(context.Background(), "refresh-active-fill-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "active-value",
+		etag:    "active-v1",
+	})
+	require.NoError(t, err)
+	defer active.Close()
+
+	closed := make(chan struct{})
+	blockedFetcher := &readCloserRefreshFetcher{
+		body: &closeTrackingReadCloser{
+			Reader:  bytes.NewReader([]byte("refresh-value")),
+			onClose: func() { close(closed) },
+		},
+		meta: &daramjwee.Metadata{CacheTag: "refresh-v1"},
+	}
+	require.NoError(t, cache.ScheduleRefresh(context.Background(), "refresh-active-fill-key", blockedFetcher))
+
+	secondFetcher := &mockFetcher{content: "other-value", etag: "other-v1"}
+	require.NoError(t, cache.ScheduleRefresh(context.Background(), "refresh-other-key", secondFetcher))
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-closed:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return secondFetcher.getFetchCount() > 0 }, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestScheduleRefreshClosesBodyWhenWriterBeginFails(t *testing.T) {
+	hot := newMockStore()
+	hot.forceSetError = true
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithWorkers(1),
+		daramjwee.WithWorkerQueue(4),
+		daramjwee.WithWorkerTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	closed := make(chan struct{})
+	fetcher := &readCloserRefreshFetcher{
+		body: &closeTrackingReadCloser{
+			Reader:  bytes.NewReader([]byte("refresh-value")),
+			onClose: func() { close(closed) },
+		},
+		meta: &daramjwee.Metadata{CacheTag: "refresh-v1"},
+	}
+	require.NoError(t, cache.ScheduleRefresh(context.Background(), "refresh-begin-fails-key", fetcher))
+	require.Eventually(t, func() bool {
+		select {
+		case <-closed:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestCache_LowerTierNotModifiedFallbackSkipsChangedPositiveEntry(t *testing.T) {
+	top := newMockStore()
+	lower := newMockStore()
+	oldCachedAt := time.Now().Add(-time.Hour)
+	lower.setData("fallback-changed-positive-key", "old-body", &daramjwee.Metadata{CacheTag: "old", CachedAt: oldCachedAt})
+	fetcher := &mockFetcher{err: daramjwee.ErrNotModified, fetchDelay: 100 * time.Millisecond}
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithFreshness(time.Second, time.Second),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "fallback-changed-positive-key", daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "old-body", string(body))
+	require.NoError(t, resp.Close())
+
+	lower.setData("fallback-changed-positive-key", "new-body", &daramjwee.Metadata{CacheTag: "new", CachedAt: oldCachedAt})
+	require.Eventually(t, func() bool { return fetcher.getFetchCount() > 0 }, 2*time.Second, 10*time.Millisecond)
+	_, _, err = top.GetStream(context.Background(), "fallback-changed-positive-key")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
+func TestCache_LowerTierNotModifiedFallbackSkipsChangedNegativeEntry(t *testing.T) {
+	top := newMockStore()
+	lower := newMockStore()
+	oldCachedAt := time.Now().Add(-time.Hour)
+	lower.setData("fallback-changed-negative-key", "", &daramjwee.Metadata{IsNegative: true, CacheTag: "old-neg", CachedAt: oldCachedAt})
+	fetcher := &mockFetcher{err: daramjwee.ErrNotModified, fetchDelay: 100 * time.Millisecond}
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithFreshness(time.Second, time.Second),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "fallback-changed-negative-key", daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	require.Equal(t, daramjwee.GetStatusNotFound, resp.Status)
+	require.NoError(t, resp.Close())
+
+	lower.setData("fallback-changed-negative-key", "new-body", &daramjwee.Metadata{CacheTag: "new", CachedAt: oldCachedAt})
+	require.Eventually(t, func() bool { return fetcher.getFetchCount() > 0 }, 2*time.Second, 10*time.Millisecond)
+	_, _, err = top.GetStream(context.Background(), "fallback-changed-negative-key")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
+func TestCache_LowerTierNotModifiedFallbackCloseErrorDoesNotPublish(t *testing.T) {
+	top := newMockStore()
+	closeErr := errors.New("fallback source close failed")
+	lower := newSecondReadCloseErrorStore("fallback-close-error-key", []byte("old-body"), &daramjwee.Metadata{CacheTag: "old", CachedAt: time.Now().Add(-time.Hour)}, closeErr)
+	fetcher := &mockFetcher{err: daramjwee.ErrNotModified}
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(top, lower),
+		daramjwee.WithFreshness(time.Second, time.Second),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "fallback-close-error-key", daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "old-body", string(body))
+	require.NoError(t, resp.Close())
+
+	require.Eventually(t, lower.secondClosed, 2*time.Second, 10*time.Millisecond)
+	_, _, err = top.GetStream(context.Background(), "fallback-close-error-key")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
+func TestCache_SameKeySetPreemptsQueuedMissFills(t *testing.T) {
+	hot := newMockStore()
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	first, err := cache.Get(context.Background(), "queued-preempt-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "origin-value-0",
+		etag:    "origin-v0",
+	})
+	require.NoError(t, err)
+	defer first.Close()
+
+	const queued = 24
+	started := make(chan struct{}, queued)
+	results := make(chan getResult, queued)
+	for i := 0; i < queued; i++ {
+		go func() {
+			resp, err := cache.Get(context.Background(), "queued-preempt-key", daramjwee.GetRequest{}, &signalingFetcher{
+				started: started,
+				content: []byte("origin-value-queued"),
+				etag:    "origin-v-queued",
+			})
+			results <- getResult{stream: resp, err: err}
+		}()
+	}
+	for i := 0; i < queued; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("queued fill %d did not reach the fetcher", i)
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- writeCacheValue(cache, "queued-preempt-key", "user-value", "user-v2")
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("same-key Set blocked behind queued miss fills")
+	}
+
+	for i := 0; i < queued; i++ {
+		select {
+		case result := <-results:
+			require.NoError(t, result.err)
+			require.NotNil(t, result.stream)
+			body, err := io.ReadAll(result.stream)
+			require.NoError(t, err)
+			assert.Equal(t, "origin-value-queued", string(body))
+			require.NoError(t, result.stream.Close())
+		case <-time.After(time.Second):
+			t.Fatalf("queued fill %d did not return after Set preempted active fill", i)
+		}
+	}
+
+	current, meta, err := readStoreValue(context.Background(), hot, "queued-preempt-key")
+	require.NoError(t, err)
+	assert.Equal(t, "user-value", current)
+	assert.Equal(t, "user-v2", meta.CacheTag)
+}
+
+func TestCache_SameKeySetPreemptsPartiallyConsumedMissFill(t *testing.T) {
+	hot := newMockStore()
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "preempt-partial-miss-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "origin-value",
+		etag:    "origin-v1",
+	})
+	require.NoError(t, err)
+
+	prefix := make([]byte, len("origin"))
+	n, err := resp.Read(prefix)
+	require.NoError(t, err)
+	assert.Equal(t, "origin", string(prefix[:n]))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- writeCacheValue(cache, "preempt-partial-miss-key", "user-value", "user-v2")
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("same-key Set blocked behind a partially consumed miss fill")
+	}
+
+	rest, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "-value", string(rest))
+	require.NoError(t, resp.Close())
+
+	current, meta, err := readStoreValue(context.Background(), hot, "preempt-partial-miss-key")
+	require.NoError(t, err)
+	assert.Equal(t, "user-value", current)
+	assert.Equal(t, "user-v2", meta.CacheTag)
+}
+
+func TestCache_DeletePreemptsUnconsumedMissFillAndKeepsKeyDeleted(t *testing.T) {
+	hot := newMockStore()
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "preempt-delete-miss-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "origin-value",
+		etag:    "origin-v1",
+	})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cache.Delete(context.Background(), "preempt-delete-miss-key")
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Delete blocked behind an unconsumed miss fill")
+	}
+
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "origin-value", string(body))
+	require.NoError(t, resp.Close())
+
+	_, _, err = hot.GetStream(context.Background(), "preempt-delete-miss-key")
+	assert.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
+func TestCache_FillLeaseExpiryTurnsMissIntoPassthrough(t *testing.T) {
+	hot := newMockStore()
+	const lease = 20 * time.Millisecond
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(lease),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "lease-miss-key", daramjwee.GetRequest{}, &mockFetcher{
+		content: "origin-value",
+		etag:    "origin-v1",
+	})
+	require.NoError(t, err)
+
+	requireStoreAbort(t, hot, "lease-miss-key", 2*time.Second)
+
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "origin-value", string(body))
+	require.NoError(t, resp.Close())
+
+	_, _, err = hot.GetStream(context.Background(), "lease-miss-key")
+	assert.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
+func TestCache_FillLeaseExpiryTurnsLowerTierPromotionIntoPassthrough(t *testing.T) {
+	hot := newMockStore()
+	cold := newMockStore()
+	cold.setData("lease-lower-key", "lower-value", &daramjwee.Metadata{CacheTag: "lower-v1", CachedAt: time.Now()})
+
+	const lease = 20 * time.Millisecond
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, cold),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(lease),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "lease-lower-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+
+	requireStoreAbort(t, hot, "lease-lower-key", 2*time.Second)
+
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "lower-value", string(body))
+	require.NoError(t, resp.Close())
+
+	_, _, err = hot.GetStream(context.Background(), "lease-lower-key")
+	assert.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
+func TestCache_SameKeySetPreemptsPartiallyConsumedLowerTierPromotion(t *testing.T) {
+	hot := newMockStore()
+	cold := newMockStore()
+	cold.setData("preempt-partial-lower-key", "lower-value", &daramjwee.Metadata{CacheTag: "lower-v1", CachedAt: time.Now()})
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, cold),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+		daramjwee.WithFillLeaseTimeout(0),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "preempt-partial-lower-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+
+	prefix := make([]byte, len("lower"))
+	n, err := resp.Read(prefix)
+	require.NoError(t, err)
+	assert.Equal(t, "lower", string(prefix[:n]))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- writeCacheValue(cache, "preempt-partial-lower-key", "user-value", "user-v2")
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("same-key Set blocked behind a partially consumed lower-tier promotion")
+	}
+
+	rest, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "-value", string(rest))
+	require.NoError(t, resp.Close())
+
+	current, meta, err := readStoreValue(context.Background(), hot, "preempt-partial-lower-key")
+	require.NoError(t, err)
+	assert.Equal(t, "user-value", current)
+	assert.Equal(t, "user-v2", meta.CacheTag)
+}
+
+func TestCache_StaleTopTierFullReadWithoutExplicitCloseSchedulesRefresh(t *testing.T) {
+	hot := newMockStore()
+	oldCachedAt := time.Now().Add(-time.Hour)
+	hot.setData("auto-refresh-top-key", "stale-value", &daramjwee.Metadata{CacheTag: "old", CachedAt: oldCachedAt})
+	fetcher := &mockFetcher{content: "fresh-value", etag: "fresh"}
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot),
+		daramjwee.WithFreshness(time.Second, time.Second),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "auto-refresh-top-key", daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "stale-value", string(body))
+
+	require.Eventually(t, func() bool {
+		current, meta, err := readStoreValue(context.Background(), hot, "auto-refresh-top-key")
+		return err == nil && current == "fresh-value" && meta.CacheTag == "fresh" && fetcher.getFetchCount() > 0
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestCache_StaleLowerTierFullReadWithoutExplicitCloseSchedulesRefresh(t *testing.T) {
+	hot := newMockStore()
+	lower := newMockStore()
+	oldCachedAt := time.Now().Add(-time.Hour)
+	lower.setData("auto-refresh-lower-key", "stale-lower", &daramjwee.Metadata{CacheTag: "old", CachedAt: oldCachedAt})
+	fetcher := &mockFetcher{content: "fresh-lower", etag: "fresh"}
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, lower),
+		daramjwee.WithFreshness(time.Second, time.Second),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "auto-refresh-lower-key", daramjwee.GetRequest{}, fetcher)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp)
+	require.NoError(t, err)
+	assert.Equal(t, "stale-lower", string(body))
+
+	require.Eventually(t, func() bool {
+		current, meta, err := readStoreValue(context.Background(), hot, "auto-refresh-lower-key")
+		return err == nil && current == "fresh-lower" && meta.CacheTag == "fresh" && fetcher.getFetchCount() > 0
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestCache_TopNegativeHitPropagatesCloseError(t *testing.T) {
+	closeErr := errors.New("top negative close failed")
+	hot := &singleEntryCloseErrorStore{
+		meta:     &daramjwee.Metadata{IsNegative: true, CachedAt: time.Now()},
+		closeErr: closeErr,
+	}
+
+	cache, err := daramjwee.New(nil, daramjwee.WithTiers(hot), daramjwee.WithOpTimeout(2*time.Second))
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "top-negative-close-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, closeErr)
+}
+
+func TestCache_LowerNegativeHitPropagatesCloseError(t *testing.T) {
+	closeErr := errors.New("lower negative close failed")
+	hot := newMockStore()
+	lower := &singleEntryCloseErrorStore{
+		meta:     &daramjwee.Metadata{IsNegative: true, CachedAt: time.Now()},
+		closeErr: closeErr,
+	}
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, lower),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "lower-negative-close-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, closeErr)
+
+	_, _, statErr := hot.GetStream(context.Background(), "lower-negative-close-key")
+	require.ErrorIs(t, statErr, daramjwee.ErrNotFound)
+}
+
+func TestCache_ReplayedNegativeHitPropagatesCloseError(t *testing.T) {
+	closeErr := errors.New("replayed negative close failed")
+	hot := &statOnlyThenReadableStore{
+		meta:     &daramjwee.Metadata{IsNegative: true, CachedAt: time.Now()},
+		closeErr: closeErr,
+	}
+	fetcher := &errFetcher{err: daramjwee.ErrNotModified}
+
+	cache, err := daramjwee.New(nil, daramjwee.WithTiers(hot), daramjwee.WithOpTimeout(2*time.Second))
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "replayed-negative-close-key", daramjwee.GetRequest{}, fetcher)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, closeErr)
+}
+
+func TestCache_TopPositiveHitPropagatesAutoCloseError(t *testing.T) {
+	closeErr := errors.New("top positive close failed")
+	hot := &singleEntryCloseErrorStore{
+		data:     []byte("top-value"),
+		meta:     &daramjwee.Metadata{CacheTag: "top-v1", CachedAt: time.Now()},
+		closeErr: closeErr,
+	}
+	cache, err := daramjwee.New(nil, daramjwee.WithTiers(hot), daramjwee.WithOpTimeout(2*time.Second))
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "top-close-error-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.Equal(t, "top-value", string(body))
+	require.ErrorIs(t, err, closeErr)
+	require.ErrorIs(t, resp.Body.Close(), closeErr)
+}
+
+func TestCache_StaleLowerTierHitPropagatesAutoCloseError(t *testing.T) {
+	closeErr := errors.New("stale lower close failed")
+	hot := newMockStore()
+	cold := &singleEntryCloseErrorStore{
+		data:     []byte("lower-value"),
+		meta:     &daramjwee.Metadata{CacheTag: "lower-v1", CachedAt: time.Now().Add(-time.Hour)},
+		closeErr: closeErr,
+	}
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, cold),
+		daramjwee.WithFreshness(time.Nanosecond, time.Nanosecond),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "stale-lower-close-error-key", daramjwee.GetRequest{}, &mockFetcher{})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.Equal(t, "lower-value", string(body))
+	require.ErrorIs(t, err, closeErr)
+	require.ErrorIs(t, resp.Body.Close(), closeErr)
+}
+
+func TestCache_ConditionalLowerTierPromotionCloseErrorAfterEOFDoesNotPublish(t *testing.T) {
+	closeErr := errors.New("lower source close failed after eof")
+	hot := newMockStore()
+	lower := &singleEntryCloseErrorStore{
+		data:     []byte("conditional-value"),
+		meta:     &daramjwee.Metadata{CacheTag: "v1", CachedAt: time.Now()},
+		closeErr: closeErr,
+	}
+
+	cache, err := daramjwee.New(
+		nil,
+		daramjwee.WithTiers(hot, lower),
+		daramjwee.WithFreshness(time.Hour, time.Hour),
+		daramjwee.WithOpTimeout(2*time.Second),
+	)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	resp, err := cache.Get(context.Background(), "conditional-close-key", daramjwee.GetRequest{IfNoneMatch: "v1"}, &mockFetcher{})
+	require.ErrorIs(t, err, closeErr)
+	require.Nil(t, resp)
+
+	_, _, err = hot.GetStream(context.Background(), "conditional-close-key")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+}
+
 func TestCache_PartialMissReadCloseDoesNotPublishToHot(t *testing.T) {
 	hot := newMockStore()
 	fetcher := &mockFetcher{content: "partial-value", etag: "v1"}
@@ -206,7 +1540,7 @@ func TestCache_PublishFailureDoesNotScheduleColdPersist(t *testing.T) {
 	require.NoError(t, err)
 
 	body, err := io.ReadAll(stream)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, errPublishFailed)
 	assert.Equal(t, "value", string(body))
 	require.ErrorIs(t, stream.Close(), errPublishFailed)
 
@@ -349,6 +1683,30 @@ type getResult struct {
 	err    error
 }
 
+type signalingFetcher struct {
+	started chan<- struct{}
+	content []byte
+	etag    string
+}
+
+func (f *signalingFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	f.started <- struct{}{}
+	return &daramjwee.FetchResult{
+		Body:     io.NopCloser(bytes.NewReader(bytes.Clone(f.content))),
+		Metadata: &daramjwee.Metadata{CacheTag: f.etag},
+	}, nil
+}
+
+func requireStoreAbort(t *testing.T, store *mockStore, key string, timeout time.Duration) {
+	t.Helper()
+	select {
+	case abortedKey := <-store.writeAborted:
+		require.Equal(t, key, abortedKey)
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for store abort for key %q", key)
+	}
+}
+
 type contextBoundFetcher struct {
 	body     []byte
 	metadata *daramjwee.Metadata
@@ -394,6 +1752,141 @@ func (s *blockingColdStore) Delete(ctx context.Context, key string) error {
 
 func (s *blockingColdStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
 	return s.metadata, nil
+}
+
+type firstBeginSetBlockingStore struct {
+	mockStore             *mockStore
+	firstBeginSetStarted  chan struct{}
+	secondBeginSetStarted chan struct{}
+	releaseFirst          chan struct{}
+	beginSetCalls         atomic.Int32
+}
+
+func newFirstBeginSetBlockingStore() *firstBeginSetBlockingStore {
+	return &firstBeginSetBlockingStore{
+		mockStore:             newMockStore(),
+		firstBeginSetStarted:  make(chan struct{}),
+		secondBeginSetStarted: make(chan struct{}),
+		releaseFirst:          make(chan struct{}),
+	}
+}
+
+func (s *firstBeginSetBlockingStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	return s.mockStore.GetStream(ctx, key)
+}
+
+func (s *firstBeginSetBlockingStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	switch s.beginSetCalls.Add(1) {
+	case 1:
+		close(s.firstBeginSetStarted)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-s.releaseFirst:
+		}
+	case 2:
+		close(s.secondBeginSetStarted)
+	}
+	return s.mockStore.BeginSet(ctx, key, metadata)
+}
+
+func (s *firstBeginSetBlockingStore) Delete(ctx context.Context, key string) error {
+	return s.mockStore.Delete(ctx, key)
+}
+
+func (s *firstBeginSetBlockingStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	return s.mockStore.Stat(ctx, key)
+}
+
+func (s *firstBeginSetBlockingStore) releaseFirstBeginSet() {
+	select {
+	case <-s.releaseFirst:
+	default:
+		close(s.releaseFirst)
+	}
+}
+
+type firstBeginSetBlockingErrorStore struct {
+	*firstBeginSetBlockingStore
+	err error
+}
+
+func newFirstBeginSetBlockingErrorStore(err error) *firstBeginSetBlockingErrorStore {
+	return &firstBeginSetBlockingErrorStore{
+		firstBeginSetBlockingStore: newFirstBeginSetBlockingStore(),
+		err:                        err,
+	}
+}
+
+func (s *firstBeginSetBlockingErrorStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	switch s.beginSetCalls.Add(1) {
+	case 1:
+		close(s.firstBeginSetStarted)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-s.releaseFirst:
+		}
+		return nil, s.err
+	case 2:
+		close(s.secondBeginSetStarted)
+	}
+	return s.mockStore.BeginSet(ctx, key, metadata)
+}
+
+type getErrorStore struct {
+	*mockStore
+	err error
+}
+
+func (s *getErrorStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	return nil, nil, s.err
+}
+
+type secondReadCloseErrorStore struct {
+	key      string
+	data     []byte
+	meta     *daramjwee.Metadata
+	closeErr error
+	reads    atomic.Int32
+	closed   atomic.Bool
+}
+
+func newSecondReadCloseErrorStore(key string, data []byte, meta *daramjwee.Metadata, closeErr error) *secondReadCloseErrorStore {
+	return &secondReadCloseErrorStore{key: key, data: bytes.Clone(data), meta: meta, closeErr: closeErr}
+}
+
+func (s *secondReadCloseErrorStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	if key != s.key || s.meta == nil {
+		return nil, nil, daramjwee.ErrNotFound
+	}
+	meta := *s.meta
+	rc := &closeTrackingReadCloser{Reader: bytes.NewReader(bytes.Clone(s.data))}
+	if s.reads.Add(1) >= 2 {
+		rc.closeErr = s.closeErr
+		rc.onClose = func() { s.closed.Store(true) }
+	}
+	return rc, &meta, nil
+}
+
+func (s *secondReadCloseErrorStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return &discardSink{}, nil
+}
+
+func (s *secondReadCloseErrorStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *secondReadCloseErrorStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	if key != s.key || s.meta == nil {
+		return nil, daramjwee.ErrNotFound
+	}
+	meta := *s.meta
+	return &meta, nil
+}
+
+func (s *secondReadCloseErrorStore) secondClosed() bool {
+	return s.closed.Load()
 }
 
 type discardSink struct{}
@@ -536,8 +2029,9 @@ func (f *errFetcher) Fetch(ctx context.Context, oldMetadata *daramjwee.Metadata)
 
 type closeTrackingReadCloser struct {
 	*bytes.Reader
-	once    sync.Once
-	onClose func()
+	once     sync.Once
+	onClose  func()
+	closeErr error
 }
 
 func (r *closeTrackingReadCloser) Close() error {
@@ -546,7 +2040,7 @@ func (r *closeTrackingReadCloser) Close() error {
 			r.onClose()
 		}
 	})
-	return nil
+	return r.closeErr
 }
 
 type statOnlyThenReadableStore struct {
@@ -554,6 +2048,7 @@ type statOnlyThenReadableStore struct {
 	meta     *daramjwee.Metadata
 	getCalls int32
 	closed   int32
+	closeErr error
 }
 
 func (s *statOnlyThenReadableStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
@@ -565,6 +2060,7 @@ func (s *statOnlyThenReadableStore) GetStream(ctx context.Context, key string) (
 		onClose: func() {
 			atomic.AddInt32(&s.closed, 1)
 		},
+		closeErr: s.closeErr,
 	}, s.meta, nil
 }
 
@@ -582,6 +2078,63 @@ func (s *statOnlyThenReadableStore) Stat(ctx context.Context, key string) (*dara
 
 func (s *statOnlyThenReadableStore) closeCount() int {
 	return int(atomic.LoadInt32(&s.closed))
+}
+
+type statOnlyMissingStore struct {
+	meta *daramjwee.Metadata
+}
+
+func (s *statOnlyMissingStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	return nil, nil, daramjwee.ErrNotFound
+}
+
+func (s *statOnlyMissingStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return &discardSink{}, nil
+}
+
+func (s *statOnlyMissingStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *statOnlyMissingStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	if s.meta == nil {
+		return nil, daramjwee.ErrNotFound
+	}
+	meta := *s.meta
+	return &meta, nil
+}
+
+type singleEntryCloseErrorStore struct {
+	data     []byte
+	meta     *daramjwee.Metadata
+	closeErr error
+}
+
+func (s *singleEntryCloseErrorStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *daramjwee.Metadata, error) {
+	if s.meta == nil {
+		return nil, nil, daramjwee.ErrNotFound
+	}
+	meta := *s.meta
+	return &closeTrackingReadCloser{
+		Reader:   bytes.NewReader(bytes.Clone(s.data)),
+		closeErr: s.closeErr,
+	}, &meta, nil
+}
+
+func (s *singleEntryCloseErrorStore) BeginSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.WriteSink, error) {
+	return &discardSink{}, nil
+}
+
+func (s *singleEntryCloseErrorStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *singleEntryCloseErrorStore) Stat(ctx context.Context, key string) (*daramjwee.Metadata, error) {
+	if s.meta == nil {
+		return nil, daramjwee.ErrNotFound
+	}
+	meta := *s.meta
+	return &meta, nil
 }
 
 type blockingReadCloser struct {

--- a/tests/pure_streaming_integration_test.go
+++ b/tests/pure_streaming_integration_test.go
@@ -362,12 +362,24 @@ func TestCache_SameKeySetPreemptsMissFillBeforeStoreBeginSetReturns(t *testing.T
 
 	select {
 	case <-hot.secondBeginSetStarted:
-		t.Fatal("same-key Set entered a second BeginSet before the abandoned fill's BeginSet returned")
+		select {
+		case <-hot.firstBeginSetReturned:
+		default:
+			t.Fatal("same-key Set entered a second BeginSet before the abandoned fill's BeginSet returned")
+		}
 	case err := <-setDone:
-		t.Fatalf("same-key Set completed before the abandoned fill's BeginSet returned: %v", err)
+		select {
+		case <-hot.firstBeginSetReturned:
+		default:
+			t.Fatalf("same-key Set completed before the abandoned fill's BeginSet returned: %v", err)
+		}
 	case <-time.After(50 * time.Millisecond):
 	}
-	assert.Equal(t, int32(1), hot.beginSetCalls.Load(), "same-key BeginSet calls must remain serialized")
+	select {
+	case <-hot.firstBeginSetReturned:
+	default:
+		assert.Equal(t, int32(1), hot.beginSetCalls.Load(), "same-key BeginSet calls must remain serialized")
+	}
 
 	hot.releaseFirstBeginSet()
 	select {
@@ -1800,6 +1812,7 @@ func (s *blockingColdStore) Stat(ctx context.Context, key string) (*daramjwee.Me
 type firstBeginSetBlockingStore struct {
 	mockStore             *mockStore
 	firstBeginSetStarted  chan struct{}
+	firstBeginSetReturned chan struct{}
 	secondBeginSetStarted chan struct{}
 	releaseFirst          chan struct{}
 	beginSetCalls         atomic.Int32
@@ -1809,6 +1822,7 @@ func newFirstBeginSetBlockingStore() *firstBeginSetBlockingStore {
 	return &firstBeginSetBlockingStore{
 		mockStore:             newMockStore(),
 		firstBeginSetStarted:  make(chan struct{}),
+		firstBeginSetReturned: make(chan struct{}),
 		secondBeginSetStarted: make(chan struct{}),
 		releaseFirst:          make(chan struct{}),
 	}
@@ -1822,6 +1836,7 @@ func (s *firstBeginSetBlockingStore) BeginSet(ctx context.Context, key string, m
 	switch s.beginSetCalls.Add(1) {
 	case 1:
 		close(s.firstBeginSetStarted)
+		defer close(s.firstBeginSetReturned)
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -1865,6 +1880,7 @@ func (s *firstBeginSetBlockingErrorStore) BeginSet(ctx context.Context, key stri
 	switch s.beginSetCalls.Add(1) {
 	case 1:
 		close(s.firstBeginSetStarted)
+		defer close(s.firstBeginSetReturned)
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/tests/stress_test.go
+++ b/tests/stress_test.go
@@ -22,6 +22,7 @@ type mockStore struct {
 	err            error
 	deleteErr      error
 	writeCompleted chan string
+	writeAborted   chan string
 	forceSetError  bool // forceSetError, if true, makes BeginSet return an error.
 }
 
@@ -31,6 +32,7 @@ func newMockStore() *mockStore {
 		data:           make(map[string][]byte),
 		meta:           make(map[string]*daramjwee.Metadata),
 		writeCompleted: make(chan string, 100),
+		writeAborted:   make(chan string, 100),
 	}
 }
 
@@ -85,8 +87,14 @@ func (s *mockStore) BeginSet(ctx context.Context, key string, metadata *daramjwe
 			}
 			return nil
 		},
-		onAbort: func() error { return nil },
-		buf:     &buf,
+		onAbort: func() error {
+			select {
+			case s.writeAborted <- key:
+			default:
+			}
+			return nil
+		},
+		buf: &buf,
 	}, nil
 }
 

--- a/tests/tiering_integration_test.go
+++ b/tests/tiering_integration_test.go
@@ -313,7 +313,7 @@ func TestCache_ConditionalHitAcceptsHTTPIfNoneMatchForms(t *testing.T) {
 	}
 }
 
-func TestCache_LowerTierConditionalHitPromotesFreshEntryToTop(t *testing.T) {
+func TestCache_LowerTierConditionalHitSkipsTopPromotion(t *testing.T) {
 	top := newMockStore()
 	lower := newMockStore()
 	cachedAt := time.Now()
@@ -337,15 +337,8 @@ func TestCache_LowerTierConditionalHitPromotesFreshEntryToTop(t *testing.T) {
 	require.Equal(t, daramjwee.GetStatusNotModified, resp.Status)
 	require.Nil(t, resp.Body)
 
-	reader, meta, err := top.GetStream(context.Background(), "conditional-lower-key")
-	require.NoError(t, err)
-	defer reader.Close()
-
-	body, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	assert.Equal(t, "cached-value", string(body))
-	assert.Equal(t, "cache-v1", meta.CacheTag)
-	assert.Equal(t, cachedAt.UnixNano(), meta.CachedAt.UnixNano())
+	_, _, err = top.GetStream(context.Background(), "conditional-lower-key")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
 }
 
 func TestCache_LowerTierNegativeStaleHitNotModifiedPromotesNegativeToTop(t *testing.T) {

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -867,6 +867,18 @@ func (s *coordinatedStagedTopWriteSink) Abort() error {
 	return s.err
 }
 
+func (s *coordinatedStagedTopWriteSink) detachForFillPreempt() func() error {
+	var cleanup func() error
+	s.once.Do(func() {
+		// Fill preemption invalidates the write before storage cleanup so a
+		// newer same-key writer is not held behind a stalled fill Write.
+		s.coord.unregisterReservation(s.generation)
+		s.err = ErrTopWriteInvalidated
+		cleanup = s.sink.Abort
+	})
+	return cleanup
+}
+
 func (s *coordinatedTopWriteSink) Close() error {
 	s.once.Do(func() {
 		defer s.coord.releaseWrite()
@@ -954,6 +966,20 @@ func (s *coordinatedTopWriteSink) Abort() error {
 		s.coord.unregisterReservation(s.generation)
 	})
 	return s.err
+}
+
+func (s *coordinatedTopWriteSink) detachForFillPreempt() func() error {
+	var cleanup func() error
+	s.once.Do(func() {
+		// The Store contract requires BeginSet data to remain unpublished until
+		// Close. Releasing the coordinator here preserves cache liveness while
+		// the abandoned sink is cleaned up after any active Write returns.
+		s.err = ErrTopWriteInvalidated
+		s.coord.unregisterReservation(s.generation)
+		s.coord.releaseWrite()
+		cleanup = s.WriteSink.Abort
+	})
+	return cleanup
 }
 
 func newConditionalGenerationWriteSink(sink WriteSink, coord *writeCoordinator, generation uint64, waitTimeout time.Duration, onInvalidated func() error) WriteSink {

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -22,13 +22,18 @@ type writeCoordinator struct {
 	stateChanged        *sync.Cond
 	committedGeneration uint64
 	activeDeletes       int
+	activePublishers    int
+	pendingWriters      int
+	activeFill          *topFillSink
 }
 
 type coordinatedTopWriteSink struct {
 	WriteSink
 	coord         *writeCoordinator
+	key           string
 	generation    uint64
 	onInvalidated func() error
+	trace         func(event string, generation uint64, keyvals ...any)
 	once          sync.Once
 	err           error
 }
@@ -137,13 +142,78 @@ func (c *writeCoordinator) current() uint64 {
 	return c.committedGeneration
 }
 
+func (c *writeCoordinator) canAttemptExpectedTopWrite(expectedGeneration uint64) bool {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.committedGeneration == expectedGeneration &&
+		c.activeDeletes == 0 &&
+		c.activePublishers == 0 &&
+		c.pendingWriters == 0
+}
+
 // begin serializes same-key top writes and snapshots the committed generation
 // visible to readers. Successful publish advances the committed generation only
 // after the underlying sink has been closed.
 func (c *writeCoordinator) begin(ctx context.Context, expected *uint64) (uint64, error) {
-	c.writeMu.Lock()
+	return c.beginWithFill(ctx, expected, nil)
+}
+
+func (c *writeCoordinator) beginBestEffort(ctx context.Context, expected *uint64) (uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	c.stateMu.Lock()
+	if c.activeFill != nil || c.activeDeletes > 0 || c.activePublishers > 0 || c.pendingWriters > 0 {
+		c.stateMu.Unlock()
+		return 0, ErrTopWriteInvalidated
+	}
+	c.stateMu.Unlock()
+	if !c.writeMu.TryLock() {
+		return 0, ErrTopWriteInvalidated
+	}
+	c.stateMu.Lock()
+	if c.activeFill != nil || c.activeDeletes > 0 || c.activePublishers > 0 || c.pendingWriters > 0 {
+		c.stateMu.Unlock()
+		c.writeMu.Unlock()
+		return 0, ErrTopWriteInvalidated
+	}
+	if expected != nil && c.committedGeneration != *expected {
+		c.stateMu.Unlock()
+		c.writeMu.Unlock()
+		return 0, ErrTopWriteInvalidated
+	}
+	generation := c.committedGeneration
+	c.stateMu.Unlock()
+	return generation, nil
+}
+
+func (c *writeCoordinator) beginWithFill(ctx context.Context, expected *uint64, fill *topFillSink) (uint64, error) {
+	writeLocked := false
+	if expected != nil && fill != nil {
+		c.stateMu.Lock()
+		if c.activeFill != nil || c.activeDeletes > 0 || c.pendingWriters > 0 {
+			c.stateMu.Unlock()
+			return 0, ErrTopWriteInvalidated
+		}
+		c.stateMu.Unlock()
+		if !c.writeMu.TryLock() {
+			return 0, ErrTopWriteInvalidated
+		}
+		writeLocked = true
+	}
+	if expected == nil {
+		c.stateMu.Lock()
+		c.pendingWriters++
+		c.stateMu.Unlock()
+		c.preemptActiveFill()
+	}
+	if !writeLocked {
+		c.writeMu.Lock()
+	}
 	c.stateMu.Lock()
 	if expected == nil {
+		c.pendingWriters--
+		c.stateChanged.Broadcast()
 		if c.activeDeletes > 0 {
 			done := make(chan struct{})
 			go func() {
@@ -165,7 +235,7 @@ func (c *writeCoordinator) begin(ctx context.Context, expected *uint64) (uint64,
 			}
 			c.stateChanged.Wait()
 		}
-	} else if c.activeDeletes > 0 {
+	} else if c.activeDeletes > 0 || c.pendingWriters > 0 {
 		c.stateMu.Unlock()
 		c.writeMu.Unlock()
 		return 0, ErrTopWriteInvalidated
@@ -176,6 +246,10 @@ func (c *writeCoordinator) begin(ctx context.Context, expected *uint64) (uint64,
 		return 0, ErrTopWriteInvalidated
 	}
 	generation := c.committedGeneration
+	if fill != nil {
+		fill.registered = true
+		c.activeFill = fill
+	}
 	c.stateMu.Unlock()
 	return generation, nil
 }
@@ -184,10 +258,61 @@ func (c *writeCoordinator) rollbackAndUnlock(_ uint64) {
 	c.writeMu.Unlock()
 }
 
-func (c *writeCoordinator) beginDelete() {
+func (c *writeCoordinator) registerActiveFill(fill *topFillSink) {
+	c.stateMu.Lock()
+	c.activeFill = fill
+	c.stateMu.Unlock()
+}
+
+func (c *writeCoordinator) unregisterActiveFill(fill *topFillSink) {
+	c.stateMu.Lock()
+	if c.activeFill == fill {
+		c.activeFill = nil
+	}
+	c.stateMu.Unlock()
+}
+
+func (c *writeCoordinator) preemptActiveFill() {
+	c.stateMu.Lock()
+	fill := c.activeFill
+	c.stateMu.Unlock()
+	if fill != nil {
+		_ = fill.Preempt()
+	}
+}
+
+func (c *writeCoordinator) beginDelete(ctx context.Context) error {
 	c.stateMu.Lock()
 	c.activeDeletes++
 	c.stateMu.Unlock()
+	c.preemptActiveFill()
+	c.stateMu.Lock()
+	if c.activePublishers > 0 {
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				c.stateMu.Lock()
+				c.stateChanged.Broadcast()
+				c.stateMu.Unlock()
+			case <-done:
+			}
+		}()
+		defer close(done)
+	}
+	for c.activePublishers > 0 {
+		if err := ctx.Err(); err != nil {
+			if c.activeDeletes > 0 {
+				c.activeDeletes--
+			}
+			c.stateChanged.Broadcast()
+			c.stateMu.Unlock()
+			return err
+		}
+		c.stateChanged.Wait()
+	}
+	c.stateMu.Unlock()
+	return nil
 }
 
 func (c *writeCoordinator) finishDelete(success bool) {
@@ -217,67 +342,167 @@ func (c *DaramjweeCache) noteTopWriteGeneration(key string) {
 func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, key string, metadata *Metadata, expectedGeneration *uint64) (WriteSink, error) {
 	store := c.topWriteStore()
 	coord := c.topWrites.coordinator(key)
+	expectedGenerationValue := diagnosticGenerationValue(expectedGeneration)
+	c.diagnosticLog("top_write_begin", key, 0, "expected_generation", expectedGenerationValue)
 	generation, err := coord.begin(ctx, expectedGeneration)
 	if err != nil {
+		c.diagnosticLog("top_write_begin_error", key, 0, "expected_generation", expectedGenerationValue, "err", err)
 		return nil, err
 	}
+	c.diagnosticLog("top_write_begin_acquired", key, generation, "expected_generation", expectedGenerationValue)
 
 	sink, err := store.BeginSet(ctx, key, metadata)
 	if err != nil {
+		c.diagnosticLog("top_write_store_begin_error", key, generation, "err", err)
 		coord.rollbackAndUnlock(generation)
 		return nil, err
 	}
+	c.diagnosticLog("top_write_store_begin_ok", key, generation)
 
 	return &coordinatedTopWriteSink{
 		WriteSink:     sink,
 		coord:         coord,
+		key:           key,
 		generation:    generation,
 		onInvalidated: func() error { return c.deleteTopStoreKey(key) },
+		trace: func(event string, generation uint64, keyvals ...any) {
+			c.diagnosticLog(event, key, generation, keyvals...)
+		},
 	}, nil
+}
+
+func (c *DaramjweeCache) setStreamToTopStoreBestEffortWithGeneration(ctx context.Context, key string, metadata *Metadata, expectedGeneration *uint64) (WriteSink, error) {
+	store := c.topWriteStore()
+	coord := c.topWrites.coordinator(key)
+	expectedGenerationValue := diagnosticGenerationValue(expectedGeneration)
+	c.diagnosticLog("top_write_begin_best_effort", key, 0, "expected_generation", expectedGenerationValue)
+	generation, err := coord.beginBestEffort(ctx, expectedGeneration)
+	if err != nil {
+		c.diagnosticLog("top_write_begin_best_effort_error", key, 0, "expected_generation", expectedGenerationValue, "err", err)
+		return nil, err
+	}
+	c.diagnosticLog("top_write_begin_best_effort_acquired", key, generation, "expected_generation", expectedGenerationValue)
+
+	sink, err := store.BeginSet(ctx, key, metadata)
+	if err != nil {
+		c.diagnosticLog("top_write_store_begin_error", key, generation, "err", err)
+		coord.rollbackAndUnlock(generation)
+		return nil, err
+	}
+	c.diagnosticLog("top_write_store_begin_ok", key, generation)
+
+	return &coordinatedTopWriteSink{
+		WriteSink:     sink,
+		coord:         coord,
+		key:           key,
+		generation:    generation,
+		onInvalidated: func() error { return c.deleteTopStoreKey(key) },
+		trace: func(event string, generation uint64, keyvals ...any) {
+			c.diagnosticLog(event, key, generation, keyvals...)
+		},
+	}, nil
+}
+
+func (c *DaramjweeCache) setStreamToTopStoreForFill(ctx context.Context, key string, metadata *Metadata, expectedGeneration uint64) (WriteSink, error) {
+	store := c.topWriteStore()
+	coord := c.topWrites.coordinator(key)
+	expectedGenerationValue := diagnosticGenerationValue(&expectedGeneration)
+	c.diagnosticLog("top_write_begin", key, 0, "expected_generation", expectedGenerationValue)
+	fill := newPendingTopFillSink(coord)
+	generation, err := coord.beginWithFill(ctx, &expectedGeneration, fill)
+	if err != nil {
+		c.diagnosticLog("top_write_begin_error", key, 0, "expected_generation", expectedGenerationValue, "err", err)
+		return nil, err
+	}
+	c.diagnosticLog("top_write_begin_acquired", key, generation, "expected_generation", expectedGenerationValue)
+
+	sink, err := store.BeginSet(ctx, key, metadata)
+	if err != nil {
+		c.diagnosticLog("top_write_store_begin_error", key, generation, "err", err)
+		fill.failBeginSet(err)
+		return nil, err
+	}
+	c.diagnosticLog("top_write_store_begin_ok", key, generation)
+
+	topWriter := &coordinatedTopWriteSink{
+		WriteSink:     sink,
+		coord:         coord,
+		key:           key,
+		generation:    generation,
+		onInvalidated: func() error { return c.deleteTopStoreKey(key) },
+		trace: func(event string, generation uint64, keyvals ...any) {
+			c.diagnosticLog(event, key, generation, keyvals...)
+		},
+	}
+	if fill.attach(topWriter) {
+		fill.startLease(c.fillLeaseTimeout)
+	} else {
+		_ = fill.finishPreemptedAttach(topWriter)
+	}
+	return fill, nil
 }
 
 func (s *coordinatedTopWriteSink) Close() error {
 	s.once.Do(func() {
-		defer s.coord.writeMu.Unlock()
+		s.traceEvent("top_write_close_start")
+		defer func() {
+			s.coord.writeMu.Unlock()
+			s.traceEvent("top_write_close_unlock", "err", s.err)
+		}()
 		s.coord.stateMu.Lock()
 		for s.coord.activeDeletes > 0 {
+			s.traceEvent("top_write_close_wait_delete")
 			s.coord.stateChanged.Wait()
 		}
 
 		if s.coord.committedGeneration != s.generation {
+			committedGeneration := s.coord.committedGeneration
 			s.coord.stateMu.Unlock()
+			s.traceEvent("top_write_close_invalidated_before_publish", "committed_generation", committedGeneration)
 			abortErr := s.WriteSink.Abort()
 			s.err = ErrTopWriteInvalidated
 			if abortErr != nil {
 				s.err = errors.Join(s.err, abortErr)
 			}
+			s.traceEvent("top_write_close_abort_after_invalidation", "err", s.err)
 			return
 		}
+		s.coord.activePublishers++
 		s.coord.stateMu.Unlock()
 
+		s.traceEvent("top_write_underlying_close_start")
 		closeErr := s.WriteSink.Close()
+		s.traceEvent("top_write_underlying_close_done", "err", closeErr)
 
 		s.coord.stateMu.Lock()
-		defer s.coord.stateMu.Unlock()
-		for s.coord.activeDeletes > 0 {
-			s.coord.stateChanged.Wait()
-		}
-
 		if closeErr != nil {
+			s.coord.activePublishers--
+			s.coord.stateChanged.Broadcast()
+			s.coord.stateMu.Unlock()
 			s.err = closeErr
 			return
 		}
-		if s.coord.committedGeneration != s.generation {
+		if s.coord.committedGeneration != s.generation || s.coord.activeDeletes > 0 {
+			committedGeneration := s.coord.committedGeneration
+			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated
+			s.traceEvent("top_write_close_invalidated_after_publish", "committed_generation", committedGeneration)
 			if s.onInvalidated != nil {
 				if cleanupErr := s.onInvalidated(); cleanupErr != nil {
 					s.err = errors.Join(s.err, cleanupErr)
 				}
 			}
+			s.coord.stateMu.Lock()
+			s.coord.activePublishers--
+			s.coord.stateChanged.Broadcast()
+			s.coord.stateMu.Unlock()
 			return
 		}
 		s.coord.committedGeneration++
+		s.traceEvent("top_write_close_committed", "committed_generation", s.coord.committedGeneration)
+		s.coord.activePublishers--
 		s.coord.stateChanged.Broadcast()
+		s.coord.stateMu.Unlock()
 	})
 	return s.err
 }
@@ -298,10 +523,29 @@ func (c *DaramjweeCache) deleteTopStoreKey(key string) error {
 
 func (s *coordinatedTopWriteSink) Abort() error {
 	s.once.Do(func() {
-		defer s.coord.writeMu.Unlock()
+		s.traceEvent("top_write_abort_start")
+		defer func() {
+			s.coord.writeMu.Unlock()
+			s.traceEvent("top_write_abort_unlock", "err", s.err)
+		}()
 		s.err = s.WriteSink.Abort()
+		s.traceEvent("top_write_abort_done", "err", s.err)
 	})
 	return s.err
+}
+
+func (s *coordinatedTopWriteSink) traceEvent(event string, keyvals ...any) {
+	if s.trace == nil {
+		return
+	}
+	s.trace(event, s.generation, keyvals...)
+}
+
+func diagnosticGenerationValue(generation *uint64) any {
+	if generation == nil {
+		return nil
+	}
+	return *generation
 }
 
 func newConditionalGenerationWriteSink(sink WriteSink, coord *writeCoordinator, generation uint64, onInvalidated func() error) WriteSink {
@@ -329,30 +573,37 @@ func (s *conditionalGenerationWriteSink) Close() error {
 			}
 			return
 		}
+		s.coord.activePublishers++
 		s.coord.stateMu.Unlock()
 
 		closeErr := s.WriteSink.Close()
 
 		s.coord.stateMu.Lock()
-		defer s.coord.stateMu.Unlock()
-		for s.coord.activeDeletes > 0 {
-			s.coord.stateChanged.Wait()
-		}
-
 		if closeErr != nil {
+			s.coord.activePublishers--
+			s.coord.stateChanged.Broadcast()
+			s.coord.stateMu.Unlock()
 			s.err = closeErr
 			return
 		}
-		if s.coord.committedGeneration != s.generation {
+		if s.coord.committedGeneration != s.generation || s.coord.activeDeletes > 0 {
+			s.coord.stateMu.Unlock()
 			s.err = ErrTopWriteInvalidated
 			if s.onInvalidated != nil {
 				if cleanupErr := s.onInvalidated(); cleanupErr != nil {
 					s.err = errors.Join(s.err, cleanupErr)
 				}
 			}
+			s.coord.stateMu.Lock()
+			s.coord.activePublishers--
+			s.coord.stateChanged.Broadcast()
+			s.coord.stateMu.Unlock()
 			return
 		}
 		s.err = nil
+		s.coord.activePublishers--
+		s.coord.stateChanged.Broadcast()
+		s.coord.stateMu.Unlock()
 	})
 	return s.err
 }

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -32,6 +32,7 @@ type writeCoordinator struct {
 	activeDeletes       int
 	activeDeletesDone   chan struct{}
 	activeFill          *topFillSink
+	fillPreemptions     int
 }
 
 type coordinatedTopWriteSink struct {
@@ -259,7 +260,7 @@ func (c *writeCoordinator) reserveBestEffort(ctx context.Context, expected *uint
 	c.init()
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
-	if c.activeFill != nil || c.activeDeletes > 0 {
+	if c.activeFill != nil || c.activeDeletes > 0 || c.fillPreemptions > 0 {
 		return 0, ErrTopWriteInvalidated
 	}
 	if err := ctx.Err(); err != nil {
@@ -279,7 +280,7 @@ func (c *writeCoordinator) reserveWithFill(ctx context.Context, expected uint64,
 	c.init()
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
-	if c.activeFill != nil || c.activeDeletes > 0 {
+	if c.activeFill != nil || c.activeDeletes > 0 || c.fillPreemptions > 0 {
 		return 0, ErrTopWriteInvalidated
 	}
 	if err := ctx.Err(); err != nil {
@@ -523,6 +524,29 @@ func (c *writeCoordinator) preemptActiveFill() {
 	}
 }
 
+func (c *writeCoordinator) preemptActiveFillForWrite() func() {
+	c.init()
+	c.stateMu.Lock()
+	fill := c.activeFill
+	if fill != nil {
+		c.fillPreemptions++
+	}
+	c.stateMu.Unlock()
+	if fill != nil {
+		_ = fill.Preempt()
+	}
+	return func() {
+		if fill == nil {
+			return
+		}
+		c.stateMu.Lock()
+		if c.fillPreemptions > 0 {
+			c.fillPreemptions--
+		}
+		c.stateMu.Unlock()
+	}
+}
+
 func (c *writeCoordinator) rollbackAndUnlock(generation uint64) {
 	c.unregisterReservation(generation)
 	c.releaseWrite()
@@ -574,7 +598,8 @@ func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, 
 	store := c.topWriteStore()
 	coord := c.topWrites.coordinator(key)
 	if expectedGeneration == nil {
-		coord.preemptActiveFill()
+		unblockFills := coord.preemptActiveFillForWrite()
+		defer unblockFills()
 	}
 	if staging, ok := store.(StagingStore); ok {
 		generation, err := coord.reserve(ctx, expectedGeneration)
@@ -697,7 +722,7 @@ func (c *DaramjweeCache) setStreamToTopStoreForFill(ctx context.Context, key str
 	fillCtx, cancelFill := context.WithCancel(ctx)
 	fill := newPendingTopFillSink(coord, func() {
 		coord.rollbackAndUnlock(generation)
-	}, nil)
+	}, cancelFill)
 	generation, err := coord.beginWithFill(fillCtx, expectedGeneration, fill)
 	if err != nil {
 		cancelFill()
@@ -716,6 +741,9 @@ func (c *DaramjweeCache) setStreamToTopStoreForFill(ctx context.Context, key str
 	finishBegin := func(result beginResult) error {
 		if result.err != nil {
 			fill.failBeginSet(result.err)
+			if fill.isPreempted() {
+				return nil
+			}
 			return result.err
 		}
 		topWriter := &coordinatedTopWriteSink{

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -356,6 +356,62 @@ func TestLegacyFillContextCancelPreemptsPendingBeginSet(t *testing.T) {
 	}
 }
 
+func TestLegacyFillPreemptCancelsPendingBeginSet(t *testing.T) {
+	store := &contextBlockingFirstBeginSetStore{
+		beginStarted: make(chan struct{}),
+		releaseBegin: make(chan struct{}),
+	}
+	cache := &DaramjweeCache{
+		tiers:            []Store{store},
+		opTimeout:        time.Second,
+		closeTimeout:     time.Second,
+		fillLeaseTimeout: time.Hour,
+	}
+
+	fillDone := make(chan error, 1)
+	go func() {
+		writer, err := cache.setStreamToTopStoreForFill(context.Background(), "key", &Metadata{CacheTag: "fill"}, 0)
+		if writer != nil {
+			_ = writer.Abort()
+		}
+		fillDone <- err
+	}()
+
+	select {
+	case <-store.beginStarted:
+	case <-time.After(time.Second):
+		t.Fatal("fill BeginSet did not start")
+	}
+
+	setDone := make(chan error, 1)
+	go func() {
+		writer, err := cache.Set(context.Background(), "key", &Metadata{CacheTag: "user"})
+		if err == nil {
+			err = writer.Abort()
+		}
+		setDone <- err
+	}()
+
+	select {
+	case err := <-setDone:
+		if err != nil {
+			t.Fatalf("same-key Set should proceed after preempting pending BeginSet, got %v", err)
+		}
+	case <-time.After(time.Second):
+		close(store.releaseBegin)
+		t.Fatal("same-key Set stayed blocked behind preempted BeginSet")
+	}
+
+	select {
+	case err := <-fillDone:
+		if err != nil {
+			t.Fatalf("preempted fill should return without setup error, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("preempted fill setup did not return")
+	}
+}
+
 func TestStaleStagedCloseAbortCleanupDoesNotBlockNewerCommit(t *testing.T) {
 	store := &blockingFirstAbortStagingStore{
 		abortStarted: make(chan struct{}),
@@ -1197,6 +1253,42 @@ func (s *blockingFirstBeginSetStore) Delete(ctx context.Context, key string) err
 }
 
 func (s *blockingFirstBeginSetStore) Stat(ctx context.Context, key string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type contextBlockingFirstBeginSetStore struct {
+	mu           sync.Mutex
+	calls        int
+	beginStarted chan struct{}
+	releaseBegin chan struct{}
+}
+
+func (s *contextBlockingFirstBeginSetStore) GetStream(ctx context.Context, key string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *contextBlockingFirstBeginSetStore) BeginSet(ctx context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	s.mu.Lock()
+	s.calls++
+	first := s.calls == 1
+	s.mu.Unlock()
+	if !first {
+		return &stubWriteSink{}, nil
+	}
+	close(s.beginStarted)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.releaseBegin:
+		return &stubWriteSink{}, nil
+	}
+}
+
+func (s *contextBlockingFirstBeginSetStore) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (s *contextBlockingFirstBeginSetStore) Stat(ctx context.Context, key string) (*Metadata, error) {
 	return nil, ErrNotFound
 }
 

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -57,6 +57,185 @@ func TestSetStreamToStoreWithTopGenerationRestoresGenerationOnBeginSetFailure(t 
 	}
 }
 
+func TestTopFillPreemptDoesNotDeadlockWithCloseWaitingOnDelete(t *testing.T) {
+	coord := &writeCoordinator{}
+	coord.stateChanged = sync.NewCond(&coord.stateMu)
+	coord.writeMu.Lock()
+	coord.stateMu.Lock()
+	coord.activeDeletes = 1
+	coord.stateMu.Unlock()
+
+	fill := newPendingTopFillSink(coord)
+	topWriter := &coordinatedTopWriteSink{
+		WriteSink:  &stubWriteSink{},
+		coord:      coord,
+		key:        "key",
+		generation: 0,
+	}
+	if !fill.attach(topWriter) {
+		t.Fatal("expected fill attach to succeed")
+	}
+	coord.stateMu.Lock()
+	fill.registered = true
+	coord.activeFill = fill
+	coord.stateMu.Unlock()
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- fill.Close()
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	preemptDone := make(chan error, 1)
+	go func() {
+		preemptDone <- fill.Preempt()
+	}()
+
+	select {
+	case err := <-preemptDone:
+		if err != nil {
+			t.Fatalf("preempt returned unexpected error: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("preempt blocked on topFillSink.mu while close waited on active delete")
+	}
+
+	coord.finishDelete(true)
+	select {
+	case err := <-closeDone:
+		if !errors.Is(err, ErrTopWriteInvalidated) {
+			t.Fatalf("expected invalidated close after delete, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("fill close did not resume after delete finished")
+	}
+}
+
+func TestDeleteWaitsForConcurrentPublisherCleanupBeforeReturning(t *testing.T) {
+	coord := &writeCoordinator{}
+	coord.stateChanged = sync.NewCond(&coord.stateMu)
+	coord.writeMu.Lock()
+	publishSink := newBlockingCloseSink()
+	cleanupDone := make(chan struct{})
+	topWriter := &coordinatedTopWriteSink{
+		WriteSink:  publishSink,
+		coord:      coord,
+		key:        "key",
+		generation: 0,
+		onInvalidated: func() error {
+			close(cleanupDone)
+			return nil
+		},
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- topWriter.Close()
+	}()
+
+	select {
+	case <-publishSink.closeStarted:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("writer close did not enter underlying publish")
+	}
+
+	deleteDone := make(chan struct{})
+	go func() {
+		if err := coord.beginDelete(context.Background()); err != nil {
+			t.Errorf("begin delete: %v", err)
+			return
+		}
+		coord.finishDelete(true)
+		close(deleteDone)
+	}()
+
+	select {
+	case <-deleteDone:
+		t.Fatal("delete returned while a concurrent publisher was still visible")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(publishSink.releaseClose)
+
+	select {
+	case <-cleanupDone:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("invalidated publisher did not run cleanup")
+	}
+	select {
+	case <-deleteDone:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("delete did not return after publisher cleanup completed")
+	}
+	select {
+	case err := <-closeDone:
+		if !errors.Is(err, ErrTopWriteInvalidated) {
+			t.Fatalf("expected invalidated close, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("writer close did not return")
+	}
+}
+
+func TestDeleteWaitsForConditionalPublisherCleanupBeforeReturning(t *testing.T) {
+	coord := &writeCoordinator{}
+	coord.stateChanged = sync.NewCond(&coord.stateMu)
+	publishSink := newBlockingCloseSink()
+	cleanupDone := make(chan struct{})
+	sink := newConditionalGenerationWriteSink(publishSink, coord, 0, func() error {
+		close(cleanupDone)
+		return nil
+	})
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- sink.Close()
+	}()
+
+	select {
+	case <-publishSink.closeStarted:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("conditional writer close did not enter underlying publish")
+	}
+
+	deleteDone := make(chan struct{})
+	go func() {
+		if err := coord.beginDelete(context.Background()); err != nil {
+			t.Errorf("begin delete: %v", err)
+			return
+		}
+		coord.finishDelete(true)
+		close(deleteDone)
+	}()
+
+	select {
+	case <-deleteDone:
+		t.Fatal("delete returned while a concurrent conditional publisher was still visible")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(publishSink.releaseClose)
+
+	select {
+	case <-cleanupDone:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("invalidated conditional publisher did not run cleanup")
+	}
+	select {
+	case <-deleteDone:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("delete did not return after conditional publisher cleanup completed")
+	}
+	select {
+	case err := <-closeDone:
+		if !errors.Is(err, ErrTopWriteInvalidated) {
+			t.Fatalf("expected invalidated close, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("conditional writer close did not return")
+	}
+}
+
 func TestCurrentTopWriteGenerationDoesNotCreateCoordinatorForMissingKey(t *testing.T) {
 	cache := &DaramjweeCache{}
 
@@ -77,7 +256,9 @@ func TestSetStreamToTopStoreWithGenerationHonorsCanceledContextWhileDeleteInProg
 	}
 
 	coord := cache.topWrites.coordinator("key")
-	coord.beginDelete()
+	if err := coord.beginDelete(context.Background()); err != nil {
+		t.Fatalf("begin delete: %v", err)
+	}
 	defer coord.finishDelete(false)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -280,6 +461,82 @@ func TestFanoutWriteManagerOrdersStaleCleanupBeforeNewerWrite(t *testing.T) {
 	}
 }
 
+func TestCoordinatedTopWriteSinkInvalidatedAfterPublishRunsCleanupWithoutStateMu(t *testing.T) {
+	coord := &writeCoordinator{}
+	coord.stateChanged = sync.NewCond(&coord.stateMu)
+	coord.committedGeneration = 1
+	coord.writeMu.Lock()
+
+	sink := &coordinatedTopWriteSink{
+		WriteSink: &testWriteSink{
+			closeFn: func() error {
+				coord.stateMu.Lock()
+				coord.committedGeneration = 2
+				coord.stateChanged.Broadcast()
+				coord.stateMu.Unlock()
+				return nil
+			},
+		},
+		coord:      coord,
+		generation: 1,
+		onInvalidated: func() error {
+			if got := coord.current(); got != 2 {
+				t.Errorf("expected cleanup to observe generation 2, got %d", got)
+			}
+			return nil
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sink.Close()
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrTopWriteInvalidated) {
+			t.Fatalf("expected invalidated error, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("cleanup blocked while stateMu was held")
+	}
+}
+
+func TestConditionalGenerationWriteSinkInvalidatedAfterPublishRunsCleanupWithoutStateMu(t *testing.T) {
+	coord := &writeCoordinator{}
+	coord.stateChanged = sync.NewCond(&coord.stateMu)
+	coord.committedGeneration = 1
+
+	sink := newConditionalGenerationWriteSink(&testWriteSink{
+		closeFn: func() error {
+			coord.stateMu.Lock()
+			coord.committedGeneration = 2
+			coord.stateChanged.Broadcast()
+			coord.stateMu.Unlock()
+			return nil
+		},
+	}, coord, 1, func() error {
+		if got := coord.current(); got != 2 {
+			t.Errorf("expected cleanup to observe generation 2, got %d", got)
+		}
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sink.Close()
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrTopWriteInvalidated) {
+			t.Fatalf("expected invalidated error, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("cleanup blocked while stateMu was held")
+	}
+}
+
 type destructiveReservationStore struct {
 	beginSetCalls int
 	data          []byte
@@ -333,6 +590,31 @@ type stubWriteSink struct{}
 func (s *stubWriteSink) Write(p []byte) (int, error) { return len(p), nil }
 func (s *stubWriteSink) Close() error                { return nil }
 func (s *stubWriteSink) Abort() error                { return nil }
+
+type blockingCloseSink struct {
+	closeStarted chan struct{}
+	releaseClose chan struct{}
+	once         sync.Once
+}
+
+func newBlockingCloseSink() *blockingCloseSink {
+	return &blockingCloseSink{
+		closeStarted: make(chan struct{}),
+		releaseClose: make(chan struct{}),
+	}
+}
+
+func (s *blockingCloseSink) Write(p []byte) (int, error) { return len(p), nil }
+
+func (s *blockingCloseSink) Close() error {
+	s.once.Do(func() {
+		close(s.closeStarted)
+	})
+	<-s.releaseClose
+	return nil
+}
+
+func (s *blockingCloseSink) Abort() error { return nil }
 
 type testWriteSink struct {
 	closeFn func() error


### PR DESCRIPTION
## Summary
- Fix file-cache stuck-key paths by making fill writes preemptable or best-effort when another same-key operation is in flight.
- Tighten streaming publication so EOF, Close, Abort, refresh, fallback promotion, and fanout preserve data integrity.
- Add deterministic stuck-cache repro, stress, fuzz, race, and review-regression coverage for positive, negative, conditional, refresh, and group lifecycle paths.

## Root Cause
Some streaming cache fill paths held the per-key top write lock until the caller consumed or closed the response body. Several expected-generation paths, including conditional lower-tier promotion, negative cache writes, and background refresh, could still wait behind that fill. Additional review found data-integrity gaps around source close errors, 304 fallback metadata mismatch, and higher-tier read errors being treated like clean misses.

## Validation
- go test ./...
- go test -race ./...
- git diff --check
- DJ_REPRO_CACHE_STUCK=1 targeted cache-stuck loop for 60s, 14 attempts
- Principal/subagent review loop ended with no material findings
- Oracle P1 review findings were applied and verified locally
