### PR TITLE
Clean objectstore seal failure staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### ⚠️ Breaking Changes & API Updates
+
+*   **The experimental SQLite store package is not part of the current public surface**: `pkg/store/sqlitestore` is not included in this release line.
+
+### 🧰 Migration Notes
+
+*   If you tested `github.com/mrchypark/daramjwee/pkg/store/sqlitestore` from a branch or non-canonical tag snapshot, remove that import before upgrading on this release line.
+
 ## v0.8.0
 
 ### ⚠️ Breaking Changes & API Updates

--- a/README.md
+++ b/README.md
@@ -305,10 +305,15 @@ The most important design point is that `objectstore.WithDir(...)` is **not** a 
 Typical ordered-tier layout:
 
 ```go
+tier0, err := filestore.New("/var/lib/daramjwee/tier0", log.With(logger, "tier", "0"))
+if err != nil {
+    return err
+}
+
 cache, err := daramjwee.New(
     logger,
     daramjwee.WithTiers(
-        filestore.New("/var/lib/daramjwee/tier0", log.With(logger, "tier", "0")),
+        tier0,
         objectstore.New(
             bucket,
             log.With(logger, "tier", "1"),

--- a/pkg/store/objectstore/README.md
+++ b/pkg/store/objectstore/README.md
@@ -5,10 +5,15 @@
 It fits into the same ordered-tier API as the other backends:
 
 ```go
+tier0, err := filestore.New("/var/lib/daramjwee/tier0", log.With(logger, "tier", "0"))
+if err != nil {
+    return err
+}
+
 cache, err := daramjwee.New(
     logger,
     daramjwee.WithTiers(
-        filestore.New("/var/lib/daramjwee/tier0", log.With(logger, "tier", "0")),
+        tier0,
         objectstore.New(
             bucket,
             log.With(logger, "tier", "1"),
@@ -38,7 +43,7 @@ That means these two setups behave differently:
 - `WithTiers(objectstore.New(...))`
   - Remote cache can be served directly.
   - Local disk is used as spool/catalog workspace.
-- `WithTiers(filestore.New(...), objectstore.New(...))`
+- `WithTiers(fileTier, objectstore.New(...))`
   - First request after a cold start can be a remote `objectstore` hit.
   - That request repopulates `FileStore`, so later requests can hit local disk in tier 0.
 

--- a/pkg/store/objectstore/ingest_test.go
+++ b/pkg/store/objectstore/ingest_test.go
@@ -2,6 +2,7 @@ package objectstore
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -833,4 +834,111 @@ func TestStore_CloseFailureDoesNotLeaveSealedSegmentVisible(t *testing.T) {
 	segments, globErr := filepath.Glob(filepath.Join(dataDir, "ingest", "sealed", "*", "*.seg"))
 	require.NoError(t, globErr)
 	require.Empty(t, segments)
+}
+
+func TestStore_CommitSealFailureCleansStagingSegment(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	store := New(
+		objstore.NewInMemBucket(),
+		log.NewNopLogger(),
+		WithDir(dataDir),
+	)
+	store.autoFlush = false
+
+	sealErr := errors.New("seal failed")
+	store.openSegmentWriter = func(root, shard, segmentID string) (segmentWriter, error) {
+		return newFailingSealSegmentWriter(root, shard, segmentID, sealErr, nil)
+	}
+
+	writer, err := store.BeginSet(ctx, "seal-failure", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, "payload")
+	require.NoError(t, err)
+
+	err = writer.Close()
+	require.ErrorIs(t, err, sealErr)
+	require.ErrorContains(t, err, "objectstore: commit: seal segment")
+
+	activeSegments, err := filepath.Glob(filepath.Join(dataDir, "ingest", "active", "*", "*.seg"))
+	require.NoError(t, err)
+	require.Empty(t, activeSegments)
+	sealedSegments, err := filepath.Glob(filepath.Join(dataDir, "ingest", "sealed", "*", "*.seg"))
+	require.NoError(t, err)
+	require.Empty(t, sealedSegments)
+}
+
+func TestStore_CommitSealFailureReturnsCleanupError(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	store := New(
+		objstore.NewInMemBucket(),
+		log.NewNopLogger(),
+		WithDir(dataDir),
+	)
+	store.autoFlush = false
+
+	sealErr := errors.New("seal failed")
+	cleanupErr := errors.New("cleanup failed")
+	store.openSegmentWriter = func(root, shard, segmentID string) (segmentWriter, error) {
+		return newFailingSealSegmentWriter(root, shard, segmentID, sealErr, cleanupErr)
+	}
+
+	writer, err := store.BeginSet(ctx, "seal-cleanup-failure", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, "payload")
+	require.NoError(t, err)
+
+	err = writer.Close()
+	require.ErrorIs(t, err, sealErr)
+	require.ErrorIs(t, err, cleanupErr)
+	require.ErrorContains(t, err, "objectstore: commit: seal segment")
+}
+
+type failingSealSegmentWriter struct {
+	activePath string
+	sealedPath string
+	sealErr    error
+	cleanupErr error
+}
+
+func newFailingSealSegmentWriter(root, shard, segmentID string, sealErr, cleanupErr error) (*failingSealSegmentWriter, error) {
+	activeDir := filepath.Join(root, "ingest", "active", shard)
+	sealedDir := filepath.Join(root, "ingest", "sealed", shard)
+	if err := os.MkdirAll(activeDir, 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(sealedDir, 0o755); err != nil {
+		return nil, err
+	}
+	activePath := filepath.Join(activeDir, segmentID+".seg")
+	if err := os.WriteFile(activePath, nil, 0o644); err != nil {
+		return nil, err
+	}
+	return &failingSealSegmentWriter{
+		activePath: activePath,
+		sealedPath: filepath.Join(sealedDir, segmentID+".seg"),
+		sealErr:    sealErr,
+		cleanupErr: cleanupErr,
+	}, nil
+}
+
+func (w *failingSealSegmentWriter) Write(p []byte) (int, error) {
+	file, err := os.OpenFile(w.activePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	return file.Write(p)
+}
+
+func (w *failingSealSegmentWriter) Seal() (string, int64, error) {
+	if err := os.Rename(w.activePath, w.sealedPath); err != nil {
+		return "", 0, err
+	}
+	return "", 0, w.sealErr
+}
+
+func (w *failingSealSegmentWriter) Abort() error {
+	return errors.Join(removeLocalSegment(w.activePath), removeLocalSegment(w.sealedPath), w.cleanupErr)
 }

--- a/pkg/store/objectstore/internal/segment/segment.go
+++ b/pkg/store/objectstore/internal/segment/segment.go
@@ -1,6 +1,7 @@
 package segment
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 )
@@ -60,19 +61,22 @@ func (w *Writer) Seal() (string, int64, error) {
 
 func (w *Writer) Abort() error {
 	closeErr := w.file.Close()
-	removeErr := os.Remove(w.activePath)
-	if os.IsNotExist(removeErr) {
-		removeErr = nil
+	removeErr := errors.Join(removeAndSync(w.activePath), removeAndSync(w.sealedPath))
+	if errors.Is(closeErr, os.ErrClosed) {
+		return removeErr
 	}
-	if removeErr == nil {
-		if err := syncDir(filepath.Dir(w.activePath)); err != nil {
-			removeErr = err
-		}
+	return errors.Join(closeErr, removeErr)
+}
+
+func removeAndSync(path string) error {
+	err := os.Remove(path)
+	if err == nil {
+		return syncDir(filepath.Dir(path))
 	}
-	if closeErr != nil {
-		return closeErr
+	if os.IsNotExist(err) {
+		return nil
 	}
-	return removeErr
+	return err
 }
 
 func syncDir(dir string) error {

--- a/pkg/store/objectstore/internal/segment/segment_unix_test.go
+++ b/pkg/store/objectstore/internal/segment/segment_unix_test.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package segment
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriter_AbortReturnsRemoveErrorWhenFileAlreadyClosed(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can unlink files from non-writable directories")
+	}
+
+	writer, err := Open(t.TempDir(), "ef", "segment-3")
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("payload"))
+	require.NoError(t, err)
+
+	require.NoError(t, writer.file.Close())
+	activeDir := filepath.Dir(writer.activePath)
+	require.NoError(t, os.Chmod(activeDir, 0o555))
+	t.Cleanup(func() {
+		_ = os.Chmod(activeDir, 0o755)
+		_ = os.Remove(writer.activePath)
+	})
+
+	err = writer.Abort()
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, os.ErrClosed))
+	assert.ErrorIs(t, err, os.ErrPermission)
+}

--- a/pkg/store/objectstore/writer.go
+++ b/pkg/store/objectstore/writer.go
@@ -2,6 +2,7 @@ package objectstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -53,17 +54,15 @@ func (w *writer) Commit(ctx context.Context) error {
 		return nil
 	}
 	if err := ctx.Err(); err != nil {
-		_ = w.segment.Abort()
-		return fmt.Errorf("objectstore: commit: %w", err)
+		return fmt.Errorf("objectstore: commit: %w", w.abortWith(err))
 	}
 	if err := w.ctx.Err(); err != nil {
-		_ = w.segment.Abort()
-		return fmt.Errorf("objectstore: commit: %w", err)
+		return fmt.Errorf("objectstore: commit: %w", w.abortWith(err))
 	}
 
 	sealedPath, size, err := w.segment.Seal()
 	if err != nil {
-		return err
+		return fmt.Errorf("objectstore: commit: seal segment: %w", w.abortWith(err))
 	}
 	metadata := daramjwee.Metadata{}
 	if w.metadata != nil {
@@ -93,6 +92,13 @@ func (w *writer) Abort() error {
 		return nil
 	}
 	return w.segment.Abort()
+}
+
+func (w *writer) abortWith(err error) error {
+	if abortErr := w.segment.Abort(); abortErr != nil {
+		return errors.Join(err, abortErr)
+	}
+	return err
 }
 
 func (w *writer) markDone() bool {


### PR DESCRIPTION
## Summary
- clean up objectstore local staging segments when segment sealing fails during commit
- make segment abort remove both active and sealed path candidates
- fix objectstore tier README examples so `filestore.New` errors are handled before `WithTiers`
- document the removed experimental SQLite store package in the v0.8.0 migration notes

## Root Cause
`objectstore.writer.Commit` marked the writer terminal before calling `Seal`. If `Seal` failed after moving a segment from active to sealed staging, the cache wrapper's later `Abort` call became a no-op and the sealed local segment could remain in `dataDir`.

## Validation
- `go test ./pkg/store/objectstore ./pkg/store/objectstore/internal/segment -count=1`
- `go test ./... -count=1 -timeout=180s`
