### PR TITLE
Harden cache and storage concurrency

### DIFF
--- a/background_runtime_group.go
+++ b/background_runtime_group.go
@@ -58,6 +58,7 @@ type queuedBackgroundJob struct {
 	cacheID string
 	kind    JobKind
 	job     worker.Job
+	onDrop  func()
 }
 
 func newGroupRuntime(logger log.Logger, workers int, timeout time.Duration) *groupRuntime {
@@ -118,6 +119,14 @@ func (r *groupRuntime) Register(cacheID string, cfg CacheRuntimeConfig) error {
 }
 
 func (r *groupRuntime) Submit(cacheID string, kind JobKind, job worker.Job) bool {
+	return r.submit(cacheID, kind, job, nil)
+}
+
+func (r *groupRuntime) SubmitWithDropCleanup(cacheID string, kind JobKind, job worker.Job, onDrop func()) bool {
+	return r.submit(cacheID, kind, job, onDrop)
+}
+
+func (r *groupRuntime) submit(cacheID string, kind JobKind, job worker.Job, onDrop func()) bool {
 	if r == nil {
 		return false
 	}
@@ -146,7 +155,7 @@ func (r *groupRuntime) Submit(cacheID string, kind JobKind, job worker.Job) bool
 		return false
 	}
 	select {
-	case state.queue <- queuedBackgroundJob{cacheID: cacheID, kind: kind, job: job}:
+	case state.queue <- queuedBackgroundJob{cacheID: cacheID, kind: kind, job: job, onDrop: onDrop}:
 	default:
 		r.noteRejectLocked(cacheID, kind, rejectReasonQueueFull, len(state.queue), state.queueLimit)
 		r.mu.Unlock()
@@ -163,6 +172,12 @@ func (r *groupRuntime) Submit(cacheID string, kind JobKind, job worker.Job) bool
 	r.cond.Signal()
 	r.mu.Unlock()
 	return true
+}
+
+func (j queuedBackgroundJob) drop() {
+	if j.onDrop != nil {
+		j.onDrop()
+	}
 }
 
 func (r *groupRuntime) RemoveCache(cacheID string) {
@@ -226,7 +241,8 @@ func (r *groupRuntime) CloseCache(cacheID string, timeout time.Duration) error {
 	state.cancel()
 	dropped := len(state.queue)
 	for len(state.queue) > 0 {
-		<-state.queue
+		job := <-state.queue
+		job.drop()
 	}
 	r.cond.Broadcast()
 	done := r.cacheCloseDoneLocked(state)
@@ -257,7 +273,8 @@ func (r *groupRuntime) Shutdown(timeout time.Duration) error {
 		}
 		dropped := len(state.queue)
 		for len(state.queue) > 0 {
-			<-state.queue
+			job := <-state.queue
+			job.drop()
 		}
 		r.cacheCloseDoneLocked(state)
 		level.Info(r.logger).Log("msg", "closing cache runtime", "cache_id", cacheID, "dropped_jobs", dropped, "timeout", timeout)
@@ -292,6 +309,7 @@ func (r *groupRuntime) workerLoop(workerID int) {
 		closed := state.closed
 		r.mu.Unlock()
 		if closed {
+			job.drop()
 			r.mu.Lock()
 			state.active--
 			r.notifyCacheActivityLocked(state)

--- a/background_runtime_test.go
+++ b/background_runtime_test.go
@@ -134,6 +134,41 @@ func TestGroupRuntime_CloseCacheWaitsForDequeuedJobReservation(t *testing.T) {
 	require.NoError(t, rt.Shutdown(time.Second))
 }
 
+func TestGroupRuntime_CloseCacheRunsQueuedJobDropCleanupOnce(t *testing.T) {
+	rt := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
+
+	const cacheID = "cache-drop-cleanup"
+	require.NoError(t, rt.Register(cacheID, CacheRuntimeConfig{Weight: 1, QueueLimit: 2}))
+
+	activeStarted := make(chan struct{})
+	releaseActive := make(chan struct{})
+	require.True(t, rt.Submit(cacheID, JobKindRefresh, func(context.Context) {
+		close(activeStarted)
+		<-releaseActive
+	}))
+	<-activeStarted
+
+	var cleanupCalls atomic.Int32
+	cleanupDone := make(chan struct{})
+	require.True(t, rt.SubmitWithDropCleanup(cacheID, JobKindPersist, func(context.Context) {
+		t.Fatal("queued job ran after CloseCache")
+	}, func() {
+		if cleanupCalls.Add(1) == 1 {
+			close(cleanupDone)
+		}
+	}))
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- rt.CloseCache(cacheID, time.Second)
+	}()
+	<-cleanupDone
+	close(releaseActive)
+	require.NoError(t, <-closeDone)
+	require.Equal(t, int32(1), cleanupCalls.Load())
+	require.NoError(t, rt.Shutdown(time.Second))
+}
+
 func TestGroupRuntime_CloseCache_IdempotentWhileJobActive(t *testing.T) {
 	rt := newGroupRuntime(log.NewNopLogger(), 1, time.Second)
 

--- a/cache.go
+++ b/cache.go
@@ -41,14 +41,14 @@ type cacheConfig struct {
 
 // DaramjweeCache is a concrete implementation of the Cache interface.
 type DaramjweeCache struct {
-	tiers      []Store
-	logger     log.Logger
-	runtime    backgroundRuntime
-	cacheID    string
-	config     cacheConfig
-	closeHook  func()
-	isClosed   atomic.Bool
-	topWrites  topWriteManager
+	tiers        []Store
+	logger       log.Logger
+	runtime      backgroundRuntime
+	cacheID      string
+	config       cacheConfig
+	closeHook    func()
+	isClosed     atomic.Bool
+	topWrites    topWriteManager
 	fanoutWrites fanoutWriteManager
 }
 
@@ -65,6 +65,7 @@ func (c *DaramjweeCache) Get(ctx context.Context, key string, req GetRequest, fe
 	}
 	setupCtx, cancel := c.newCtxWithTimeout(ctx)
 	topGenerationAtStart := c.currentTopWriteGeneration(key)
+	defer topGenerationAtStart.release()
 	higherTiersClean := true
 
 	for i, tier := range c.tiers {
@@ -131,6 +132,7 @@ func (c *DaramjweeCache) Set(ctx context.Context, key string, metadata *Metadata
 	if metadata == nil {
 		metadata = &Metadata{}
 	}
+	metadata = cloneMetadata(metadata)
 	metadata.CachedAt = time.Now()
 
 	wc, err := c.setStreamToTopStoreWithGeneration(c.beginSetContextForStore(ctx, setupCtx, target), key, metadata, nil)
@@ -153,11 +155,13 @@ func (c *DaramjweeCache) Delete(ctx context.Context, key string) error {
 	}
 	coord := c.topWrites.coordinator(key)
 	if err := coord.beginDelete(ctx); err != nil {
+		coord.releaseReference()
 		return err
 	}
 	topDeleteSucceeded := false
 	defer func() {
 		coord.finishDelete(topDeleteSucceeded)
+		coord.releaseReference()
 	}()
 	var firstErr error
 	top := c.topWriteStore()

--- a/cache_background_panic_test.go
+++ b/cache_background_panic_test.go
@@ -1,0 +1,400 @@
+package daramjwee
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee/internal/worker"
+	"github.com/stretchr/testify/require"
+)
+
+type panicBackgroundReadCloser struct {
+	triggered chan struct{}
+	once      sync.Once
+}
+
+func (r *panicBackgroundReadCloser) Read([]byte) (int, error) {
+	r.once.Do(func() { close(r.triggered) })
+	panic("background source read panic")
+}
+
+func (*panicBackgroundReadCloser) Close() error { return nil }
+
+type panicBackgroundStore struct {
+	panicWrite bool
+	triggered  chan struct{}
+}
+
+func (*panicBackgroundStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *panicBackgroundStore) BeginSet(context.Context, string, *Metadata) (WriteSink, error) {
+	return &panicBackgroundSink{store: s}, nil
+}
+
+func (s *panicBackgroundStore) BeginStagedSet(context.Context, string, *Metadata) (StagedWriteSink, error) {
+	return &panicBackgroundSink{store: s}, nil
+}
+
+func (*panicBackgroundStore) Delete(context.Context, string) error { return nil }
+
+func (*panicBackgroundStore) Stat(context.Context, string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type panicBackgroundSink struct {
+	store *panicBackgroundStore
+	once  sync.Once
+}
+
+func (s *panicBackgroundSink) Write(p []byte) (int, error) {
+	if s.store.panicWrite {
+		s.once.Do(func() { close(s.store.triggered) })
+		panic("background destination write panic")
+	}
+	return len(p), nil
+}
+
+func (*panicBackgroundSink) Close() error                 { return nil }
+func (*panicBackgroundSink) Commit(context.Context) error { return nil }
+func (*panicBackgroundSink) Abort() error                 { return nil }
+
+type panicPersistSourceStore struct {
+	panicRead bool
+	triggered chan struct{}
+}
+
+func (s *panicPersistSourceStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	if s.panicRead {
+		return &panicBackgroundReadCloser{triggered: s.triggered}, &Metadata{CacheTag: "v1"}, nil
+	}
+	return io.NopCloser(bytes.NewReader([]byte("value"))), &Metadata{CacheTag: "v1"}, nil
+}
+
+func (*panicPersistSourceStore) BeginSet(context.Context, string, *Metadata) (WriteSink, error) {
+	return &panicBackgroundSink{store: &panicBackgroundStore{}}, nil
+}
+
+func (*panicPersistSourceStore) Delete(context.Context, string) error { return nil }
+
+func (*panicPersistSourceStore) Stat(context.Context, string) (*Metadata, error) {
+	return &Metadata{CacheTag: "v1"}, nil
+}
+
+type panicRefreshFetcher struct {
+	panicRead bool
+	triggered chan struct{}
+}
+
+type panicNotModifiedFetcher struct{}
+
+func (panicNotModifiedFetcher) Fetch(context.Context, *Metadata) (*FetchResult, error) {
+	return nil, ErrNotModified
+}
+
+type panicCacheableNotFoundFetcher struct{}
+
+func (panicCacheableNotFoundFetcher) Fetch(context.Context, *Metadata) (*FetchResult, error) {
+	return nil, ErrCacheableNotFound
+}
+
+type panicCommitStore struct {
+	commitTriggered chan struct{}
+	commitOnce      sync.Once
+	abortCalls      atomic.Int32
+}
+
+func (*panicCommitStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *panicCommitStore) BeginSet(context.Context, string, *Metadata) (WriteSink, error) {
+	return &panicCommitSink{store: s}, nil
+}
+
+func (s *panicCommitStore) BeginStagedSet(context.Context, string, *Metadata) (StagedWriteSink, error) {
+	return &panicCommitSink{store: s}, nil
+}
+
+func (*panicCommitStore) Delete(context.Context, string) error { return nil }
+
+func (*panicCommitStore) Stat(context.Context, string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+type panicCommitSink struct {
+	store *panicCommitStore
+}
+
+func (*panicCommitSink) Write(p []byte) (int, error) { return len(p), nil }
+
+func (s *panicCommitSink) Close() error { return s.Commit(context.Background()) }
+
+func (s *panicCommitSink) Commit(context.Context) error {
+	s.store.commitOnce.Do(func() { close(s.store.commitTriggered) })
+	panic("background staged commit panic")
+}
+
+func (s *panicCommitSink) Abort() error {
+	s.store.abortCalls.Add(1)
+	return nil
+}
+
+type panicFallbackSourceStore struct {
+	meta      *Metadata
+	panicRead bool
+	triggered chan struct{}
+}
+
+func (s *panicFallbackSourceStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	if s.panicRead {
+		return &panicBackgroundReadCloser{triggered: s.triggered}, cloneMetadata(s.meta), nil
+	}
+	return io.NopCloser(bytes.NewReader([]byte("fallback"))), cloneMetadata(s.meta), nil
+}
+
+func (*panicFallbackSourceStore) BeginSet(context.Context, string, *Metadata) (WriteSink, error) {
+	return &panicBackgroundSink{store: &panicBackgroundStore{}}, nil
+}
+
+func (*panicFallbackSourceStore) Delete(context.Context, string) error { return nil }
+
+func (s *panicFallbackSourceStore) Stat(context.Context, string) (*Metadata, error) {
+	return cloneMetadata(s.meta), nil
+}
+
+type panicStaleTopStore struct {
+	meta      *Metadata
+	triggered chan struct{}
+}
+
+func (s *panicStaleTopStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	return io.NopCloser(bytes.NewReader([]byte("current"))), cloneMetadata(s.meta), nil
+}
+
+func (s *panicStaleTopStore) BeginSet(context.Context, string, *Metadata) (WriteSink, error) {
+	return &panicBackgroundSink{store: &panicBackgroundStore{panicWrite: true, triggered: s.triggered}}, nil
+}
+
+func (s *panicStaleTopStore) BeginStagedSet(context.Context, string, *Metadata) (StagedWriteSink, error) {
+	return &panicBackgroundSink{store: &panicBackgroundStore{panicWrite: true, triggered: s.triggered}}, nil
+}
+
+func (*panicStaleTopStore) Delete(context.Context, string) error { return nil }
+
+func (s *panicStaleTopStore) Stat(context.Context, string) (*Metadata, error) {
+	return cloneMetadata(s.meta), nil
+}
+
+func (f panicRefreshFetcher) Fetch(context.Context, *Metadata) (*FetchResult, error) {
+	if f.panicRead {
+		return &FetchResult{
+			Body:     &panicBackgroundReadCloser{triggered: f.triggered},
+			Metadata: &Metadata{CacheTag: "v2"},
+		}, nil
+	}
+	return &FetchResult{
+		Body:     io.NopCloser(bytes.NewReader([]byte("value"))),
+		Metadata: &Metadata{CacheTag: "v2"},
+	}, nil
+}
+
+func newPanicTestRuntime(t *testing.T) backgroundRuntime {
+	t.Helper()
+	manager, err := worker.NewManager("pool", log.NewNopLogger(), 1, 4, time.Second)
+	require.NoError(t, err)
+	return newStandaloneRuntime(manager)
+}
+
+func waitForRuntimeRecovery(t *testing.T, runtime backgroundRuntime, cacheID string, kind JobKind) {
+	t.Helper()
+	recovered := make(chan struct{})
+	require.True(t, runtime.Submit(cacheID, kind, func(context.Context) { close(recovered) }))
+	select {
+	case <-recovered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("native runtime did not continue after background panic")
+	}
+}
+
+func waitForPanicTrigger(t *testing.T, triggered <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-triggered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background panic path was not reached")
+	}
+}
+
+func requireCoordinatorRetired(t *testing.T, cache *DaramjweeCache, key string) {
+	t.Helper()
+	if _, ok := cache.topWrites.coords.Load(key); ok {
+		t.Fatalf("top-write coordinator for %q remained after recovered panic", key)
+	}
+}
+
+func requireLaterSameKeyWrite(t *testing.T, cache *DaramjweeCache, key string) {
+	t.Helper()
+	writer, err := cache.Set(context.Background(), key, &Metadata{CacheTag: "later"})
+	require.NoError(t, err)
+	require.NoError(t, writer.Abort())
+	requireCoordinatorRetired(t, cache, key)
+}
+
+func TestPersistBackgroundPanicReleasesCoordinator(t *testing.T) {
+	for _, panicAt := range []string{"source", "destination"} {
+		t.Run(panicAt, func(t *testing.T) {
+			triggered := make(chan struct{})
+			source := &panicPersistSourceStore{panicRead: panicAt == "source", triggered: triggered}
+			destination := &panicBackgroundStore{panicWrite: panicAt == "destination", triggered: triggered}
+			runtime := newPanicTestRuntime(t)
+			cache := &DaramjweeCache{
+				tiers:   []Store{source},
+				runtime: runtime,
+				cacheID: "persist-panic-" + panicAt,
+				logger:  log.NewNopLogger(),
+				config:  cacheConfig{opTimeout: time.Second, closeTimeout: time.Second},
+			}
+			t.Cleanup(cache.Close)
+
+			key := "key"
+			expected := cache.currentTopWriteGeneration(key)
+			cache.schedulePersistFromTop(context.Background(), key, expected, tierDestination{tierIndex: 1, store: destination})
+			expected.release()
+			waitForPanicTrigger(t, triggered)
+			waitForRuntimeRecovery(t, runtime, cache.cacheID, JobKindPersist)
+			requireCoordinatorRetired(t, cache, key)
+			requireLaterSameKeyWrite(t, cache, key)
+		})
+	}
+}
+
+func TestRefreshBackgroundPanicReleasesCoordinator(t *testing.T) {
+	for _, panicAt := range []string{"source", "destination"} {
+		t.Run(panicAt, func(t *testing.T) {
+			triggered := make(chan struct{})
+			top := &panicBackgroundStore{panicWrite: panicAt == "destination", triggered: triggered}
+			runtime := newPanicTestRuntime(t)
+			cache := &DaramjweeCache{
+				tiers:   []Store{top},
+				runtime: runtime,
+				cacheID: "refresh-panic-" + panicAt,
+				logger:  log.NewNopLogger(),
+				config:  cacheConfig{opTimeout: time.Second, closeTimeout: time.Second},
+			}
+			t.Cleanup(cache.Close)
+
+			key := "key"
+			err := cache.scheduleRefreshWithMetadata(context.Background(), key, panicRefreshFetcher{
+				panicRead: panicAt == "source",
+				triggered: triggered,
+			}, nil, nil, nil)
+			require.NoError(t, err)
+			waitForPanicTrigger(t, triggered)
+			waitForRuntimeRecovery(t, runtime, cache.cacheID, JobKindRefresh)
+			requireCoordinatorRetired(t, cache, key)
+			requireLaterSameKeyWrite(t, cache, key)
+		})
+	}
+}
+
+func TestNotModifiedFallbackPanicReleasesCoordinator(t *testing.T) {
+	for _, panicAt := range []string{"source", "destination"} {
+		t.Run(panicAt, func(t *testing.T) {
+			triggered := make(chan struct{})
+			meta := &Metadata{CacheTag: "fallback", CachedAt: time.Now().Add(-time.Hour)}
+			top := &panicBackgroundStore{panicWrite: panicAt == "destination", triggered: triggered}
+			fallback := &panicFallbackSourceStore{meta: meta, panicRead: panicAt == "source", triggered: triggered}
+			runtime := newPanicTestRuntime(t)
+			cache := &DaramjweeCache{
+				tiers:   []Store{top, fallback},
+				runtime: runtime,
+				cacheID: "not-modified-fallback-panic-" + panicAt,
+				logger:  log.NewNopLogger(),
+				config:  cacheConfig{opTimeout: time.Second, closeTimeout: time.Second},
+			}
+			t.Cleanup(cache.Close)
+
+			key := "key"
+			err := cache.scheduleRefreshWithMetadata(
+				context.Background(),
+				key,
+				panicNotModifiedFetcher{},
+				meta,
+				&tierDestination{tierIndex: 1, store: fallback},
+				nil,
+			)
+			require.NoError(t, err)
+			waitForPanicTrigger(t, triggered)
+			waitForRuntimeRecovery(t, runtime, cache.cacheID, JobKindRefresh)
+			requireCoordinatorRetired(t, cache, key)
+			requireLaterSameKeyWrite(t, cache, key)
+		})
+	}
+}
+
+func TestNotModifiedStaleTopWritePanicReleasesCoordinator(t *testing.T) {
+	triggered := make(chan struct{})
+	top := &panicStaleTopStore{
+		meta:      &Metadata{CacheTag: "current", CachedAt: time.Now().Add(-time.Hour)},
+		triggered: triggered,
+	}
+	runtime := newPanicTestRuntime(t)
+	cache := &DaramjweeCache{
+		tiers:   []Store{top},
+		runtime: runtime,
+		cacheID: "not-modified-stale-top-panic",
+		logger:  log.NewNopLogger(),
+		config:  cacheConfig{opTimeout: time.Second, closeTimeout: time.Second, positiveFreshness: time.Minute},
+	}
+	t.Cleanup(cache.Close)
+
+	key := "key"
+	require.NoError(t, cache.scheduleRefreshWithMetadata(
+		context.Background(),
+		key,
+		panicNotModifiedFetcher{},
+		nil,
+		nil,
+		nil,
+	))
+	waitForPanicTrigger(t, triggered)
+	waitForRuntimeRecovery(t, runtime, cache.cacheID, JobKindRefresh)
+	requireCoordinatorRetired(t, cache, key)
+	requireLaterSameKeyWrite(t, cache, key)
+}
+
+func TestCacheableNotFoundCommitPanicAbortsAndReleasesCoordinator(t *testing.T) {
+	top := &panicCommitStore{commitTriggered: make(chan struct{})}
+	runtime := newPanicTestRuntime(t)
+	cache := &DaramjweeCache{
+		tiers:   []Store{top},
+		runtime: runtime,
+		cacheID: "cacheable-not-found-commit-panic",
+		logger:  log.NewNopLogger(),
+		config:  cacheConfig{opTimeout: time.Second, closeTimeout: time.Second},
+	}
+	t.Cleanup(cache.Close)
+
+	key := "key"
+	require.NoError(t, cache.scheduleRefreshWithMetadata(
+		context.Background(),
+		key,
+		panicCacheableNotFoundFetcher{},
+		nil,
+		nil,
+		nil,
+	))
+	waitForPanicTrigger(t, top.commitTriggered)
+	waitForRuntimeRecovery(t, runtime, cache.cacheID, JobKindRefresh)
+	require.Equal(t, int32(1), top.abortCalls.Load())
+	requireCoordinatorRetired(t, cache, key)
+	requireLaterSameKeyWrite(t, cache, key)
+}

--- a/cache_persist.go
+++ b/cache_persist.go
@@ -3,7 +3,20 @@ package daramjwee
 import (
 	"context"
 	"errors"
+
+	"github.com/mrchypark/daramjwee/internal/worker"
 )
+
+type backgroundRuntimeWithDropCleanup interface {
+	SubmitWithDropCleanup(cacheID string, kind JobKind, job worker.Job, onDrop func()) bool
+}
+
+func submitBackgroundJob(runtime backgroundRuntime, cacheID string, kind JobKind, job worker.Job, onDrop func()) bool {
+	if dropAware, ok := runtime.(backgroundRuntimeWithDropCleanup); ok {
+		return dropAware.SubmitWithDropCleanup(cacheID, kind, job, onDrop)
+	}
+	return runtime.Submit(cacheID, kind, job)
+}
 
 func (c *DaramjweeCache) persistDestinationsAfterTop() []tierDestination {
 	if len(c.tiers) <= 1 {
@@ -34,10 +47,12 @@ func (c *DaramjweeCache) regularFanoutDestinations(sourceIndex int) []tierDestin
 }
 
 func (c *DaramjweeCache) schedulePersistFromCurrentTop(ctx context.Context, key string, destinations ...tierDestination) {
-	c.schedulePersistFromTop(ctx, key, c.currentTopWriteGeneration(key), destinations...)
+	expectedGeneration := c.currentTopWriteGeneration(key)
+	defer expectedGeneration.release()
+	c.schedulePersistFromTop(ctx, key, expectedGeneration, destinations...)
 }
 
-func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string, expectedGeneration uint64, destinations ...tierDestination) {
+func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string, expectedGeneration *topWriteGeneration, destinations ...tierDestination) {
 	srcStore := c.topWriteStore()
 	if !hasRealStore(srcStore) || len(destinations) == 0 {
 		return
@@ -56,7 +71,9 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 
 		destTierIndex := destination.tierIndex
 		dest := destStore
+		jobGeneration := expectedGeneration.retain()
 		job := func(jobCtx context.Context) {
+			defer jobGeneration.release()
 			persistCtx := overlayContextValues(jobCtx, valueCtx)
 			c.infoLog("msg", "starting background set", "key", key, "dest_tier", destTierIndex)
 			srcStream, meta, err := c.getStreamFromStore(persistCtx, srcStore, key)
@@ -79,11 +96,13 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 				c.errorLog("msg", "failed to get writer for destination store", "key", key, "dest_tier", destTierIndex, "err", err)
 				return
 			}
-			destWriter = newConditionalGenerationWriteSink(destWriter, c.topWrites.coordinator(key), expectedGeneration, c.config.closeTimeout, func() error {
+			jobGeneration.coord.retainReference()
+			destWriter = newConditionalGenerationWriteSink(destWriter, jobGeneration.coord, jobGeneration.generation, c.config.closeTimeout, func() error {
 				cleanupCtx, cancel := c.newCtxWithTimeout(valueCtx)
 				defer cancel()
 				return c.deleteFromStore(cleanupCtx, dest, key)
 			})
+			defer destWriter.Abort()
 
 			if persistErr := copyCloseSourceThenCommit(destWriter, srcStream); persistErr != nil {
 				if errors.Is(persistErr, ErrTopWriteInvalidated) {
@@ -96,7 +115,8 @@ func (c *DaramjweeCache) schedulePersistFromTop(ctx context.Context, key string,
 			c.infoLog("msg", "background set successful", "key", key, "dest_tier", destTierIndex)
 		}
 
-		if !c.runtime.Submit(c.cacheID, JobKindPersist, job) {
+		if !submitBackgroundJob(c.runtime, c.cacheID, JobKindPersist, job, jobGeneration.release) {
+			jobGeneration.release()
 			c.warnLog("msg", "background set rejected", "key", key, "dest_tier", destTierIndex)
 		}
 	}

--- a/cache_persist_test.go
+++ b/cache_persist_test.go
@@ -151,7 +151,9 @@ func TestSchedulePersistFromTop_InvalidationCleanupUsesFreshContext(t *testing.T
 	t.Cleanup(cache.Close)
 
 	key := "persist-cleanup-key"
-	cache.schedulePersistFromTop(context.Background(), key, 0, tierDestination{tierIndex: 1, store: dest})
+	expectedGeneration := cache.currentTopWriteGeneration(key)
+	defer expectedGeneration.release()
+	cache.schedulePersistFromTop(context.Background(), key, expectedGeneration, tierDestination{tierIndex: 1, store: dest})
 
 	select {
 	case <-dest.closeStartedCh:

--- a/cache_read.go
+++ b/cache_read.go
@@ -8,7 +8,7 @@ import (
 )
 
 // handleTopTierHit processes the logic when an object is found in tier 0.
-func (c *DaramjweeCache) handleTopTierHit(requestCtx context.Context, key string, req GetRequest, fetcher Fetcher, stream io.ReadCloser, meta *Metadata, cancel context.CancelFunc, observedGeneration uint64) (*GetResponse, error) {
+func (c *DaramjweeCache) handleTopTierHit(requestCtx context.Context, key string, req GetRequest, fetcher Fetcher, stream io.ReadCloser, meta *Metadata, cancel context.CancelFunc, observedGeneration *topWriteGeneration) (*GetResponse, error) {
 	c.debugLog("msg", "top tier hit", "key", key)
 
 	isStale := c.isTierCachedStale(meta, 0)
@@ -29,13 +29,13 @@ func (c *DaramjweeCache) handleTopTierHit(requestCtx context.Context, key string
 	return newGetResponse(GetStatusOK, streamCloser, meta), nil
 }
 
-func (c *DaramjweeCache) handleConditionalTopTierHit(requestCtx context.Context, key string, fetcher Fetcher, stream io.ReadCloser, meta *Metadata, cancel context.CancelFunc, isStale bool, observedGeneration uint64) (*GetResponse, error) {
+func (c *DaramjweeCache) handleConditionalTopTierHit(requestCtx context.Context, key string, fetcher Fetcher, stream io.ReadCloser, meta *Metadata, cancel context.CancelFunc, isStale bool, observedGeneration *topWriteGeneration) (*GetResponse, error) {
 	if err := stream.Close(); err != nil {
 		cancel()
 		return nil, err
 	}
 	if isStale {
-		if err := c.scheduleRefreshWithMetadata(detachedValueContext(requestCtx), key, fetcher, cloneMetadata(meta), nil, &observedGeneration); err != nil {
+		if err := c.scheduleRefreshWithMetadata(detachedValueContext(requestCtx), key, fetcher, cloneMetadata(meta), nil, observedGeneration); err != nil {
 			c.warnLog("msg", "failed to schedule stale refresh", "key", key, "err", err)
 		}
 	}
@@ -43,7 +43,7 @@ func (c *DaramjweeCache) handleConditionalTopTierHit(requestCtx context.Context,
 	return newGetResponse(GetStatusNotModified, nil, meta), nil
 }
 
-func (c *DaramjweeCache) topTierCloseCallback(requestCtx context.Context, key string, fetcher Fetcher, cancel context.CancelFunc, meta *Metadata, isStale bool, observedGeneration uint64) func() {
+func (c *DaramjweeCache) topTierCloseCallback(requestCtx context.Context, key string, fetcher Fetcher, cancel context.CancelFunc, meta *Metadata, isStale bool, observedGeneration *topWriteGeneration) func() {
 	if !isStale {
 		return func() {
 			cancel()
@@ -65,7 +65,7 @@ type lowerTierHitParams struct {
 	src                io.ReadCloser
 	meta               *Metadata
 	cancel             context.CancelFunc
-	expectedGeneration uint64
+	expectedGeneration *topWriteGeneration
 	higherTiersClean   bool
 }
 
@@ -101,7 +101,7 @@ func (c *DaramjweeCache) serveLowerTierWithoutPromotion(p lowerTierHitParams, is
 	return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(p.src, p.cancel), p.meta), nil
 }
 
-func (c *DaramjweeCache) handleConditionalLowerTierHit(requestCtx, _ context.Context, key string, tierIndex int, fetcher Fetcher, src io.ReadCloser, meta, _ *Metadata, cancel context.CancelFunc, isStale bool, expectedGeneration uint64) (*GetResponse, error) {
+func (c *DaramjweeCache) handleConditionalLowerTierHit(requestCtx, _ context.Context, key string, tierIndex int, fetcher Fetcher, src io.ReadCloser, meta, _ *Metadata, cancel context.CancelFunc, isStale bool, expectedGeneration *topWriteGeneration) (*GetResponse, error) {
 	if !c.canServeConditionalLowerHit(key, expectedGeneration) {
 		return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(src, cancel), meta), nil
 	}
@@ -112,7 +112,7 @@ func (c *DaramjweeCache) handleConditionalLowerTierHit(requestCtx, _ context.Con
 
 	if isStale {
 		source := tierDestination{tierIndex: tierIndex, store: c.tiers[tierIndex]}
-		if err := c.scheduleRefreshWithMetadata(detachedValueContext(requestCtx), key, fetcher, cloneMetadata(meta), &source, &expectedGeneration); err != nil {
+		if err := c.scheduleRefreshWithMetadata(detachedValueContext(requestCtx), key, fetcher, cloneMetadata(meta), &source, expectedGeneration); err != nil {
 			c.warnLog("msg", "failed to schedule stale refresh", "key", key, "source_tier", tierIndex, "err", err)
 		}
 	}
@@ -120,16 +120,15 @@ func (c *DaramjweeCache) handleConditionalLowerTierHit(requestCtx, _ context.Con
 	return newGetResponse(GetStatusNotModified, nil, meta), nil
 }
 
-func (c *DaramjweeCache) canServeConditionalLowerHit(key string, expectedGeneration uint64) bool {
+func (c *DaramjweeCache) canServeConditionalLowerHit(key string, expectedGeneration *topWriteGeneration) bool {
 	return c.canAttemptExpectedTopWrite(key, expectedGeneration)
 }
 
-func (c *DaramjweeCache) canAttemptExpectedTopWrite(key string, expectedGeneration uint64) bool {
-	coord := c.topWrites.coordinatorIfPresent(key)
-	if coord == nil {
-		return expectedGeneration == 0
-	}
-	return coord.canAttemptExpectedTopWrite(expectedGeneration)
+func (c *DaramjweeCache) canAttemptExpectedTopWrite(key string, expectedGeneration *topWriteGeneration) bool {
+	return expectedGeneration != nil &&
+		expectedGeneration.coord.manager == &c.topWrites &&
+		expectedGeneration.coord.key == key &&
+		expectedGeneration.coord.canAttemptExpectedTopWrite(expectedGeneration.generation)
 }
 
 func (c *DaramjweeCache) handleConditionalLowerTierPromotionError(key string, tierIndex int, err error, src io.ReadCloser, meta *Metadata, cancel context.CancelFunc) *GetResponse {
@@ -149,7 +148,7 @@ func (c *DaramjweeCache) handleConditionalLowerTierPromotionError(key string, ti
 	return newGetResponse(GetStatusNotModified, nil, meta)
 }
 
-func (c *DaramjweeCache) handleStaleLowerTierHit(requestCtx context.Context, key string, tierIndex int, fetcher Fetcher, src io.ReadCloser, meta *Metadata, cancel context.CancelFunc, expectedGeneration uint64) (*GetResponse, error) {
+func (c *DaramjweeCache) handleStaleLowerTierHit(requestCtx context.Context, key string, tierIndex int, fetcher Fetcher, src io.ReadCloser, meta *Metadata, cancel context.CancelFunc, expectedGeneration *topWriteGeneration) (*GetResponse, error) {
 	c.debugLog("msg", "lower tier is stale, serving stale and scheduling refresh", "key", key, "tier_index", tierIndex)
 	source := tierDestination{tierIndex: tierIndex, store: c.tiers[tierIndex]}
 	streamCloser := newSafeCloser(src, c.lowerTierRefreshOnCloseCallback(requestCtx, key, fetcher, cancel, meta, source, expectedGeneration))
@@ -162,9 +161,9 @@ func (c *DaramjweeCache) handleStaleLowerTierHit(requestCtx context.Context, key
 	return newGetResponse(GetStatusOK, streamCloser, meta), nil
 }
 
-func (c *DaramjweeCache) promoteNegativeLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, meta, metaToPromote *Metadata, cancel context.CancelFunc, expectedGeneration uint64) (*GetResponse, error) {
+func (c *DaramjweeCache) promoteNegativeLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, meta, metaToPromote *Metadata, cancel context.CancelFunc, expectedGeneration *topWriteGeneration) (*GetResponse, error) {
 	target := c.topWriteStore()
-	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, target), key, metaToPromote, &expectedGeneration)
+	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, target), key, metaToPromote, expectedGeneration)
 	if err != nil {
 		closeErr := src.Close()
 		if closeErr != nil {
@@ -202,7 +201,7 @@ func (c *DaramjweeCache) promoteNegativeLowerTierHit(requestCtx, setupCtx contex
 	return newGetResponse(GetStatusNotFound, nil, meta), nil
 }
 
-func (c *DaramjweeCache) promotePositiveLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, meta, metaToPromote *Metadata, cancel context.CancelFunc, expectedGeneration uint64) *GetResponse {
+func (c *DaramjweeCache) promotePositiveLowerTierHit(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, meta, metaToPromote *Metadata, cancel context.CancelFunc, expectedGeneration *topWriteGeneration) *GetResponse {
 	target := c.topWriteStore()
 	writer, err := c.setStreamToTopStoreForFill(c.beginSetContextForStore(requestCtx, setupCtx, target), key, metaToPromote, expectedGeneration)
 	if err != nil {
@@ -221,13 +220,13 @@ func (c *DaramjweeCache) promotePositiveLowerTierHit(requestCtx, setupCtx contex
 		}
 	}
 	return newGetResponse(GetStatusOK, streamThroughWithTrace(src, writer, cancel, onPublish, func(event string, keyvals ...any) {
-		c.diagnosticLog(event, key, expectedGeneration, keyvals...)
+		c.diagnosticLog(event, key, expectedGeneration.generation, keyvals...)
 	}), meta)
 }
 
-func (c *DaramjweeCache) promoteLowerTierHitToTop(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, metadata *Metadata, expectedGeneration uint64) error {
+func (c *DaramjweeCache) promoteLowerTierHitToTop(requestCtx, setupCtx context.Context, key string, tierIndex int, src io.ReadCloser, metadata *Metadata, expectedGeneration *topWriteGeneration) error {
 	target := c.topWriteStore()
-	writer, err := c.setStreamToTopStoreWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, target), key, metadata, &expectedGeneration)
+	writer, err := c.setStreamToTopStoreWithGeneration(c.beginSetContextForStore(requestCtx, setupCtx, target), key, metadata, expectedGeneration)
 	if err != nil {
 		if errors.Is(err, ErrTopWriteInvalidated) {
 			return lowerTierPromotionInvalidatedError{preserveBody: true}
@@ -259,7 +258,7 @@ func (c *DaramjweeCache) promoteLowerTierHitToTop(requestCtx, setupCtx context.C
 }
 
 // handleMiss processes the logic when an object is not found in any tier.
-func (c *DaramjweeCache) handleMiss(requestCtx, setupCtx context.Context, key string, req GetRequest, fetcher Fetcher, cancel context.CancelFunc, expectedGeneration uint64, higherTiersClean bool) (*GetResponse, error) {
+func (c *DaramjweeCache) handleMiss(requestCtx, setupCtx context.Context, key string, req GetRequest, fetcher Fetcher, cancel context.CancelFunc, expectedGeneration *topWriteGeneration, higherTiersClean bool) (*GetResponse, error) {
 	c.debugLog("msg", "full cache miss, fetching from origin", "key", key)
 
 	var oldMetadata *Metadata
@@ -275,6 +274,7 @@ func (c *DaramjweeCache) handleMiss(requestCtx, setupCtx context.Context, key st
 	if result.Metadata == nil {
 		result.Metadata = &Metadata{}
 	}
+	result.Metadata = cloneMetadata(result.Metadata)
 	result.Metadata.CachedAt = time.Now()
 
 	if !higherTiersClean {
@@ -283,13 +283,13 @@ func (c *DaramjweeCache) handleMiss(requestCtx, setupCtx context.Context, key st
 	return c.publishMissResult(requestCtx, setupCtx, key, result, cancel, expectedGeneration), nil
 }
 
-func (c *DaramjweeCache) handleMissFetchError(requestCtx, setupCtx context.Context, key string, req GetRequest, cancel context.CancelFunc, fetcher Fetcher, fetchErr error, expectedGeneration uint64, higherTiersClean bool) (*GetResponse, error) {
+func (c *DaramjweeCache) handleMissFetchError(requestCtx, setupCtx context.Context, key string, req GetRequest, cancel context.CancelFunc, fetcher Fetcher, fetchErr error, expectedGeneration *topWriteGeneration, higherTiersClean bool) (*GetResponse, error) {
 	if errors.Is(fetchErr, ErrCacheableNotFound) {
 		if !higherTiersClean {
 			cancel()
 			return newGetResponse(GetStatusNotFound, nil, &Metadata{IsNegative: true, CachedAt: time.Now()}), nil
 		}
-		return c.handleNegativeCacheWithGeneration(requestCtx, setupCtx, key, cancel, &expectedGeneration)
+		return c.handleNegativeCacheWithGeneration(requestCtx, setupCtx, key, cancel, expectedGeneration)
 	}
 	if errors.Is(fetchErr, ErrNotModified) {
 		if !higherTiersClean {
@@ -334,7 +334,7 @@ func (c *DaramjweeCache) replayTopTierAfterNotModified(requestCtx, setupCtx cont
 	return newGetResponse(GetStatusOK, newCancelOnCloseReadCloser(stream, cancel), meta), nil
 }
 
-func (c *DaramjweeCache) publishMissResult(requestCtx, setupCtx context.Context, key string, result *FetchResult, cancel context.CancelFunc, expectedGeneration uint64) *GetResponse {
+func (c *DaramjweeCache) publishMissResult(requestCtx, setupCtx context.Context, key string, result *FetchResult, cancel context.CancelFunc, expectedGeneration *topWriteGeneration) *GetResponse {
 	target := c.topWriteStore()
 	writer, err := c.setStreamToTopStoreForFill(c.beginSetContextForStore(requestCtx, setupCtx, target), key, result.Metadata, expectedGeneration)
 	if err != nil {
@@ -348,7 +348,7 @@ func (c *DaramjweeCache) publishMissResult(requestCtx, setupCtx context.Context,
 	return newGetResponse(GetStatusOK, streamThroughWithTrace(result.Body, writer, cancel, func() {
 		c.schedulePersistFromCurrentTop(requestCtx, key, c.persistDestinationsAfterTop()...)
 	}, func(event string, keyvals ...any) {
-		c.diagnosticLog(event, key, expectedGeneration, keyvals...)
+		c.diagnosticLog(event, key, expectedGeneration.generation, keyvals...)
 	}), result.Metadata)
 }
 

--- a/cache_read_test.go
+++ b/cache_read_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testTopWriteGeneration(t *testing.T, cache *DaramjweeCache, key string) *topWriteGeneration {
+	t.Helper()
+	observed := cache.currentTopWriteGeneration(key)
+	t.Cleanup(observed.release)
+	return observed
+}
+
 func TestHandleConditionalLowerTierPromotionError_CancelsOnGenericPromotionFailure(t *testing.T) {
 	cache := &DaramjweeCache{
 		logger: log.NewNopLogger(),
@@ -51,7 +58,7 @@ func TestPromoteNegativeLowerTierHitJoinsWriterSetupAndSourceCloseErrors(t *test
 		&Metadata{IsNegative: true},
 		&Metadata{IsNegative: true},
 		func() { canceled = true },
-		0,
+		testTopWriteGeneration(t, cache, "key"),
 	)
 
 	require.Nil(t, resp)
@@ -77,7 +84,7 @@ func TestPromoteLowerTierHitToTopJoinsWriterSetupAndSourceCloseErrors(t *testing
 		1,
 		src,
 		&Metadata{},
-		0,
+		testTopWriteGeneration(t, cache, "key"),
 	)
 
 	require.ErrorIs(t, err, writerSetupErr)
@@ -100,7 +107,7 @@ func TestPromoteRefreshFallbackToTopPreservesInvalidationOnSourceCloseSuccess(t 
 		"key",
 		tierDestination{tierIndex: 1, store: cache.tiers[1]},
 		meta,
-		0,
+		testTopWriteGeneration(t, cache, "key"),
 	)
 
 	require.ErrorIs(t, err, ErrTopWriteInvalidated)
@@ -122,7 +129,7 @@ func TestPromoteRefreshFallbackToTopJoinsInvalidationAndSourceCloseError(t *test
 		"key",
 		tierDestination{tierIndex: 1, store: cache.tiers[1]},
 		meta,
-		0,
+		testTopWriteGeneration(t, cache, "key"),
 	)
 
 	require.ErrorIs(t, err, ErrTopWriteInvalidated)
@@ -144,7 +151,7 @@ func TestPromoteRefreshFallbackToTopPreservesNegativeInvalidation(t *testing.T) 
 		"key",
 		tierDestination{tierIndex: 1, store: cache.tiers[1]},
 		meta,
-		0,
+		testTopWriteGeneration(t, cache, "key"),
 	)
 
 	require.ErrorIs(t, err, ErrTopWriteInvalidated)
@@ -165,7 +172,7 @@ func TestPromoteRefreshFallbackToTopSkipsMissingNegativeSource(t *testing.T) {
 		"key",
 		tierDestination{tierIndex: 1, store: cache.tiers[1]},
 		meta,
-		0,
+		testTopWriteGeneration(t, cache, "key"),
 	)
 
 	require.NoError(t, err)
@@ -186,7 +193,7 @@ func TestPromoteRefreshFallbackToTopSkipsMissingSourceStream(t *testing.T) {
 		"key",
 		tierDestination{tierIndex: 1, store: cache.tiers[1]},
 		meta,
-		0,
+		testTopWriteGeneration(t, cache, "key"),
 	)
 
 	require.NoError(t, err)

--- a/cache_refresh.go
+++ b/cache_refresh.go
@@ -12,7 +12,7 @@ func (c *DaramjweeCache) ScheduleRefresh(ctx context.Context, key string, fetche
 	return c.scheduleRefreshWithMetadata(ctx, key, fetcher, nil, nil, nil)
 }
 
-func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key string, fetcher Fetcher, fallbackMetadata *Metadata, fallbackSource *tierDestination, observedGeneration *uint64) error {
+func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key string, fetcher Fetcher, fallbackMetadata *Metadata, fallbackSource *tierDestination, observedGeneration *topWriteGeneration) error {
 	if c.isClosed.Load() {
 		return ErrCacheClosed
 	}
@@ -29,12 +29,15 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 		return errors.New("worker is not configured, cannot schedule refresh")
 	}
 
-	expectedGeneration := c.currentTopWriteGeneration(key)
+	var expectedGeneration *topWriteGeneration
 	if observedGeneration != nil {
-		expectedGeneration = *observedGeneration
+		expectedGeneration = observedGeneration.retain()
+	} else {
+		expectedGeneration = c.currentTopWriteGeneration(key)
 	}
 	valueCtx := detachedValueContext(ctx)
 	job := func(jobCtx context.Context) {
+		defer expectedGeneration.release()
 		refreshCtx := overlayContextValues(jobCtx, valueCtx)
 		c.infoLog("msg", "starting background refresh", "key", key)
 
@@ -50,7 +53,7 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 		if err != nil {
 			if errors.Is(err, ErrCacheableNotFound) {
 				c.debugLog("msg", "re-caching as negative entry during background refresh", "key", key)
-				c.handleNegativeCacheWithGeneration(refreshCtx, refreshCtx, key, nil, &expectedGeneration)
+				c.handleNegativeCacheWithGeneration(refreshCtx, refreshCtx, key, nil, expectedGeneration)
 			} else if errors.Is(err, ErrNotModified) {
 				c.debugLog("msg", "background refresh: object not modified", "key", key)
 				if fallbackSource != nil {
@@ -76,9 +79,10 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 		if result.Metadata == nil {
 			result.Metadata = &Metadata{}
 		}
+		result.Metadata = cloneMetadata(result.Metadata)
 		result.Metadata.CachedAt = time.Now()
 
-		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(refreshCtx, key, result.Metadata, &expectedGeneration)
+		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(refreshCtx, key, result.Metadata, expectedGeneration)
 		if err != nil {
 			closeErr := result.Body.Close()
 			if errors.Is(err, ErrTopWriteInvalidated) {
@@ -91,6 +95,7 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 			c.errorLog("msg", "failed to get cache writer for refresh", "key", key, "err", errors.Join(err, closeErr))
 			return
 		}
+		defer writer.Abort()
 
 		if publishErr := copyCloseSourceThenCommit(writer, result.Body); publishErr != nil {
 			if errors.Is(publishErr, ErrTopWriteInvalidated) {
@@ -104,31 +109,36 @@ func (c *DaramjweeCache) scheduleRefreshWithMetadata(ctx context.Context, key st
 		}
 	}
 
-	if !c.runtime.Submit(c.cacheID, JobKindRefresh, job) {
+	if !submitBackgroundJob(c.runtime, c.cacheID, JobKindRefresh, job, expectedGeneration.release) {
+		expectedGeneration.release()
 		return ErrBackgroundJobRejected
 	}
 	return nil
 }
 
-func (c *DaramjweeCache) refreshOnCloseCallback(requestCtx context.Context, key string, fetcher Fetcher, cancel context.CancelFunc, oldMetadata *Metadata, observedGeneration uint64) func() {
+func (c *DaramjweeCache) refreshOnCloseCallback(requestCtx context.Context, key string, fetcher Fetcher, cancel context.CancelFunc, oldMetadata *Metadata, observedGeneration *topWriteGeneration) func() {
+	ownedGeneration := observedGeneration.retain()
 	return func() {
 		defer cancel()
-		if err := c.scheduleRefreshWithMetadata(detachedValueContext(requestCtx), key, fetcher, cloneMetadata(oldMetadata), nil, &observedGeneration); err != nil {
+		defer ownedGeneration.release()
+		if err := c.scheduleRefreshWithMetadata(detachedValueContext(requestCtx), key, fetcher, cloneMetadata(oldMetadata), nil, ownedGeneration); err != nil {
 			c.warnLog("msg", "failed to schedule stale refresh", "key", key, "err", err)
 		}
 	}
 }
 
-func (c *DaramjweeCache) lowerTierRefreshOnCloseCallback(requestCtx context.Context, key string, fetcher Fetcher, cancel context.CancelFunc, oldMetadata *Metadata, source tierDestination, observedGeneration uint64) func() {
+func (c *DaramjweeCache) lowerTierRefreshOnCloseCallback(requestCtx context.Context, key string, fetcher Fetcher, cancel context.CancelFunc, oldMetadata *Metadata, source tierDestination, observedGeneration *topWriteGeneration) func() {
+	ownedGeneration := observedGeneration.retain()
 	return func() {
 		defer cancel()
-		if err := c.scheduleRefreshWithMetadata(detachedValueContext(requestCtx), key, fetcher, cloneMetadata(oldMetadata), &source, &observedGeneration); err != nil {
+		defer ownedGeneration.release()
+		if err := c.scheduleRefreshWithMetadata(detachedValueContext(requestCtx), key, fetcher, cloneMetadata(oldMetadata), &source, ownedGeneration); err != nil {
 			c.warnLog("msg", "failed to schedule stale refresh", "key", key, "source_tier", source.tierIndex, "err", err)
 		}
 	}
 }
 
-func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key string, source tierDestination, fallbackMetadata *Metadata, expectedGeneration uint64) error {
+func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key string, source tierDestination, fallbackMetadata *Metadata, expectedGeneration *topWriteGeneration) error {
 	target := c.topWriteStore()
 	if !hasRealStore(target) || !hasRealStore(source.store) || sameStoreInstance(source.store, target) {
 		return nil
@@ -156,10 +166,11 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 		if !sameCacheEntry(sourceMeta, fallbackMetadata) {
 			return nil
 		}
-		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, metaToPromote, &expectedGeneration)
+		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, metaToPromote, expectedGeneration)
 		if err != nil {
 			return err
 		}
+		defer writer.Abort()
 		if err := writer.Close(); err != nil {
 			return err
 		}
@@ -180,11 +191,12 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 		return srcStream.Close()
 	}
 
-	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, metaToPromote, &expectedGeneration)
+	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, metaToPromote, expectedGeneration)
 	if err != nil {
 		closeErr := srcStream.Close()
 		return errors.Join(err, closeErr)
 	}
+	defer writer.Abort()
 
 	if err := copyCloseSourceThenCommit(writer, srcStream); err != nil {
 		return err
@@ -195,9 +207,12 @@ func (c *DaramjweeCache) promoteRefreshFallbackToTop(ctx context.Context, key st
 	return nil
 }
 
-func (c *DaramjweeCache) refreshTopEntryCachedAt(ctx context.Context, key string, oldMetadata *Metadata, expectedGeneration uint64) error {
+func (c *DaramjweeCache) refreshTopEntryCachedAt(ctx context.Context, key string, oldMetadata *Metadata, expectedGeneration *topWriteGeneration) error {
 	target := c.topWriteStore()
 	if !hasRealStore(target) {
+		return nil
+	}
+	if _, ok := target.(StagingStore); !ok {
 		return nil
 	}
 
@@ -224,13 +239,14 @@ func (c *DaramjweeCache) refreshTopEntryCachedAt(ctx context.Context, key string
 	metaToRefresh.CachedAt = time.Now()
 
 	if metaToRefresh.IsNegative {
-		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, &metaToRefresh, &expectedGeneration)
+		writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, &metaToRefresh, expectedGeneration)
 		if err != nil {
 			if errors.Is(err, ErrTopWriteInvalidated) {
 				return nil
 			}
 			return err
 		}
+		defer writer.Abort()
 		return writer.Close()
 	}
 
@@ -238,30 +254,30 @@ func (c *DaramjweeCache) refreshTopEntryCachedAt(ctx context.Context, key string
 	if err != nil {
 		return err
 	}
-	content, err := io.ReadAll(srcStream)
-	closeErr := srcStream.Close()
+
+	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, &metaToRefresh, expectedGeneration)
 	if err != nil {
+		closeErr := srcStream.Close()
+		if errors.Is(err, ErrTopWriteInvalidated) {
+			return closeErr
+		}
 		return errors.Join(err, closeErr)
 	}
-	if closeErr != nil {
-		return closeErr
-	}
-
-	writer, err := c.setStreamToTopStoreBestEffortWithGeneration(ctx, key, &metaToRefresh, &expectedGeneration)
-	if err != nil {
-		if errors.Is(err, ErrTopWriteInvalidated) {
-			return nil
-		}
-		return err
-	}
-	if _, copyErr := writer.Write(content); copyErr != nil {
+	defer writer.Abort()
+	_, copyErr := io.Copy(writer, srcStream)
+	sourceCloseErr := srcStream.Close()
+	if copyErr != nil || sourceCloseErr != nil {
 		abortErr := writer.Abort()
-		return errors.Join(copyErr, abortErr)
+		return errors.Join(copyErr, sourceCloseErr, abortErr)
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		abortErr := writer.Abort()
+		return errors.Join(ctxErr, abortErr)
 	}
 	return writer.Close()
 }
 
-func (c *DaramjweeCache) handleNegativeCacheWithGeneration(requestCtx, setupCtx context.Context, key string, cancel context.CancelFunc, expectedGeneration *uint64) (*GetResponse, error) {
+func (c *DaramjweeCache) handleNegativeCacheWithGeneration(requestCtx, setupCtx context.Context, key string, cancel context.CancelFunc, expectedGeneration *topWriteGeneration) (*GetResponse, error) {
 	_, negativeFreshFor := c.tierFreshness(0)
 	c.debugLog("msg", "caching as negative entry", "key", key, "negative_fresh_for", negativeFreshFor)
 
@@ -280,6 +296,7 @@ func (c *DaramjweeCache) handleNegativeCacheWithGeneration(requestCtx, setupCtx 
 		}
 		c.warnLog("msg", "failed to get writer for negative cache entry", "key", key, "err", err)
 	} else {
+		defer writer.Abort()
 		if closeErr := writer.Close(); closeErr != nil {
 			if errors.Is(closeErr, ErrTopWriteInvalidated) {
 				c.infoLog("msg", "skipping negative cache publish because top-tier state changed", "key", key)

--- a/cache_refresh_test.go
+++ b/cache_refresh_test.go
@@ -1,0 +1,284 @@
+package daramjwee
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshTopEntryCachedAtStreamsBeforeSourceEOF(t *testing.T) {
+	oldCachedAt := time.Now().Add(-time.Hour)
+	source := newGatedRefreshSource([]byte("first-"), []byte("second"))
+	store := &streamingRefreshStore{
+		body:       []byte("old"),
+		meta:       &Metadata{CacheTag: "v1", CachedAt: oldCachedAt},
+		source:     source,
+		firstWrite: make(chan struct{}),
+	}
+	cache := &DaramjweeCache{
+		tiers:  []Store{store},
+		config: cacheConfig{positiveFreshness: time.Minute},
+	}
+
+	// A failing assertion must not leave the source reader blocked.
+	t.Cleanup(source.releaseEOF)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cache.refreshTopEntryCachedAt(context.Background(), "key", cloneMetadata(store.meta), nil)
+	}()
+
+	select {
+	case <-store.firstWrite:
+		// The first staged write proves the source was copied incrementally.
+	case <-time.After(time.Second):
+		t.Fatal("staged sink did not receive the first chunk before source EOF was released")
+	}
+
+	source.releaseEOF()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("stale metadata refresh did not finish")
+	}
+
+	body, meta := store.committed()
+	require.Equal(t, []byte("first-second"), body)
+	require.Equal(t, "v1", meta.CacheTag)
+	require.False(t, meta.IsNegative)
+	require.True(t, meta.CachedAt.After(oldCachedAt))
+	require.True(t, source.closed.Load(), "source must close before staged commit")
+	require.True(t, store.sourceClosedBeforeCommit.Load(), "staged commit ran before source close")
+}
+
+func TestRefreshTopEntryCachedAtSkipsNonStagingStore(t *testing.T) {
+	cachedAt := time.Date(2020, time.January, 2, 3, 4, 5, 6, time.UTC)
+	for _, tt := range []struct {
+		name     string
+		metadata *Metadata
+	}{
+		{
+			name:     "stale positive",
+			metadata: &Metadata{CacheTag: "v1", CachedAt: cachedAt},
+		},
+		{
+			name:     "stale negative",
+			metadata: &Metadata{CacheTag: "v1", IsNegative: true, CachedAt: cachedAt},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &nonStagingRefreshSpy{metadata: cloneMetadata(tt.metadata)}
+			cache := &DaramjweeCache{
+				tiers:  []Store{store},
+				config: cacheConfig{positiveFreshness: time.Minute},
+			}
+
+			require.NoError(t, cache.refreshTopEntryCachedAt(context.Background(), "key", cloneMetadata(tt.metadata), nil))
+			require.Zero(t, store.statCalls)
+			require.Zero(t, store.getStreamCalls)
+			require.Zero(t, store.beginSetCalls)
+			require.Zero(t, store.bodyCalls)
+			require.Equal(t, tt.metadata, store.metadata)
+		})
+	}
+}
+
+func TestRefreshTopEntryCachedAtStagingStoreCancelsBeforeCommit(t *testing.T) {
+	oldCachedAt := time.Now().Add(-time.Hour)
+	source := newGatedRefreshSource([]byte("first-"), []byte("second"))
+	store := &streamingRefreshStore{
+		body:       []byte("old"),
+		meta:       &Metadata{CacheTag: "v1", CachedAt: oldCachedAt},
+		source:     source,
+		firstWrite: make(chan struct{}),
+	}
+	cache := &DaramjweeCache{
+		tiers:  []Store{store},
+		config: cacheConfig{positiveFreshness: time.Minute},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(source.releaseEOF)
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cache.refreshTopEntryCachedAt(ctx, "key", cloneMetadata(store.meta), nil)
+	}()
+
+	select {
+	case <-store.firstWrite:
+	case <-time.After(time.Second):
+		t.Fatal("staged sink did not receive the first chunk")
+	}
+	cancel()
+	source.releaseEOF()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("canceled stale metadata refresh did not finish")
+	}
+
+	body, meta := store.committed()
+	require.Equal(t, []byte("old"), body)
+	require.Equal(t, oldCachedAt, meta.CachedAt)
+	require.False(t, store.published.Load(), "canceled staged refresh must not commit")
+	require.Positive(t, store.abortCalls.Load(), "canceled staged refresh must abort")
+}
+
+type gatedRefreshSource struct {
+	first, second []byte
+	stage         int
+	release       chan struct{}
+	releaseOnce   sync.Once
+	closed        atomic.Bool
+}
+
+func newGatedRefreshSource(first, second []byte) *gatedRefreshSource {
+	return &gatedRefreshSource{first: first, second: second, release: make(chan struct{})}
+}
+
+func (r *gatedRefreshSource) Read(p []byte) (int, error) {
+	switch r.stage {
+	case 0:
+		r.stage++
+		return copy(p, r.first), nil
+	case 1:
+		<-r.release
+		r.stage++
+		return copy(p, r.second), nil
+	default:
+		return 0, io.EOF
+	}
+}
+
+func (r *gatedRefreshSource) Close() error {
+	r.closed.Store(true)
+	return nil
+}
+
+func (r *gatedRefreshSource) releaseEOF() {
+	r.releaseOnce.Do(func() { close(r.release) })
+}
+
+type streamingRefreshStore struct {
+	mu                       sync.Mutex
+	body                     []byte
+	meta                     *Metadata
+	source                   *gatedRefreshSource
+	firstWrite               chan struct{}
+	firstWriteOnce           sync.Once
+	sourceClosedBeforeCommit atomic.Bool
+	published                atomic.Bool
+	abortCalls               atomic.Int32
+}
+
+func (s *streamingRefreshStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	return s.source, cloneMetadata(s.meta), nil
+}
+
+func (s *streamingRefreshStore) BeginSet(context.Context, string, *Metadata) (WriteSink, error) {
+	return nil, io.ErrClosedPipe
+}
+
+func (s *streamingRefreshStore) BeginStagedSet(_ context.Context, _ string, meta *Metadata) (StagedWriteSink, error) {
+	return &streamingRefreshSink{store: s, meta: cloneMetadata(meta)}, nil
+}
+
+func (*streamingRefreshStore) Delete(context.Context, string) error { return nil }
+
+func (s *streamingRefreshStore) Stat(context.Context, string) (*Metadata, error) {
+	return cloneMetadata(s.meta), nil
+}
+
+func (s *streamingRefreshStore) committed() ([]byte, *Metadata) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.body...), cloneMetadata(s.meta)
+}
+
+type streamingRefreshSink struct {
+	store *streamingRefreshStore
+	meta  *Metadata
+	body  []byte
+}
+
+func (s *streamingRefreshSink) Write(p []byte) (int, error) {
+	s.body = append(s.body, p...)
+	s.store.firstWriteOnce.Do(func() { close(s.store.firstWrite) })
+	return len(p), nil
+}
+
+func (s *streamingRefreshSink) Commit(context.Context) error {
+	s.store.sourceClosedBeforeCommit.Store(s.store.source.closed.Load())
+	s.store.mu.Lock()
+	defer s.store.mu.Unlock()
+	s.store.body = append([]byte(nil), s.body...)
+	s.store.meta = cloneMetadata(s.meta)
+	s.store.published.Store(true)
+	return nil
+}
+
+func (s *streamingRefreshSink) Abort() error {
+	s.store.abortCalls.Add(1)
+	return nil
+}
+
+type nonStagingRefreshSpy struct {
+	metadata                                 *Metadata
+	statCalls, getStreamCalls, beginSetCalls int
+	bodyCalls                                int
+}
+
+func (s *nonStagingRefreshSpy) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	s.getStreamCalls++
+	return &nonStagingRefreshBody{spy: s}, cloneMetadata(s.metadata), nil
+}
+
+func (s *nonStagingRefreshSpy) BeginSet(context.Context, string, *Metadata) (WriteSink, error) {
+	s.beginSetCalls++
+	return &nonStagingRefreshSink{spy: s}, nil
+}
+
+func (*nonStagingRefreshSpy) Delete(context.Context, string) error { return nil }
+
+func (s *nonStagingRefreshSpy) Stat(context.Context, string) (*Metadata, error) {
+	s.statCalls++
+	return cloneMetadata(s.metadata), nil
+}
+
+type nonStagingRefreshBody struct{ spy *nonStagingRefreshSpy }
+
+func (b *nonStagingRefreshBody) Read([]byte) (int, error) {
+	b.spy.bodyCalls++
+	return 0, io.EOF
+}
+
+func (b *nonStagingRefreshBody) Close() error {
+	b.spy.bodyCalls++
+	return nil
+}
+
+type nonStagingRefreshSink struct{ spy *nonStagingRefreshSpy }
+
+func (s *nonStagingRefreshSink) Write(p []byte) (int, error) {
+	s.spy.bodyCalls++
+	return len(p), nil
+}
+
+func (s *nonStagingRefreshSink) Close() error {
+	s.spy.bodyCalls++
+	return nil
+}
+
+func (s *nonStagingRefreshSink) Abort() error {
+	s.spy.bodyCalls++
+	return nil
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,9 +1,17 @@
 package daramjwee
 
 import (
+	"bytes"
+	"context"
 	"io"
 	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/mrchypark/daramjwee/internal/worker"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSafeCloserReadAll(t *testing.T) {
@@ -185,3 +193,183 @@ func TestReadAllSmart(t *testing.T) {
 		})
 	}
 }
+
+func TestSetKeepsCallerMetadataUnchangedWhileStoringFreshCachedAt(t *testing.T) {
+	store := newMetadataOwnershipStore()
+	cache := newMetadataOwnershipCache(store)
+	sentinel := time.Unix(1, 0).UTC()
+	metadata := &Metadata{CacheTag: "set-v1", CachedAt: sentinel}
+	want := *metadata
+
+	sink, err := cache.Set(context.Background(), "set-key", metadata)
+	require.NoError(t, err)
+	require.NoError(t, sink.Close())
+
+	require.Equal(t, want, *metadata)
+	require.True(t, store.metadata("set-key").CachedAt.After(sentinel))
+}
+
+func TestMissKeepsFetcherMetadataUnchangedWhileReturningAndStoringFreshCachedAt(t *testing.T) {
+	store := newMetadataOwnershipStore()
+	cache := newMetadataOwnershipCache(store)
+	sentinel := time.Unix(1, 0).UTC()
+	metadata := &Metadata{CacheTag: "miss-v1", CachedAt: sentinel}
+	want := *metadata
+
+	resp, err := cache.Get(context.Background(), "miss-key", GetRequest{}, metadataOwnershipFetcher{metadata: metadata})
+	require.NoError(t, err)
+	_, err = io.ReadAll(resp)
+	require.NoError(t, err)
+
+	require.Equal(t, want, *metadata)
+	require.True(t, resp.Metadata.CachedAt.After(sentinel))
+	storedMetadata := store.metadata("miss-key")
+	require.NotNil(t, storedMetadata)
+	require.Equal(t, resp.Metadata, *storedMetadata)
+}
+
+func TestRefreshKeepsFetcherMetadataUnchangedWhileStoringFreshCachedAt(t *testing.T) {
+	store := newMetadataOwnershipStore()
+	manager, err := worker.NewManager("pool", log.NewNopLogger(), 1, 1, time.Second)
+	require.NoError(t, err)
+	cache := &DaramjweeCache{
+		tiers:   []Store{store},
+		logger:  log.NewNopLogger(),
+		runtime: newStandaloneRuntime(manager),
+		cacheID: "metadata-ownership-refresh",
+		config:  cacheConfig{opTimeout: time.Second, closeTimeout: time.Second},
+	}
+	t.Cleanup(cache.Close)
+
+	sentinel := time.Unix(1, 0).UTC()
+	metadata := &Metadata{CacheTag: "refresh-v1", CachedAt: sentinel}
+	want := *metadata
+
+	require.NoError(t, cache.ScheduleRefresh(context.Background(), "refresh-key", metadataOwnershipFetcher{metadata: metadata}))
+	select {
+	case <-store.closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background refresh did not publish")
+	}
+
+	require.Equal(t, want, *metadata)
+	require.True(t, store.metadata("refresh-key").CachedAt.After(sentinel))
+}
+
+func TestPublicSetAndMissDoNotRaceOnSharedMetadata(t *testing.T) {
+	store := newMetadataOwnershipStore()
+	cache := newMetadataOwnershipCache(store)
+	metadata := &Metadata{CacheTag: "shared", CachedAt: time.Unix(1, 0).UTC()}
+	start := make(chan struct{})
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 100; i++ {
+			sink, err := cache.Set(context.Background(), "set-race-key", metadata)
+			if err == nil {
+				err = sink.Abort()
+			}
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 100; i++ {
+			resp, err := cache.Get(context.Background(), "miss-race-key", GetRequest{}, metadataOwnershipFetcher{metadata: metadata})
+			if err == nil {
+				_, err = io.ReadAll(resp)
+			}
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+	close(start)
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+func newMetadataOwnershipCache(store Store) *DaramjweeCache {
+	return &DaramjweeCache{
+		tiers:  []Store{store},
+		logger: log.NewNopLogger(),
+		config: cacheConfig{opTimeout: time.Second, closeTimeout: time.Second},
+	}
+}
+
+type metadataOwnershipFetcher struct {
+	metadata *Metadata
+}
+
+func (f metadataOwnershipFetcher) Fetch(context.Context, *Metadata) (*FetchResult, error) {
+	return &FetchResult{
+		Body:     io.NopCloser(strings.NewReader("value")),
+		Metadata: f.metadata,
+	}, nil
+}
+
+type metadataOwnershipStore struct {
+	mu      sync.Mutex
+	entries map[string]*Metadata
+	closed  chan struct{}
+}
+
+func newMetadataOwnershipStore() *metadataOwnershipStore {
+	return &metadataOwnershipStore{entries: make(map[string]*Metadata), closed: make(chan struct{}, 10)}
+}
+
+func (s *metadataOwnershipStore) GetStream(context.Context, string) (io.ReadCloser, *Metadata, error) {
+	return nil, nil, ErrNotFound
+}
+
+func (s *metadataOwnershipStore) BeginSet(_ context.Context, key string, metadata *Metadata) (WriteSink, error) {
+	return &metadataOwnershipSink{store: s, key: key, metadata: cloneMetadata(metadata)}, nil
+}
+
+func (*metadataOwnershipStore) Delete(context.Context, string) error { return nil }
+
+func (*metadataOwnershipStore) Stat(context.Context, string) (*Metadata, error) {
+	return nil, ErrNotFound
+}
+
+func (s *metadataOwnershipStore) metadata(key string) *Metadata {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneMetadata(s.entries[key])
+}
+
+type metadataOwnershipSink struct {
+	bytes.Buffer
+	store    *metadataOwnershipStore
+	key      string
+	metadata *Metadata
+	close    sync.Once
+}
+
+func (s *metadataOwnershipSink) Close() error {
+	s.close.Do(func() {
+		s.store.mu.Lock()
+		s.store.entries[s.key] = cloneMetadata(s.metadata)
+		s.store.mu.Unlock()
+		select {
+		case s.store.closed <- struct{}{}:
+		default:
+		}
+	})
+	return nil
+}
+
+func (*metadataOwnershipSink) Abort() error { return nil }

--- a/pkg/policy/s3fifo.go
+++ b/pkg/policy/s3fifo.go
@@ -143,6 +143,9 @@ func (p *S3FIFO) Evict() []string {
 			elem = prevElem
 		}
 		// If the loop finishes, all items in the main queue were given a second chance.
+		// They have now had their hit flags reset, so evict the oldest entry.
+		victim := p.removeElement(p.mainQueue.Back())
+		return []string{victim.key}
 	}
 
 	// 3. If the main queue is empty, or if the small queue still exceeds capacity

--- a/pkg/policy/s3fifo_test.go
+++ b/pkg/policy/s3fifo_test.go
@@ -143,6 +143,28 @@ func TestS3FIFO_EvictFromMainWithSecondChance(t *testing.T) {
 	}
 }
 
+func TestS3FIFO_EvictSingleMainEntryAfterSecondChance(t *testing.T) {
+	p := NewS3FIFO(100, 20).(*S3FIFO)
+
+	p.Add("key1", 10)
+	p.Touch("key1") // Promote to the main queue.
+	p.Touch("key1") // Give the main-queue entry its second chance.
+
+	evicted := p.Evict()
+	if len(evicted) != 1 || evicted[0] != "key1" {
+		t.Fatalf("Evict should return live key1, got %v", evicted)
+	}
+	if isInCache(p, "key1") {
+		t.Error("key1 should not be in cache after eviction")
+	}
+	if p.smallQueue.Len() != 0 || p.mainQueue.Len() != 0 || len(p.cache) != 0 {
+		t.Errorf("expected empty queues and cache, got small:%d main:%d cache:%d", p.smallQueue.Len(), p.mainQueue.Len(), len(p.cache))
+	}
+	if p.smallSize != 0 || p.mainSize != 0 {
+		t.Errorf("expected zero sizes, got small:%d main:%d", p.smallSize, p.mainSize)
+	}
+}
+
 // TestS3FIFO_Remove tests explicit removal of items.
 func TestS3FIFO_Remove(t *testing.T) {
 	p := NewS3FIFO(100, 50).(*S3FIFO)

--- a/pkg/policy/sieve.go
+++ b/pkg/policy/sieve.go
@@ -123,12 +123,16 @@ func (p *Sieve) Evict() []string {
 func (p *Sieve) removeElement(e *list.Element) *sieveEntry {
 	// If the element to be removed is the one pointed to by hand, move hand to the previous element.
 	if e == p.hand {
-		prev := e.Prev()
-		if prev == nil {
-			// If the removed element was the first and hand pointed to it, wrap hand to the end.
-			p.hand = p.ll.Back()
+		if p.ll.Len() == 1 {
+			p.hand = nil
 		} else {
-			p.hand = prev
+			prev := e.Prev()
+			if prev == nil {
+				// If the removed element was the first and hand pointed to it, wrap hand to the end.
+				p.hand = p.ll.Back()
+			} else {
+				p.hand = prev
+			}
 		}
 	}
 

--- a/pkg/policy/sieve_test.go
+++ b/pkg/policy/sieve_test.go
@@ -148,6 +148,22 @@ func TestSieve_EvictSingleItem(t *testing.T) {
 	assert.Equal(t, 0, p.(*Sieve).ll.Len(), "Cache should be empty after eviction.")
 }
 
+func TestSieve_EvictAfterSoleEntryEvicted(t *testing.T) {
+	p := NewSieve().(*Sieve)
+	p.Add("A", 1)
+
+	assert.Equal(t, []string{"A"}, p.Evict())
+	assert.Zero(t, p.ll.Len())
+	assert.Empty(t, p.cache)
+	assert.Nil(t, p.hand, "the hand must not retain a detached element")
+
+	p.Add("B", 1)
+	assert.Equal(t, []string{"B"}, p.Evict(), "the next eviction must select the live entry")
+	assert.Zero(t, p.ll.Len())
+	assert.Empty(t, p.cache)
+	assert.Nil(t, p.hand)
+}
+
 // TestSieve_RemoveHandledElement verifies that the hand pointer is safely adjusted
 // when the item it points to is removed.
 func TestSieve_RemoveHandledElement(t *testing.T) {

--- a/pkg/store/adapter/objstore.go
+++ b/pkg/store/adapter/objstore.go
@@ -59,6 +59,10 @@ func (a *objstoreAdapter) BeginSet(ctx context.Context, key string, metadata *da
 	return a.modern.BeginSet(ctx, key, metadata)
 }
 
+func (a *objstoreAdapter) BeginStagedSet(ctx context.Context, key string, metadata *daramjwee.Metadata) (daramjwee.StagedWriteSink, error) {
+	return a.modern.BeginStagedSet(ctx, key, metadata)
+}
+
 func (a *objstoreAdapter) Delete(ctx context.Context, key string) error {
 	legacyExists, err := a.hasLegacyMetadataObject(ctx, key)
 	if err != nil {

--- a/pkg/store/adapter/objstore_test.go
+++ b/pkg/store/adapter/objstore_test.go
@@ -66,6 +66,31 @@ func TestObjstoreAdapter_PrefersModernEntriesOverLegacyFallback(t *testing.T) {
 	assert.Equal(t, "modern", meta.CacheTag)
 }
 
+func TestObjstoreAdapter_StagedWriteCommitsOnlyOnCommit(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	store := NewObjstoreAdapter(bucket, log.NewNopLogger(), objectstore.WithDir(t.TempDir()))
+	staging, ok := store.(daramjwee.StagingStore)
+	require.True(t, ok)
+
+	writer, err := staging.BeginStagedSet(ctx, "staged-key", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, "staged body")
+	require.NoError(t, err)
+
+	_, err = store.Stat(ctx, "staged-key")
+	require.ErrorIs(t, err, daramjwee.ErrNotFound)
+
+	require.NoError(t, writer.Commit(ctx))
+	reader, meta, err := store.GetStream(ctx, "staged-key")
+	require.NoError(t, err)
+	defer reader.Close()
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "staged body", string(body))
+	assert.Equal(t, "v1", meta.CacheTag)
+}
+
 func TestObjstoreAdapter_DeleteRemovesLegacyObjects(t *testing.T) {
 	ctx := context.Background()
 	bucket := objstore.NewInMemBucket()

--- a/pkg/store/filestore/storage.go
+++ b/pkg/store/filestore/storage.go
@@ -158,7 +158,7 @@ func New(dir string, logger log.Logger, opts ...Option) (*FileStore, error) {
 
 	// Initialize current size by scanning existing files
 	if err := fs.initializeCurrentSize(); err != nil {
-		level.Warn(logger).Log("msg", "failed to initialize current size", "err", err)
+		return nil, fmt.Errorf("filestore: initialize current size: %w", err)
 	}
 
 	return fs, nil
@@ -775,7 +775,16 @@ func (s *stagedFileWriteSink) abort() error {
 // and populate the fileSizes map for existing files.
 // It uses filepath.WalkDir for better performance than filepath.Walk.
 func (fs *FileStore) initializeCurrentSize() error {
-	return filepath.WalkDir(fs.baseDir, func(path string, d os.DirEntry, err error) error {
+	type policyOperation struct {
+		key    string
+		size   int64
+		remove bool
+	}
+
+	fileSizes := make(map[string]int64)
+	var currentSize int64
+	var policyOperations []policyOperation
+	if err := filepath.WalkDir(fs.baseDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -807,16 +816,29 @@ func (fs *FileStore) initializeCurrentSize() error {
 		}
 		size := info.Size()
 
-		if oldSize, exists := fs.fileSizes[key]; exists {
-			fs.currentSize -= oldSize
-			fs.policy.Remove(key)
+		if oldSize, exists := fileSizes[key]; exists {
+			currentSize -= oldSize
+			policyOperations = append(policyOperations, policyOperation{key: key, remove: true})
 		}
-		fs.fileSizes[key] = size
-		fs.currentSize += size
-		fs.policy.Add(key, size)
+		fileSizes[key] = size
+		currentSize += size
+		policyOperations = append(policyOperations, policyOperation{key: key, size: size})
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	fs.fileSizes = fileSizes
+	fs.currentSize = currentSize
+	for _, operation := range policyOperations {
+		if operation.remove {
+			fs.policy.Remove(operation.key)
+			continue
+		}
+		fs.policy.Add(operation.key, operation.size)
+	}
+	return nil
 }
 
 func (fs *FileStore) nextGeneration() uint64 {

--- a/pkg/store/filestore/storage_test.go
+++ b/pkg/store/filestore/storage_test.go
@@ -3,6 +3,7 @@ package filestore
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -1199,6 +1200,87 @@ func TestFileStore_ReopenPreservesLegacyB64PrefixedKeyTracking(t *testing.T) {
 	require.NoError(t, fs.Delete(ctx, key))
 	_, statErr := os.Stat(legacyPath)
 	assert.True(t, os.IsNotExist(statErr), "reopened store should still track and delete legacy b64-prefixed files")
+}
+
+func TestFileStore_NewFailsWhenAmbiguousLegacyFileHasShortMetadata(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "b64_broken")
+
+	// Root-level b64_ files are ambiguous legacy paths, so initialization reads
+	// their metadata to determine the stored key. Declare more metadata bytes
+	// than are present to make that scan fail deterministically.
+	require.NoError(t, os.WriteFile(legacyPath, []byte{0, 0, 0, 2, '{'}, 0644))
+
+	fs, err := New(dir, log.NewNopLogger())
+	require.Nil(t, fs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "initialize current size")
+	require.True(t, errors.Is(err, io.ErrUnexpectedEOF))
+}
+
+func TestFileStore_NewFailureDoesNotMutateEvictionPolicy(t *testing.T) {
+	dir := t.TempDir()
+	policy := newRecordingEvictionPolicy()
+
+	validPath := filepath.Join(dir, "a_valid")
+	validFile, err := os.Create(validPath)
+	require.NoError(t, err)
+	require.NoError(t, writeMetadata(validFile, &daramjwee.Metadata{CacheTag: "valid"}))
+	_, err = validFile.Write([]byte("valid-data"))
+	require.NoError(t, err)
+	require.NoError(t, validFile.Close())
+
+	// filepath.Walk visits a_valid before b64_broken, so the old scan mutates
+	// the policy before the malformed ambiguous legacy entry returns an error.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b64_broken"), []byte{0, 0, 0, 2, '{'}, 0644))
+
+	fs, err := New(dir, log.NewNopLogger(), WithEviction(policy))
+	require.Nil(t, fs)
+	require.True(t, errors.Is(err, io.ErrUnexpectedEOF))
+	assert.Empty(t, policy.entries)
+	assert.Empty(t, policy.order)
+
+	clean, err := New(t.TempDir(), log.NewNopLogger(), WithEviction(policy), WithCapacity(1))
+	require.NoError(t, err)
+	writer, err := clean.BeginSet(context.Background(), "fresh", nil)
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("too large"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	assert.Equal(t, []string{"fresh"}, policy.evictions)
+}
+
+type recordingEvictionPolicy struct {
+	entries   map[string]int64
+	order     []string
+	evictions []string
+}
+
+func newRecordingEvictionPolicy() *recordingEvictionPolicy {
+	return &recordingEvictionPolicy{entries: make(map[string]int64)}
+}
+
+func (p *recordingEvictionPolicy) Touch(string) {}
+
+func (p *recordingEvictionPolicy) Add(key string, size int64) {
+	if _, exists := p.entries[key]; !exists {
+		p.order = append(p.order, key)
+	}
+	p.entries[key] = size
+}
+
+func (p *recordingEvictionPolicy) Remove(key string) {
+	delete(p.entries, key)
+}
+
+func (p *recordingEvictionPolicy) Evict() []string {
+	for _, key := range p.order {
+		if _, exists := p.entries[key]; exists {
+			p.evictions = append(p.evictions, key)
+			return []string{key}
+		}
+	}
+	return nil
 }
 
 func TestFileStore_InitializeCurrentSizeDoesNotDoubleCountDuplicateLogicalKeys(t *testing.T) {

--- a/pkg/store/objectstore/catalog.go
+++ b/pkg/store/objectstore/catalog.go
@@ -220,8 +220,34 @@ func removeLocalSegment(path string) error {
 	return nil
 }
 
+func sweepLocalSegmentFiles(root string, keep func(string) bool) error {
+	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".seg" {
+			return nil
+		}
+		if keep != nil && keep(path) {
+			return nil
+		}
+		return removeLocalSegment(path)
+	})
+}
+
 func (s *Store) sweepOrphanedLocalSegments() error {
-	if s.catalog == nil || s.dataDir == "" {
+	if s.dataDir == "" {
+		return nil
+	}
+
+	activeRoot := filepath.Join(s.dataDir, "ingest", "active")
+	if err := sweepLocalSegmentFiles(activeRoot, nil); err != nil {
+		return err
+	}
+	if s.catalog == nil {
 		return nil
 	}
 
@@ -233,22 +259,10 @@ func (s *Store) sweepOrphanedLocalSegments() error {
 	}
 
 	sealedRoot := filepath.Join(s.dataDir, "ingest", "sealed")
-	return filepath.WalkDir(sealedRoot, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-		if d.IsDir() || filepath.Ext(path) != ".seg" {
-			return nil
-		}
+	return sweepLocalSegmentFiles(sealedRoot, func(path string) bool {
 		if _, ok := referenced[path]; ok {
-			return nil
+			return true
 		}
-		if err := removeLocalSegment(path); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		return nil
+		return false
 	})
 }

--- a/pkg/store/objectstore/compaction_test.go
+++ b/pkg/store/objectstore/compaction_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +14,123 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 )
+
+func TestStore_CompactWaitsForFlushCheckpointPublication(t *testing.T) {
+	store, bucket, baseBucket, flushDone := startCheckpointBlockedFlush(t, "compact-during-flush")
+	require.Len(t, listObjectNames(t, baseBucket, joinPath(store.prefix, "segments")), 1)
+
+	waitObserved := make(chan struct{})
+	compactCtx := &waitObservedContext{Context: context.Background(), observed: waitObserved}
+	type compactResult struct {
+		stats SweepStats
+		err   error
+	}
+	compactDone := make(chan compactResult, 1)
+	go func() {
+		stats, err := store.Compact(compactCtx, 0)
+		compactDone <- compactResult{stats: stats, err: err}
+	}()
+
+	select {
+	case <-waitObserved:
+	case <-bucket.compactRemoteStarted:
+		bucket.releaseCompactRemote()
+		result := <-compactDone
+		bucket.releaseCheckpoint()
+		require.NoError(t, <-flushDone)
+		require.NoError(t, result.err)
+		t.Fatal("compaction reached and completed remote traversal before checkpoint publication")
+	case <-time.After(5 * time.Second):
+		t.Fatal("compaction reached neither the publication gate nor remote traversal")
+	}
+
+	select {
+	case result := <-compactDone:
+		t.Fatalf("compaction completed before checkpoint publication: %v", result.err)
+	default:
+	}
+	select {
+	case <-bucket.compactRemoteStarted:
+		t.Fatal("compaction reached remote traversal before checkpoint publication")
+	default:
+	}
+
+	bucket.releaseCheckpoint()
+	require.NoError(t, <-flushDone)
+	select {
+	case <-bucket.compactRemoteStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("compaction did not reach remote traversal after checkpoint publication")
+	}
+	bucket.releaseCompactRemote()
+
+	var result compactResult
+	select {
+	case result = <-compactDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("compaction did not finish after checkpoint publication")
+	}
+	require.NoError(t, result.err)
+
+	remoteOnly := New(baseBucket, log.NewNopLogger(), WithDir(t.TempDir()))
+	stream, meta, err := remoteOnly.GetStream(context.Background(), "compact-during-flush")
+	require.NoError(t, err)
+	defer stream.Close()
+	body, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	assert.Equal(t, "flush body", string(body))
+	assert.Equal(t, "v1", meta.CacheTag)
+}
+
+func TestStore_RemotePublicationWaitHonorsContext(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *Store) error
+		want error
+	}{
+		{
+			name: "compact deadline",
+			run: func(ctx context.Context, store *Store) error {
+				_, err := store.Compact(ctx, 0)
+				return err
+			},
+			want: context.DeadlineExceeded,
+		},
+		{name: "flush cancellation", run: func(ctx context.Context, store *Store) error {
+			return store.flushPending(ctx)
+		}, want: context.Canceled},
+		{name: "delete cancellation", run: func(ctx context.Context, store *Store) error {
+			return store.Delete(ctx, "context-wait")
+		}, want: context.Canceled},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, bucket, _, flushDone := startCheckpointBlockedFlush(t, "context-wait")
+			var ctx context.Context
+			var cancel context.CancelFunc
+			if tc.want == context.DeadlineExceeded {
+				ctx, cancel = context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+			} else {
+				ctx, cancel = context.WithCancel(context.Background())
+				cancel()
+			}
+			defer cancel()
+
+			done := make(chan error, 1)
+			go func() { done <- tc.run(ctx, store) }()
+			select {
+			case err := <-done:
+				require.ErrorIs(t, err, tc.want)
+			case <-time.After(5 * time.Second):
+				t.Fatalf("operation did not honor context while publication was blocked")
+			}
+
+			bucket.releaseCheckpoint()
+			require.NoError(t, <-flushDone)
+		})
+	}
+}
 
 func TestStore_CompactReclaimsSupersededRemoteObjects(t *testing.T) {
 	ctx := context.Background()
@@ -142,4 +260,103 @@ func TestStore_ReclaimAutomaticallySchedulesFlushForPublishedUnflushedLocalEntri
 	pending := len(reopened.pendingShards)
 	reopened.flushMu.Unlock()
 	assert.Zero(t, pending)
+}
+
+type blockingCheckpointUploadBucket struct {
+	objstore.Bucket
+	checkpointUploadStarted chan struct{}
+	checkpointUploadRelease chan struct{}
+	compactRemoteStarted    chan struct{}
+	compactRemoteRelease    chan struct{}
+	checkpointOnce          sync.Once
+	checkpointReleaseOnce   sync.Once
+	compactRemoteOnce       sync.Once
+	compactReleaseOnce      sync.Once
+}
+
+func (b *blockingCheckpointUploadBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
+	block := false
+	if strings.HasSuffix(name, "/latest.json") {
+		b.checkpointOnce.Do(func() {
+			block = true
+			close(b.checkpointUploadStarted)
+		})
+	}
+	if block {
+		select {
+		case <-b.checkpointUploadRelease:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return b.Bucket.Upload(ctx, name, r, opts...)
+}
+
+func (b *blockingCheckpointUploadBucket) Iter(ctx context.Context, dir string, f func(name string) error, opts ...objstore.IterOption) error {
+	block := false
+	b.compactRemoteOnce.Do(func() {
+		block = true
+		close(b.compactRemoteStarted)
+	})
+	if block {
+		select {
+		case <-b.compactRemoteRelease:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return b.Bucket.Iter(ctx, dir, f, opts...)
+}
+
+func (b *blockingCheckpointUploadBucket) releaseCheckpoint() {
+	b.checkpointReleaseOnce.Do(func() { close(b.checkpointUploadRelease) })
+}
+
+func (b *blockingCheckpointUploadBucket) releaseCompactRemote() {
+	b.compactReleaseOnce.Do(func() { close(b.compactRemoteRelease) })
+}
+
+func startCheckpointBlockedFlush(t *testing.T, key string) (*Store, *blockingCheckpointUploadBucket, objstore.Bucket, <-chan error) {
+	t.Helper()
+	ctx := context.Background()
+	baseBucket := objstore.NewInMemBucket()
+	bucket := &blockingCheckpointUploadBucket{
+		Bucket:                  baseBucket,
+		checkpointUploadStarted: make(chan struct{}),
+		checkpointUploadRelease: make(chan struct{}),
+		compactRemoteStarted:    make(chan struct{}),
+		compactRemoteRelease:    make(chan struct{}),
+	}
+	t.Cleanup(func() {
+		bucket.releaseCheckpoint()
+		bucket.releaseCompactRemote()
+	})
+	store := New(bucket, log.NewNopLogger(), WithDir(t.TempDir()))
+	store.autoFlush = false
+
+	writer, err := store.BeginSet(ctx, key, &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, "flush body")
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	flushDone := make(chan error, 1)
+	go func() { flushDone <- store.flushPending(ctx) }()
+	select {
+	case <-bucket.checkpointUploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("flush did not reach checkpoint publication")
+	}
+	return store, bucket, baseBucket, flushDone
+}
+
+type waitObservedContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *waitObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
 }

--- a/pkg/store/objectstore/compactor.go
+++ b/pkg/store/objectstore/compactor.go
@@ -13,6 +13,10 @@ import (
 
 func (s *Store) Compact(ctx context.Context, olderThan time.Duration) (SweepStats, error) {
 	var stats SweepStats
+	if err := s.remoteState.acquire(ctx); err != nil {
+		return stats, err
+	}
+	defer s.remoteState.release()
 
 	reachable, err := s.collectReachableRemotePaths(ctx, &stats)
 	if err != nil {

--- a/pkg/store/objectstore/flush_test.go
+++ b/pkg/store/objectstore/flush_test.go
@@ -104,8 +104,12 @@ func TestStore_FlushPacksMultipleKeysIntoSingleRemoteSegment(t *testing.T) {
 		require.NoError(t, writer.Close())
 	}
 
-	writeAndClose(keyA, "v1", "alpha payload")
-	writeAndClose(keyB, "v2", "beta payload")
+	bodies := map[string]string{
+		keyA: "alpha payload",
+		keyB: "beta payload",
+	}
+	writeAndClose(keyA, "v1", bodies[keyA])
+	writeAndClose(keyB, "v2", bodies[keyB])
 
 	require.NoError(t, store.flushPending(ctx))
 
@@ -119,6 +123,19 @@ func TestStore_FlushPacksMultipleKeysIntoSingleRemoteSegment(t *testing.T) {
 	require.Len(t, checkpoint.Entries, 2)
 	assert.Equal(t, segmentObjects[0], checkpoint.Entries[keyA].SegmentPath)
 	assert.Equal(t, segmentObjects[0], checkpoint.Entries[keyB].SegmentPath)
+	assert.Equal(t, int64(0), checkpoint.Entries[keyA].Offset)
+	assert.Equal(t, int64(len(bodies[keyA])), checkpoint.Entries[keyB].Offset)
+
+	remoteOnly := New(bucket, log.NewNopLogger(), WithDir(t.TempDir()))
+	for key, wantBody := range bodies {
+		stream, metadata, err := remoteOnly.GetStream(ctx, key)
+		require.NoError(t, err)
+		body, err := io.ReadAll(stream)
+		closeErr := stream.Close()
+		require.NoError(t, errors.Join(err, closeErr))
+		assert.Equal(t, wantBody, string(body), key)
+		assert.Equal(t, map[string]string{keyA: "v1", keyB: "v2"}[key], metadata.CacheTag, key)
+	}
 }
 
 func TestStore_FlushWritesShardScopedCheckpointWithoutKeyManifests(t *testing.T) {
@@ -172,6 +189,79 @@ func TestStore_FlushFailureKeepsShardPendingForRetry(t *testing.T) {
 
 	segmentObjects := listObjectNames(t, bucket, joinPath(store.prefix, "segments"))
 	require.Len(t, segmentObjects, 1)
+}
+
+func TestStore_AutomaticFlushBacksOffAndResetsAfterSuccess(t *testing.T) {
+	bucket := &failingUploadBucket{
+		Bucket: objstore.NewInMemBucket(),
+		failuresLeft: map[string]int{
+			"segments/": 8,
+		},
+	}
+	store := New(bucket, log.NewNopLogger(), WithDir(t.TempDir()))
+	scheduler := &manualFlushScheduler{}
+	store.scheduleFlushAfter = scheduler.after
+
+	writePendingObject(t, store, "automatic-retry", "retry payload")
+
+	wantDelays := []time.Duration{
+		flushDebounce,
+		flushRetryMin,
+		2 * flushRetryMin,
+		4 * flushRetryMin,
+		8 * flushRetryMin,
+		16 * flushRetryMin,
+		32 * flushRetryMin,
+		flushRetryMax,
+		flushRetryMax,
+	}
+	for _, wantDelay := range wantDelays {
+		scheduled := scheduler.pop(t)
+		assert.Equal(t, wantDelay, scheduled.delay)
+		scheduled.run()
+	}
+	require.Zero(t, scheduler.len())
+
+	entry, ok := store.catalog.Get("automatic-retry")
+	require.True(t, ok)
+	assert.NotEmpty(t, entry.RemotePath)
+
+	writePendingObject(t, store, "automatic-after-success", "fresh payload")
+	assert.Equal(t, flushDebounce, scheduler.pop(t).delay)
+}
+
+func TestStore_AutomaticFlushKeepsOneRetryWhenNewShardIsQueued(t *testing.T) {
+	bucket := &failingUploadBucket{
+		Bucket: objstore.NewInMemBucket(),
+		failuresLeft: map[string]int{
+			"segments/": 1,
+		},
+	}
+	store := New(bucket, log.NewNopLogger(), WithDir(t.TempDir()))
+	scheduler := &manualFlushScheduler{}
+	store.scheduleFlushAfter = scheduler.after
+
+	firstKey := "retry-one-scheduler"
+	secondKey := differentShardKey(firstKey)
+	writePendingObject(t, store, firstKey, "first payload")
+
+	initial := scheduler.pop(t)
+	require.Equal(t, flushDebounce, initial.delay)
+	initial.run()
+
+	writePendingObject(t, store, secondKey, "second payload")
+	require.Equal(t, 1, scheduler.len(), "enqueue during backoff must reuse the pending retry")
+
+	retry := scheduler.pop(t)
+	require.Equal(t, flushRetryMin, retry.delay)
+	retry.run()
+	require.Zero(t, scheduler.len())
+
+	for _, key := range []string{firstKey, secondKey} {
+		entry, ok := store.catalog.Get(key)
+		require.True(t, ok)
+		assert.NotEmpty(t, entry.RemotePath, key)
+	}
 }
 
 func TestStore_DeleteRepublishesCheckpointWithoutDeletedKey(t *testing.T) {
@@ -326,6 +416,59 @@ func sameShardKeys3(base string) (string, string, string) {
 		panic("failed to find same-shard keys")
 	}
 	return keys[0], keys[1], keys[2]
+}
+
+func differentShardKey(base string) string {
+	shard := shardForKey(base)
+	for i := 1; i < 2048; i++ {
+		candidate := base + "-" + strconv.Itoa(i)
+		if shardForKey(candidate) != shard {
+			return candidate
+		}
+	}
+	panic("failed to find different-shard key")
+}
+
+func writePendingObject(t *testing.T, store *Store, key, body string) {
+	t.Helper()
+
+	writer, err := store.BeginSet(context.Background(), key, &daramjwee.Metadata{CacheTag: key})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+}
+
+type scheduledFlush struct {
+	delay time.Duration
+	run   func()
+}
+
+type manualFlushScheduler struct {
+	mu        sync.Mutex
+	scheduled []scheduledFlush
+}
+
+func (s *manualFlushScheduler) after(delay time.Duration, run func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scheduled = append(s.scheduled, scheduledFlush{delay: delay, run: run})
+}
+
+func (s *manualFlushScheduler) pop(t *testing.T) scheduledFlush {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	require.NotEmpty(t, s.scheduled)
+	next := s.scheduled[0]
+	s.scheduled = s.scheduled[1:]
+	return next
+}
+
+func (s *manualFlushScheduler) len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.scheduled)
 }
 
 func loadCheckpoint(t *testing.T, bucket objstore.Bucket, objectName string) checkpoint {

--- a/pkg/store/objectstore/flusher.go
+++ b/pkg/store/objectstore/flusher.go
@@ -16,7 +16,11 @@ import (
 	internalshard "github.com/mrchypark/daramjwee/pkg/store/objectstore/internal/shard"
 )
 
-const flushDebounce = 10 * time.Millisecond
+const (
+	flushDebounce = 10 * time.Millisecond
+	flushRetryMin = 20 * time.Millisecond
+	flushRetryMax = time.Second
+)
 
 type checkpoint struct {
 	UpdatedAt time.Time                  `json:"updated_at"`
@@ -47,15 +51,26 @@ func (s *Store) enqueueFlush(key string) {
 }
 
 func (s *Store) scheduleFlushLocked() {
-	if s.flushTimer != nil {
+	if s.flushScheduled {
 		return
 	}
-	s.flushTimer = time.AfterFunc(flushDebounce, func() {
-		if err := s.flushPending(context.Background()); err != nil {
+	delay := flushDebounce
+	if s.flushRetryDelay > delay {
+		delay = s.flushRetryDelay
+	}
+	s.flushScheduled = true
+	s.scheduleFlushAfter(delay, func() {
+		err := s.flushPending(context.Background())
+		if err != nil {
 			level.Warn(s.logger).Log("msg", "objectstore flush failed", "err", err)
 		}
 		s.flushMu.Lock()
-		s.flushTimer = nil
+		s.flushScheduled = false
+		if err != nil {
+			s.flushRetryDelay = nextFlushRetryDelay(s.flushRetryDelay)
+		} else {
+			s.flushRetryDelay = 0
+		}
 		if len(s.pendingShards) > 0 {
 			s.scheduleFlushLocked()
 		}
@@ -63,9 +78,21 @@ func (s *Store) scheduleFlushLocked() {
 	})
 }
 
+func nextFlushRetryDelay(current time.Duration) time.Duration {
+	if current < flushRetryMin {
+		return flushRetryMin
+	}
+	if current >= flushRetryMax/2 {
+		return flushRetryMax
+	}
+	return current * 2
+}
+
 func (s *Store) flushPending(ctx context.Context) error {
-	s.flushRunMu.Lock()
-	defer s.flushRunMu.Unlock()
+	if err := s.flushRun.acquire(ctx); err != nil {
+		return err
+	}
+	defer s.flushRun.release()
 
 	for {
 		shards := s.takePendingShards()
@@ -119,6 +146,14 @@ func (s *Store) flushShard(ctx context.Context, shardID string) error {
 		return err
 	}
 	mergedEntries := mergeCheckpointEntries(baseEntries, currentEntries, shardID)
+
+	// Compaction must see the upload and its checkpoint/catalog publication as
+	// one transition, or it can sweep the newly uploaded object in between.
+	if err := s.remoteState.acquire(ctx); err != nil {
+		return err
+	}
+	defer s.remoteState.release()
+
 	if len(records) == 0 {
 		return s.publishCheckpoint(ctx, shardID, mergedEntries)
 	}
@@ -185,24 +220,16 @@ func (s *Store) flushPackedRecords(
 	segmentID := s.nextVersion()
 	remotePath := internalshard.SegmentObjectPath(s.prefix, shardID, segmentID)
 
-	payload := bytes.NewBuffer(nil)
-	offsets := make(map[string]int64, len(records))
-	for _, record := range records {
-		offsets[record.key] = int64(payload.Len())
-		file, err := os.Open(record.entry.SegmentPath)
-		if err != nil {
-			return err
-		}
-		if _, err := io.Copy(payload, io.NewSectionReader(file, record.entry.Offset, record.entry.Length)); err != nil {
-			_ = file.Close()
-			return err
-		}
-		if err := file.Close(); err != nil {
-			return err
-		}
+	payload, offsets, err := newPackedRecordReader(records, nil)
+	if err != nil {
+		return err
 	}
-
-	if err := s.bucket.Upload(ctx, remotePath, bytes.NewReader(payload.Bytes())); err != nil {
+	releasePins, err := s.pinPackedSegments(records)
+	if err != nil {
+		return err
+	}
+	defer releasePins()
+	if err := s.uploadPackedBody(ctx, remotePath, payload); err != nil {
 		return err
 	}
 
@@ -225,6 +252,11 @@ func (s *Store) flushPackedRecords(
 		}
 	}
 	return nil
+}
+
+func (s *Store) uploadPackedBody(ctx context.Context, remotePath string, payload io.ReadCloser) error {
+	uploadErr := s.bucket.Upload(ctx, remotePath, payload)
+	return errors.Join(uploadErr, payload.Close())
 }
 
 func (s *Store) flushDirectRecord(

--- a/pkg/store/objectstore/ingest_test.go
+++ b/pkg/store/objectstore/ingest_test.go
@@ -765,6 +765,53 @@ func TestStore_ReopenSweepsOrphanedLocalSegments(t *testing.T) {
 	assert.Equal(t, "v1", meta.CacheTag)
 }
 
+func TestStore_ReopenSweepsAbandonedActiveSegments(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	bucket := objstore.NewInMemBucket()
+	store := New(
+		bucket,
+		log.NewNopLogger(),
+		WithDir(dataDir),
+	)
+	store.autoFlush = false
+
+	writer, err := store.BeginSet(ctx, "live-key", &daramjwee.Metadata{CacheTag: "v1"})
+	require.NoError(t, err)
+	_, err = io.WriteString(writer, "live payload")
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	activeDir := filepath.Join(dataDir, "ingest", "active", shardForKey("abandoned-key"))
+	require.NoError(t, os.MkdirAll(activeDir, 0o755))
+	abandonedPath := filepath.Join(activeDir, "abandoned.seg")
+	require.NoError(t, os.WriteFile(abandonedPath, []byte("partial"), 0o644))
+	unknownPath := filepath.Join(activeDir, "keep.txt")
+	require.NoError(t, os.WriteFile(unknownPath, []byte("unknown"), 0o644))
+
+	reopened := New(
+		bucket,
+		log.NewNopLogger(),
+		WithDir(dataDir),
+	)
+	reopened.autoFlush = false
+	require.NoError(t, reopened.ensureReady())
+
+	_, err = os.Stat(abandonedPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(unknownPath)
+	require.NoError(t, err)
+
+	stream, meta, err := reopened.GetStream(ctx, "live-key")
+	require.NoError(t, err)
+	defer stream.Close()
+
+	body, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	assert.Equal(t, "live payload", string(body))
+	assert.Equal(t, "v1", meta.CacheTag)
+}
+
 func TestStore_ReopenFailsWhenRecoveryCannotPersistCatalogRepair(t *testing.T) {
 	ctx := context.Background()
 	dataDir := t.TempDir()

--- a/pkg/store/objectstore/packed_upload.go
+++ b/pkg/store/objectstore/packed_upload.go
@@ -1,0 +1,191 @@
+package objectstore
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+)
+
+type packedSourceFile interface {
+	io.ReaderAt
+	io.Closer
+}
+
+type packedSourceOpener func(string) (packedSourceFile, error)
+
+type packedRecordReader struct {
+	records   []pendingFlushRecord
+	open      packedSourceOpener
+	next      int
+	current   packedSourceFile
+	section   *io.SectionReader
+	remaining int64
+	closed    bool
+	done      bool
+}
+
+func newPackedRecordReader(
+	records []pendingFlushRecord,
+	open packedSourceOpener,
+) (*packedRecordReader, map[string]int64, error) {
+	if open == nil {
+		open = openPackedSourceFile
+	}
+
+	offsets := make(map[string]int64, len(records))
+	var offset int64
+	for _, record := range records {
+		if record.entry.Offset < 0 || record.entry.Length < 0 {
+			return nil, nil, fmt.Errorf("objectstore: invalid packed record bounds for %q", record.key)
+		}
+		if record.entry.Offset > math.MaxInt64-record.entry.Length {
+			return nil, nil, fmt.Errorf("objectstore: packed record bounds overflow for %q", record.key)
+		}
+		if record.entry.Length > math.MaxInt64-offset {
+			return nil, nil, fmt.Errorf("objectstore: packed upload size overflow")
+		}
+		offsets[record.key] = offset
+		offset += record.entry.Length
+	}
+
+	return &packedRecordReader{
+		records: records,
+		open:    open,
+	}, offsets, nil
+}
+
+func (s *Store) pinPackedSegments(records []pendingFlushRecord) (func(), error) {
+	seen := make(map[string]struct{}, len(records))
+	pinned := make([]string, 0, len(records))
+	release := func() {
+		for index := len(pinned) - 1; index >= 0; index-- {
+			s.releaseLocalSegment(pinned[index])
+		}
+	}
+
+	for _, record := range records {
+		segmentPath := record.entry.SegmentPath
+		if _, ok := seen[segmentPath]; ok {
+			continue
+		}
+		seen[segmentPath] = struct{}{}
+		s.acquireLocalSegment(segmentPath)
+		pinned = append(pinned, segmentPath)
+		if _, err := os.Stat(segmentPath); err != nil {
+			release()
+			return nil, err
+		}
+	}
+	return release, nil
+}
+
+func openPackedSourceFile(path string) (packedSourceFile, error) {
+	return os.Open(path)
+}
+
+func (r *packedRecordReader) Read(p []byte) (int, error) {
+	if r.closed {
+		return 0, io.ErrClosedPipe
+	}
+	if r.done {
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	read := 0
+	for len(p) > 0 {
+		if r.current == nil {
+			if r.next == len(r.records) {
+				r.done = true
+				if read > 0 {
+					return read, nil
+				}
+				return 0, io.EOF
+			}
+			if err := r.openCurrent(); err != nil {
+				r.closed = true
+				return read, err
+			}
+			if r.remaining == 0 {
+				if err := r.finishCurrent(); err != nil {
+					r.closed = true
+					return read, err
+				}
+				continue
+			}
+		}
+
+		n, readErr := r.section.Read(p)
+		read += n
+		p = p[n:]
+		r.remaining -= int64(n)
+
+		if r.remaining == 0 {
+			if errors.Is(readErr, io.EOF) {
+				readErr = nil
+			}
+			closeErr := r.finishCurrent()
+			if readErr != nil || closeErr != nil {
+				r.closed = true
+				return read, errors.Join(readErr, closeErr)
+			}
+			continue
+		}
+
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				readErr = io.ErrUnexpectedEOF
+			}
+			closeErr := r.finishCurrent()
+			r.closed = true
+			return read, errors.Join(readErr, closeErr)
+		}
+		if n == 0 {
+			closeErr := r.finishCurrent()
+			r.closed = true
+			return read, errors.Join(io.ErrNoProgress, closeErr)
+		}
+	}
+	return read, nil
+}
+
+func (r *packedRecordReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	if r.current == nil {
+		return nil
+	}
+	return r.closeCurrent()
+}
+
+func (r *packedRecordReader) openCurrent() error {
+	record := r.records[r.next]
+	file, err := r.open(record.entry.SegmentPath)
+	if err != nil {
+		return err
+	}
+	r.current = file
+	r.section = io.NewSectionReader(file, record.entry.Offset, record.entry.Length)
+	r.remaining = record.entry.Length
+	return nil
+}
+
+func (r *packedRecordReader) finishCurrent() error {
+	err := r.closeCurrent()
+	r.next++
+	return err
+}
+
+func (r *packedRecordReader) closeCurrent() error {
+	err := r.current.Close()
+	r.current = nil
+	r.section = nil
+	r.remaining = 0
+	return err
+}

--- a/pkg/store/objectstore/packed_upload_test.go
+++ b/pkg/store/objectstore/packed_upload_test.go
@@ -1,0 +1,345 @@
+package objectstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+)
+
+func TestPackedRecordReaderStreamsExactSectionsOneFileAtATime(t *testing.T) {
+	files := newTrackingPackedFiles(map[string]string{
+		"first.seg":  "--alpha--tail",
+		"second.seg": "!beta?",
+		"third.seg":  "xxgamma",
+	})
+	records := []pendingFlushRecord{
+		{key: "a", entry: localCatalogEntry{SegmentPath: "first.seg", Offset: 2, Length: 5}},
+		{key: "b", entry: localCatalogEntry{SegmentPath: "second.seg", Offset: 1, Length: 4}},
+		{key: "c", entry: localCatalogEntry{SegmentPath: "third.seg", Offset: 2, Length: 5}},
+	}
+
+	reader, offsets, err := newPackedRecordReader(records, files.open)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int64{"a": 0, "b": 5, "c": 9}, offsets)
+
+	var body bytes.Buffer
+	_, err = io.CopyBuffer(&body, reader, make([]byte, 2))
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, "alphabetagamma", body.String())
+	assert.Equal(t, 1, files.maxOpenCount())
+	assert.Equal(t, 0, files.openCount())
+	assert.Equal(t, []string{
+		"open:first.seg", "close:first.seg",
+		"open:second.seg", "close:second.seg",
+		"open:third.seg", "close:third.seg",
+	}, files.eventsSnapshot())
+}
+
+func TestPackedRecordReaderExplicitCloseClosesCurrentFile(t *testing.T) {
+	files := newTrackingPackedFiles(map[string]string{"only.seg": "payload"})
+	reader, _, err := newPackedRecordReader([]pendingFlushRecord{
+		{key: "only", entry: localCatalogEntry{SegmentPath: "only.seg", Length: 7}},
+	}, files.open)
+	require.NoError(t, err)
+
+	buffer := make([]byte, 1)
+	n, err := reader.Read(buffer)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, 0, files.openCount())
+	assert.Equal(t, []string{"open:only.seg", "close:only.seg"}, files.eventsSnapshot())
+
+	_, err = reader.Read(buffer)
+	require.ErrorIs(t, err, io.ErrClosedPipe)
+}
+
+func TestPackedRecordReaderJoinsReadAndCloseErrors(t *testing.T) {
+	readErr := errors.New("read failed")
+	closeErr := errors.New("close failed")
+	files := newTrackingPackedFiles(map[string]string{"broken.seg": "payload"})
+	files.readErrors["broken.seg"] = readErr
+	files.closeErrors["broken.seg"] = closeErr
+	reader, _, err := newPackedRecordReader([]pendingFlushRecord{
+		{key: "broken", entry: localCatalogEntry{SegmentPath: "broken.seg", Length: 7}},
+	}, files.open)
+	require.NoError(t, err)
+
+	_, err = reader.Read(make([]byte, 1))
+	require.ErrorIs(t, err, readErr)
+	require.ErrorIs(t, err, closeErr)
+	assert.Equal(t, 0, files.openCount())
+	assert.Equal(t, []string{"open:broken.seg", "close:broken.seg"}, files.eventsSnapshot())
+}
+
+func TestPackedRecordReaderRejectsSectionBoundsOverflowBeforeOpen(t *testing.T) {
+	openCalls := 0
+	reader, offsets, err := newPackedRecordReader([]pendingFlushRecord{
+		{key: "overflow", entry: localCatalogEntry{
+			SegmentPath: "overflow.seg",
+			Offset:      int64(^uint64(0) >> 1),
+			Length:      1,
+		}},
+	}, func(string) (packedSourceFile, error) {
+		openCalls++
+		return nil, errors.New("must not open")
+	})
+	require.Error(t, err)
+	assert.Nil(t, reader)
+	assert.Nil(t, offsets)
+	assert.Zero(t, openCalls)
+}
+
+func TestStoreUploadPackedBodyClosesReaderWhenUploadStopsEarly(t *testing.T) {
+	uploadErr := errors.New("upload stopped early")
+	files := newTrackingPackedFiles(map[string]string{"early.seg": "payload"})
+	reader, _, err := newPackedRecordReader([]pendingFlushRecord{
+		{key: "early", entry: localCatalogEntry{SegmentPath: "early.seg", Length: 7}},
+	}, files.open)
+	require.NoError(t, err)
+	store := &Store{bucket: &earlyExitUploadBucket{
+		Bucket: objstore.NewInMemBucket(),
+		err:    uploadErr,
+	}}
+
+	err = store.uploadPackedBody(context.Background(), "segments/packed", reader)
+	require.ErrorIs(t, err, uploadErr)
+	assert.Equal(t, 0, files.openCount())
+	assert.Equal(t, []string{"open:early.seg", "close:early.seg"}, files.eventsSnapshot())
+}
+
+func TestStorePackedFlushPinsSourcesUntilUploadReaderCloses(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *Store, string) <-chan error
+	}{
+		{
+			name: "overwrite",
+			mutate: func(t *testing.T, store *Store, key string) <-chan error {
+				writePendingObject(t, store, key, "replacement payload")
+				return nil
+			},
+		},
+		{
+			name: "delete",
+			mutate: func(t *testing.T, store *Store, key string) <-chan error {
+				done := make(chan error, 1)
+				go func() { done <- store.Delete(context.Background(), key) }()
+				require.Eventually(t, func() bool {
+					entry, ok := store.catalog.Get(key)
+					return ok && entry.Missing
+				}, 5*time.Second, time.Millisecond)
+				return done
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseBucket := objstore.NewInMemBucket()
+			bucket := newBlockingPackedUploadBucket(baseBucket)
+			t.Cleanup(bucket.releaseUpload)
+			store := New(bucket, log.NewNopLogger(), WithDir(t.TempDir()))
+			store.autoFlush = false
+			keyA, keyB := sameShardKeys("pin-packed-source-" + tc.name)
+			writePendingObject(t, store, keyA, "original payload")
+			writePendingObject(t, store, keyB, "neighbor payload")
+
+			entryA, ok := store.catalog.Get(keyA)
+			require.True(t, ok)
+			entryB, ok := store.catalog.Get(keyB)
+			require.True(t, ok)
+
+			flushDone := make(chan error, 1)
+			go func() { flushDone <- store.flushPending(context.Background()) }()
+			select {
+			case <-bucket.uploadStarted:
+			case <-time.After(5 * time.Second):
+				t.Fatal("packed upload did not reach the before-read gate")
+			}
+
+			assert.Equal(t, 1, store.localSegmentRefCount(entryA.SegmentPath))
+			assert.Equal(t, 1, store.localSegmentRefCount(entryB.SegmentPath))
+			mutationDone := tc.mutate(t, store, keyA)
+			_, err := os.Stat(entryA.SegmentPath)
+			require.NoError(t, err, "concurrent mutation reclaimed a not-yet-read packed source")
+
+			bucket.releaseUpload()
+			require.NoError(t, <-flushDone)
+			if mutationDone != nil {
+				require.NoError(t, <-mutationDone)
+			}
+			_, err = os.Stat(entryA.SegmentPath)
+			require.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestStorePinPackedSegmentsReleasesEarlierPinsOnFailure(t *testing.T) {
+	store := New(objstore.NewInMemBucket(), log.NewNopLogger(), WithDir(t.TempDir()))
+	store.autoFlush = false
+	existingPath := filepath.Join(t.TempDir(), "existing.seg")
+	require.NoError(t, os.WriteFile(existingPath, []byte("body"), 0o600))
+	missingPath := filepath.Join(t.TempDir(), "missing.seg")
+
+	release, err := store.pinPackedSegments([]pendingFlushRecord{
+		{key: "first", entry: localCatalogEntry{SegmentPath: existingPath, Length: 4}},
+		{key: "second", entry: localCatalogEntry{SegmentPath: missingPath, Length: 4}},
+	})
+	require.Error(t, err)
+	assert.Nil(t, release)
+	assert.Zero(t, store.localSegmentRefCount(existingPath))
+	assert.Zero(t, store.localSegmentRefCount(missingPath))
+}
+
+type trackingPackedFiles struct {
+	mu          sync.Mutex
+	contents    map[string]string
+	readErrors  map[string]error
+	closeErrors map[string]error
+	events      []string
+	openFiles   int
+	maxOpen     int
+}
+
+func newTrackingPackedFiles(contents map[string]string) *trackingPackedFiles {
+	return &trackingPackedFiles{
+		contents:    contents,
+		readErrors:  make(map[string]error),
+		closeErrors: make(map[string]error),
+	}
+}
+
+func (s *Store) localSegmentRefCount(path string) int {
+	s.segmentRefsMu.Lock()
+	defer s.segmentRefsMu.Unlock()
+	return s.segmentRefs[path]
+}
+
+func (f *trackingPackedFiles) open(path string) (packedSourceFile, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	content, ok := f.contents[path]
+	if !ok {
+		return nil, errors.New("file not found")
+	}
+	f.openFiles++
+	if f.openFiles > f.maxOpen {
+		f.maxOpen = f.openFiles
+	}
+	f.events = append(f.events, "open:"+path)
+	return &trackingPackedFile{
+		Reader:   bytes.NewReader([]byte(content)),
+		owner:    f,
+		path:     path,
+		readErr:  f.readErrors[path],
+		closeErr: f.closeErrors[path],
+	}, nil
+}
+
+func (f *trackingPackedFiles) openCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.openFiles
+}
+
+func (f *trackingPackedFiles) maxOpenCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.maxOpen
+}
+
+func (f *trackingPackedFiles) eventsSnapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.events...)
+}
+
+type trackingPackedFile struct {
+	*bytes.Reader
+	owner    *trackingPackedFiles
+	path     string
+	readErr  error
+	closeErr error
+	closed   bool
+}
+
+func (f *trackingPackedFile) ReadAt(p []byte, off int64) (int, error) {
+	if f.readErr != nil {
+		return 0, f.readErr
+	}
+	return f.Reader.ReadAt(p, off)
+}
+
+func (f *trackingPackedFile) Close() error {
+	f.owner.mu.Lock()
+	defer f.owner.mu.Unlock()
+	if f.closed {
+		return nil
+	}
+	f.closed = true
+	f.owner.openFiles--
+	f.owner.events = append(f.owner.events, "close:"+f.path)
+	return f.closeErr
+}
+
+type earlyExitUploadBucket struct {
+	objstore.Bucket
+	err error
+}
+
+func (b *earlyExitUploadBucket) Upload(_ context.Context, _ string, reader io.Reader, _ ...objstore.ObjectUploadOption) error {
+	_, _ = reader.Read(make([]byte, 1))
+	return b.err
+}
+
+type blockingPackedUploadBucket struct {
+	objstore.Bucket
+	uploadStarted chan struct{}
+	uploadRelease chan struct{}
+	startOnce     sync.Once
+	releaseOnce   sync.Once
+}
+
+func newBlockingPackedUploadBucket(bucket objstore.Bucket) *blockingPackedUploadBucket {
+	return &blockingPackedUploadBucket{
+		Bucket:        bucket,
+		uploadStarted: make(chan struct{}),
+		uploadRelease: make(chan struct{}),
+	}
+}
+
+func (b *blockingPackedUploadBucket) Upload(ctx context.Context, name string, reader io.Reader, opts ...objstore.ObjectUploadOption) error {
+	blocked := false
+	if strings.Contains(name, "segments/") {
+		b.startOnce.Do(func() {
+			blocked = true
+			close(b.uploadStarted)
+		})
+	}
+	if blocked {
+		select {
+		case <-b.uploadRelease:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return b.Bucket.Upload(ctx, name, reader, opts...)
+}
+
+func (b *blockingPackedUploadBucket) releaseUpload() {
+	b.releaseOnce.Do(func() { close(b.uploadRelease) })
+}

--- a/pkg/store/objectstore/store.go
+++ b/pkg/store/objectstore/store.go
@@ -48,37 +48,67 @@ type manifest struct {
 	Metadata daramjwee.Metadata `json:"metadata"`
 }
 
+type contextSemaphore chan struct{}
+
+func newContextSemaphore() contextSemaphore {
+	semaphore := make(contextSemaphore, 1)
+	semaphore <- struct{}{}
+	return semaphore
+}
+
+func (s contextSemaphore) acquire(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s:
+		return nil
+	}
+}
+
+func (s contextSemaphore) release() {
+	s <- struct{}{}
+}
+
 // Store is a first-party object storage backend.
 // It currently publishes immutable blob versions via internal manifest pointers.
 type Store struct {
-	bucket            objstore.Bucket
-	logger            log.Logger
-	dataDir           string
-	prefix            string
-	gcGrace           time.Duration
-	packThreshold     int64
-	pagedThreshold    int64
-	pageSize          int64
-	blockCache        *blockcache.Cache
-	pageCache         *pagecache.Cache
-	checkpointCache   *checkpointCache
-	catalog           *internalcatalog.Catalog
-	lockManager       *stripedlock.Manager
-	blockLoads        singleflight.Group
-	pageLoads         singleflight.Group
-	versionSeq        atomic.Uint64
-	generationSeq     atomic.Uint64
-	initErr           error
-	segmentRefsMu     sync.Mutex
-	segmentRefs       map[string]int
-	reclaimableSegs   map[string]struct{}
-	flushMu           sync.Mutex
-	flushRunMu        sync.Mutex
-	pendingShards     map[string]struct{}
-	flushTimer        *time.Timer
-	autoFlush         bool
-	now               func() time.Time
-	openSegmentWriter func(root, shard, segmentID string) (segmentWriter, error)
+	bucket             objstore.Bucket
+	logger             log.Logger
+	dataDir            string
+	prefix             string
+	gcGrace            time.Duration
+	packThreshold      int64
+	pagedThreshold     int64
+	pageSize           int64
+	blockCache         *blockcache.Cache
+	pageCache          *pagecache.Cache
+	checkpointCache    *checkpointCache
+	catalog            *internalcatalog.Catalog
+	lockManager        *stripedlock.Manager
+	blockLoads         singleflight.Group
+	pageLoads          singleflight.Group
+	versionSeq         atomic.Uint64
+	generationSeq      atomic.Uint64
+	initErr            error
+	segmentRefsMu      sync.Mutex
+	segmentRefs        map[string]int
+	reclaimableSegs    map[string]struct{}
+	flushMu            sync.Mutex
+	flushRun           contextSemaphore
+	remoteState        contextSemaphore
+	pendingShards      map[string]struct{}
+	flushScheduled     bool
+	flushRetryDelay    time.Duration
+	scheduleFlushAfter func(time.Duration, func())
+	autoFlush          bool
+	now                func() time.Time
+	openSegmentWriter  func(root, shard, segmentID string) (segmentWriter, error)
 }
 
 func (s *Store) GetStreamUsesContext() bool { return true }
@@ -132,8 +162,13 @@ func New(bucket objstore.Bucket, logger log.Logger, opts ...Option) *Store {
 		segmentRefs:     make(map[string]int),
 		reclaimableSegs: make(map[string]struct{}),
 		pendingShards:   make(map[string]struct{}),
+		flushRun:        newContextSemaphore(),
+		remoteState:     newContextSemaphore(),
 		autoFlush:       true,
 		now:             time.Now,
+		scheduleFlushAfter: func(delay time.Duration, run func()) {
+			time.AfterFunc(delay, run)
+		},
 		openSegmentWriter: func(root, shard, segmentID string) (segmentWriter, error) {
 			return segment.Open(root, shard, segmentID)
 		},
@@ -547,8 +582,6 @@ func (s *Store) OwnsObjectPath(name string) bool {
 	return false
 }
 
-
-
 type fileSectionReadCloser struct {
 	io.Reader
 	closeFn func() error
@@ -579,8 +612,6 @@ func objectTimestampFromPath(objectPath string) (time.Time, bool) {
 func blobTimestampFromPath(blobPath string) (time.Time, bool) {
 	return objectTimestampFromPath(blobPath)
 }
-
-
 
 func (s *Store) nextGeneration() uint64 {
 	return s.generationSeq.Add(1)

--- a/tests/tiering_integration_test.go
+++ b/tests/tiering_integration_test.go
@@ -3,6 +3,7 @@ package daramjwee_test
 import (
 	"context"
 	"io"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -769,23 +770,36 @@ func TestCache_SingleTierStaleHitRefreshesOnlyTier(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
-func TestCache_SingleTierStaleNotModifiedRefreshesCachedAt(t *testing.T) {
+func TestCache_SingleTierStaleNotModifiedLeavesNonStagingEntryStale(t *testing.T) {
 	tier := newMockStore()
-	oldCachedAt := time.Now().Add(-time.Hour)
+	oldCachedAt := time.Date(2020, time.January, 2, 3, 4, 5, 6, time.UTC)
 	tier.setData("single-tier-stale-304", "old-value", &daramjwee.Metadata{
 		CacheTag: "old",
 		CachedAt: oldCachedAt,
 	})
-	fetcher := &mockFetcher{err: daramjwee.ErrNotModified}
-
-	cache, err := daramjwee.New(
-		nil,
+	fetcher := &notModifiedSignalFetcher{}
+	cacheID := t.Name()
+	logger := &refreshCompletionLogger{
+		cacheID:     cacheID,
+		completions: make(chan struct{}, 2),
+	}
+	group, err := daramjwee.NewGroup(logger, daramjwee.WithGroupWorkers(1))
+	require.NoError(t, err)
+	cache, err := group.NewCache(
+		cacheID,
 		daramjwee.WithTiers(tier),
 		daramjwee.WithFreshness(time.Second, 0),
 		daramjwee.WithOpTimeout(2*time.Second),
 	)
 	require.NoError(t, err)
-	defer cache.Close()
+	defer group.Close()
+	waitForRefresh := func(round string) {
+		select {
+		case <-logger.completions:
+		case <-time.After(time.Second):
+			t.Fatalf("%s stale revalidation did not finish", round)
+		}
+	}
 
 	stream, err := cache.Get(context.Background(), "single-tier-stale-304", daramjwee.GetRequest{}, fetcher)
 	require.NoError(t, err)
@@ -794,15 +808,18 @@ func TestCache_SingleTierStaleNotModifiedRefreshesCachedAt(t *testing.T) {
 	require.NoError(t, stream.Close())
 	assert.Equal(t, "old-value", string(body))
 
-	require.Eventually(t, func() bool {
-		meta, err := tier.Stat(context.Background(), "single-tier-stale-304")
-		if err != nil {
-			return false
-		}
-		return meta.CacheTag == "old" && meta.CachedAt.After(oldCachedAt)
-	}, 2*time.Second, 10*time.Millisecond)
+	waitForRefresh("first")
+	meta, err := tier.Stat(context.Background(), "single-tier-stale-304")
+	require.NoError(t, err)
+	assert.Equal(t, "old", meta.CacheTag)
+	assert.False(t, meta.IsNegative)
+	assert.Equal(t, oldCachedAt, meta.CachedAt)
+	select {
+	case key := <-tier.writeCompleted:
+		t.Fatalf("unexpected top-tier write for %q", key)
+	default:
+	}
 
-	fetchCount := fetcher.getFetchCount()
 	stream, err = cache.Get(context.Background(), "single-tier-stale-304", daramjwee.GetRequest{}, fetcher)
 	require.NoError(t, err)
 	body, err = io.ReadAll(stream)
@@ -810,8 +827,58 @@ func TestCache_SingleTierStaleNotModifiedRefreshesCachedAt(t *testing.T) {
 	require.NoError(t, stream.Close())
 	assert.Equal(t, "old-value", string(body))
 
-	time.Sleep(150 * time.Millisecond)
-	assert.Equal(t, fetchCount, fetcher.getFetchCount())
+	waitForRefresh("second")
+	assert.Equal(t, int32(2), fetcher.fetchCount.Load())
+	meta, err = tier.Stat(context.Background(), "single-tier-stale-304")
+	require.NoError(t, err)
+	assert.Equal(t, "old", meta.CacheTag)
+	assert.False(t, meta.IsNegative)
+	assert.Equal(t, oldCachedAt, meta.CachedAt)
+	select {
+	case key := <-tier.writeCompleted:
+		t.Fatalf("unexpected top-tier write for %q", key)
+	default:
+	}
+}
+
+type notModifiedSignalFetcher struct {
+	fetchCount atomic.Int32
+}
+
+func (f *notModifiedSignalFetcher) Fetch(context.Context, *daramjwee.Metadata) (*daramjwee.FetchResult, error) {
+	f.fetchCount.Add(1)
+	return nil, daramjwee.ErrNotModified
+}
+
+type refreshCompletionLogger struct {
+	cacheID     string
+	completions chan struct{}
+}
+
+func (l *refreshCompletionLogger) Log(keyvals ...interface{}) error {
+	var msg, cacheID, jobKind string
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		key, ok := keyvals[i].(string)
+		if !ok {
+			continue
+		}
+		value, _ := keyvals[i+1].(string)
+		switch key {
+		case "msg":
+			msg = value
+		case "cache_id":
+			cacheID = value
+		case "job_kind":
+			jobKind = value
+		}
+	}
+	if msg == "finished background job" && cacheID == l.cacheID && jobKind == "refresh" {
+		select {
+		case l.completions <- struct{}{}:
+		default:
+		}
+	}
+	return nil
 }
 
 func TestCache_SingleTierFilestoreStaleNotModifiedRefreshesWithoutSelfDeadlock(t *testing.T) {

--- a/write_coordinator.go
+++ b/write_coordinator.go
@@ -18,6 +18,10 @@ type fanoutWriteManager struct {
 }
 
 type writeCoordinator struct {
+	manager     *topWriteManager
+	key         string
+	refMu       sync.Mutex
+	references  int
 	initOnce    sync.Once
 	leaseOnce   sync.Once
 	writeLease  chan struct{}
@@ -35,6 +39,11 @@ type writeCoordinator struct {
 	fillPreemptions     int
 }
 
+type topWriteGeneration struct {
+	coord      *writeCoordinator
+	generation uint64
+	once       sync.Once
+}
 type fanoutWriteLock struct {
 	mu    sync.Mutex
 	refMu sync.Mutex
@@ -47,25 +56,99 @@ type fanoutLockKey struct {
 }
 
 func (m *topWriteManager) coordinator(key string) *writeCoordinator {
-	if coord, ok := m.coords.Load(key); ok {
-		resolved := coord.(*writeCoordinator)
-		resolved.init()
-		return resolved
+	for {
+		if coord := m.acquireCoordinatorIfPresent(key); coord != nil {
+			return coord
+		}
+
+		coord := &writeCoordinator{
+			manager:    m,
+			key:        key,
+			references: 1,
+		}
+		coord.init()
+		if _, loaded := m.coords.LoadOrStore(key, coord); !loaded {
+			return coord
+		}
 	}
-	coord := &writeCoordinator{}
-	coord.init()
-	actual, _ := m.coords.LoadOrStore(key, coord)
-	resolved := actual.(*writeCoordinator)
-	resolved.init()
-	return resolved
 }
 
-func (m *topWriteManager) coordinatorIfPresent(key string) *writeCoordinator {
-	coord, ok := m.coords.Load(key)
-	if !ok {
+func (m *topWriteManager) acquireCoordinatorIfPresent(key string) *writeCoordinator {
+	for {
+		value, ok := m.coords.Load(key)
+		if !ok {
+			return nil
+		}
+		coord := value.(*writeCoordinator)
+		coord.refMu.Lock()
+		current, stillPresent := m.coords.Load(key)
+		if !stillPresent || current != value {
+			coord.refMu.Unlock()
+			continue
+		}
+		coord.references++
+		coord.refMu.Unlock()
+		return coord
+	}
+}
+
+func (c *writeCoordinator) releaseReference() {
+	if c.manager == nil {
+		return
+	}
+	c.refMu.Lock()
+	defer c.refMu.Unlock()
+	c.references--
+	if c.references < 0 {
+		panic("daramjwee: released top-write coordinator too many times")
+	}
+	if c.references == 0 {
+		c.manager.coords.CompareAndDelete(c.key, c)
+	}
+}
+
+func (c *writeCoordinator) retainReference() bool {
+	if c.manager == nil {
+		return true
+	}
+	c.refMu.Lock()
+	defer c.refMu.Unlock()
+	if c.references <= 0 {
+		return false
+	}
+	c.references++
+	return true
+}
+
+func (g *topWriteGeneration) retain() *topWriteGeneration {
+	if g == nil {
 		return nil
 	}
-	return coord.(*writeCoordinator)
+	if !g.coord.retainReference() {
+		return nil
+	}
+	return &topWriteGeneration{coord: g.coord, generation: g.generation}
+}
+
+func (g *topWriteGeneration) release() {
+	if g == nil {
+		return
+	}
+	g.once.Do(g.coord.releaseReference)
+}
+
+func (m *topWriteManager) coordinatorForWrite(key string, expected *topWriteGeneration) (*writeCoordinator, *uint64, error) {
+	if expected == nil {
+		return m.coordinator(key), nil, nil
+	}
+	if expected.coord.manager != m || expected.coord.key != key {
+		return nil, nil, ErrTopWriteInvalidated
+	}
+	if !expected.coord.retainReference() {
+		return nil, nil, ErrTopWriteInvalidated
+	}
+	generation := expected.generation
+	return expected.coord, &generation, nil
 }
 
 func (m *fanoutWriteManager) lock(destTierIndex int, key string) func() {
@@ -120,12 +203,9 @@ func (m *fanoutWriteManager) release(lockKey fanoutLockKey, lock *fanoutWriteLoc
 	}
 }
 
-func (m *topWriteManager) currentGeneration(key string) uint64 {
-	coord := m.coordinatorIfPresent(key)
-	if coord == nil {
-		return 0
-	}
-	return coord.current()
+func (m *topWriteManager) currentGeneration(key string) *topWriteGeneration {
+	coord := m.coordinator(key)
+	return &topWriteGeneration{coord: coord, generation: coord.current()}
 }
 
 func (c *writeCoordinator) current() uint64 {
@@ -553,32 +633,38 @@ func (c *writeCoordinator) finishDelete(success bool) {
 	c.releaseCommit()
 }
 
-func (c *DaramjweeCache) currentTopWriteGeneration(key string) uint64 {
+func (c *DaramjweeCache) currentTopWriteGeneration(key string) *topWriteGeneration {
 	return c.topWrites.currentGeneration(key)
 }
 
 func (c *DaramjweeCache) noteTopWriteGeneration(key string) {
 	coord := c.topWrites.coordinator(key)
+	defer coord.releaseReference()
 	coord.stateMu.Lock()
 	coord.advanceCommittedLocked()
 	coord.stateMu.Unlock()
 }
 
-func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, key string, metadata *Metadata, expectedGeneration *uint64) (WriteSink, error) {
+func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, key string, metadata *Metadata, expectedGeneration *topWriteGeneration) (WriteSink, error) {
 	store := c.topWriteStore()
-	coord := c.topWrites.coordinator(key)
+	coord, expected, err := c.topWrites.coordinatorForWrite(key, expectedGeneration)
+	if err != nil {
+		return nil, err
+	}
 	if expectedGeneration == nil {
 		unblockFills := coord.preemptActiveFillForWrite()
 		defer unblockFills()
 	}
 	if staging, ok := store.(StagingStore); ok {
-		generation, err := coord.reserve(ctx, expectedGeneration)
+		generation, err := coord.reserve(ctx, expected)
 		if err != nil {
+			coord.releaseReference()
 			return nil, err
 		}
 		sink, err := staging.BeginStagedSet(ctx, key, metadata)
 		if err != nil {
 			coord.unregisterReservation(generation)
+			coord.releaseReference()
 			return nil, err
 		}
 		return &coordinatedStagedTopWriteSink{
@@ -589,14 +675,16 @@ func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, 
 			onInvalidated: func() error { return c.deleteTopStoreKey(key) },
 		}, nil
 	}
-	generation, err := coord.begin(ctx, expectedGeneration)
+	generation, err := coord.begin(ctx, expected)
 	if err != nil {
+		coord.releaseReference()
 		return nil, err
 	}
 
 	sink, err := store.BeginSet(ctx, key, metadata)
 	if err != nil {
 		coord.rollbackAndUnlock(generation)
+		coord.releaseReference()
 		return nil, err
 	}
 
@@ -609,17 +697,22 @@ func (c *DaramjweeCache) setStreamToTopStoreWithGeneration(ctx context.Context, 
 	}, nil
 }
 
-func (c *DaramjweeCache) setStreamToTopStoreBestEffortWithGeneration(ctx context.Context, key string, metadata *Metadata, expectedGeneration *uint64) (WriteSink, error) {
+func (c *DaramjweeCache) setStreamToTopStoreBestEffortWithGeneration(ctx context.Context, key string, metadata *Metadata, expectedGeneration *topWriteGeneration) (WriteSink, error) {
 	store := c.topWriteStore()
-	coord := c.topWrites.coordinator(key)
+	coord, expected, err := c.topWrites.coordinatorForWrite(key, expectedGeneration)
+	if err != nil {
+		return nil, err
+	}
 	if staging, ok := store.(StagingStore); ok {
-		generation, err := coord.reserveBestEffort(ctx, expectedGeneration)
+		generation, err := coord.reserveBestEffort(ctx, expected)
 		if err != nil {
+			coord.releaseReference()
 			return nil, err
 		}
 		sink, err := staging.BeginStagedSet(ctx, key, metadata)
 		if err != nil {
 			coord.unregisterReservation(generation)
+			coord.releaseReference()
 			return nil, err
 		}
 		return &coordinatedStagedTopWriteSink{
@@ -631,13 +724,15 @@ func (c *DaramjweeCache) setStreamToTopStoreBestEffortWithGeneration(ctx context
 		}, nil
 	}
 
-	generation, err := coord.beginBestEffort(ctx, expectedGeneration)
+	generation, err := coord.beginBestEffort(ctx, expected)
 	if err != nil {
+		coord.releaseReference()
 		return nil, err
 	}
 	sink, err := store.BeginSet(ctx, key, metadata)
 	if err != nil {
 		coord.rollbackAndUnlock(generation)
+		coord.releaseReference()
 		return nil, err
 	}
 	return &coordinatedTopWriteSink{
@@ -649,24 +744,32 @@ func (c *DaramjweeCache) setStreamToTopStoreBestEffortWithGeneration(ctx context
 	}, nil
 }
 
-func (c *DaramjweeCache) setStreamToTopStoreForFill(ctx context.Context, key string, metadata *Metadata, expectedGeneration uint64) (WriteSink, error) {
+func (c *DaramjweeCache) setStreamToTopStoreForFill(ctx context.Context, key string, metadata *Metadata, expectedGeneration *topWriteGeneration) (WriteSink, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	store := c.topWriteStore()
-	coord := c.topWrites.coordinator(key)
+	coord, expected, err := c.topWrites.coordinatorForWrite(key, expectedGeneration)
+	if err != nil {
+		return nil, err
+	}
+	if expected == nil {
+		coord.releaseReference()
+		return nil, ErrTopWriteInvalidated
+	}
 	var generation uint64
 
 	if staging, ok := store.(StagingStore); ok {
 		fillCtx, cancelFill := context.WithCancel(ctx)
 		fill := newPendingTopFillSink(coord, func() {
 			coord.unregisterReservation(generation)
+			coord.releaseReference()
 		}, cancelFill)
 		fill.reportPreemptOnClose = true
-		var err error
-		generation, err = coord.reserveWithFill(fillCtx, expectedGeneration, fill)
+		generation, err = coord.reserveWithFill(fillCtx, *expected, fill)
 		if err != nil {
 			cancelFill()
+			coord.releaseReference()
 			return nil, err
 		}
 		sink, err := staging.BeginStagedSet(fillCtx, key, metadata)
@@ -692,10 +795,12 @@ func (c *DaramjweeCache) setStreamToTopStoreForFill(ctx context.Context, key str
 	fillCtx, cancelFill := context.WithCancel(ctx)
 	fill := newPendingTopFillSink(coord, func() {
 		coord.rollbackAndUnlock(generation)
+		coord.releaseReference()
 	}, cancelFill)
-	generation, err := coord.beginWithFill(fillCtx, expectedGeneration, fill)
+	generation, err = coord.beginWithFill(fillCtx, *expected, fill)
 	if err != nil {
 		cancelFill()
+		coord.releaseReference()
 		return nil, err
 	}
 	type beginResult struct {

--- a/write_coordinator_sink_base.go
+++ b/write_coordinator_sink_base.go
@@ -8,11 +8,11 @@ import (
 
 // closeCoreParams holds parameters for the shared close sequence.
 type closeCoreParams struct {
-	generation     uint64
-	coord          *writeCoordinator
-	waitTimeout    time.Duration
-	onInvalidated  func() error
-	advanceGen     bool // whether to advance committedGeneration on success
+	generation    uint64
+	coord         *writeCoordinator
+	waitTimeout   time.Duration
+	onInvalidated func() error
+	advanceGen    bool // whether to advance committedGeneration on success
 }
 
 // closeCore executes the shared close sequence for generation-coordinated sinks.
@@ -25,6 +25,11 @@ func closeCore(
 	abortFn func() error,
 	releaseLease func(),
 ) error {
+	defer p.coord.releaseReference()
+	if releaseLease != nil {
+		defer releaseLease()
+	}
+
 	waitCtx, cancelWait := newCoordinatorWaitContext(p.waitTimeout)
 	defer cancelWait()
 
@@ -35,9 +40,6 @@ func closeCore(
 			if abortErr := abortFn(); abortErr != nil {
 				return errors.Join(err, abortErr)
 			}
-		}
-		if releaseLease != nil {
-			releaseLease()
 		}
 		return err
 	}
@@ -52,9 +54,6 @@ func closeCore(
 				return errors.Join(ErrTopWriteInvalidated, abortErr)
 			}
 		}
-		if releaseLease != nil {
-			releaseLease()
-		}
 		return ErrTopWriteInvalidated
 	}
 	p.coord.stateMu.Unlock()
@@ -64,9 +63,6 @@ func closeCore(
 		p.coord.stateMu.Lock()
 		p.coord.removeReservationLocked(p.generation)
 		p.coord.stateMu.Unlock()
-		if releaseLease != nil {
-			releaseLease()
-		}
 		return commitErr
 	}
 
@@ -95,15 +91,9 @@ func closeCore(
 				err = errors.Join(err, cleanupErr)
 			}
 		}
-		if releaseLease != nil {
-			releaseLease()
-		}
 		return err
 	}
 	p.coord.stateMu.Unlock()
 
-	if releaseLease != nil {
-		releaseLease()
-	}
 	return nil
 }

--- a/write_coordinator_sinks.go
+++ b/write_coordinator_sinks.go
@@ -22,11 +22,11 @@ type coordinatedTopWriteSink struct {
 func (s *coordinatedTopWriteSink) Close() error {
 	s.once.Do(func() {
 		err := closeCore(context.Background(), closeCoreParams{
-			generation:     s.generation,
-			coord:          s.coord,
-			waitTimeout:    s.waitTimeout,
-			onInvalidated:  s.onInvalidated,
-			advanceGen:     true,
+			generation:    s.generation,
+			coord:         s.coord,
+			waitTimeout:   s.waitTimeout,
+			onInvalidated: s.onInvalidated,
+			advanceGen:    true,
 		}, func(ctx context.Context) error {
 			return s.WriteSink.Close()
 		}, func() error {
@@ -41,6 +41,7 @@ func (s *coordinatedTopWriteSink) Close() error {
 
 func (s *coordinatedTopWriteSink) Abort() error {
 	s.once.Do(func() {
+		defer s.coord.releaseReference()
 		defer s.coord.releaseWrite()
 		s.err = s.WriteSink.Abort()
 		s.coord.unregisterReservation(s.generation)
@@ -51,6 +52,7 @@ func (s *coordinatedTopWriteSink) Abort() error {
 func (s *coordinatedTopWriteSink) detachForFillPreempt() func() error {
 	var cleanup func() error
 	s.once.Do(func() {
+		defer s.coord.releaseReference()
 		s.err = ErrTopWriteInvalidated
 		s.coord.unregisterReservation(s.generation)
 		s.coord.releaseWrite()
@@ -77,6 +79,17 @@ func (s *coordinatedStagedTopWriteSink) Write(p []byte) (int, error) {
 
 func (s *coordinatedStagedTopWriteSink) Close() error {
 	s.once.Do(func() {
+		defer s.coord.releaseReference()
+		defer func() {
+			if panicValue := recover(); panicValue != nil {
+				s.coord.unregisterReservation(s.generation)
+				func() {
+					defer func() { _ = recover() }()
+					_ = s.sink.Abort()
+				}()
+				panic(panicValue)
+			}
+		}()
 		commitCtx, cancelCommit := newCoordinatorWaitContext(s.waitTimeout)
 		defer cancelCommit()
 		waitCtx, cancelWait := newCoordinatorWaitContext(s.waitTimeout)
@@ -152,6 +165,7 @@ func (s *coordinatedStagedTopWriteSink) Close() error {
 
 func (s *coordinatedStagedTopWriteSink) Abort() error {
 	s.once.Do(func() {
+		defer s.coord.releaseReference()
 		s.coord.unregisterReservation(s.generation)
 		s.err = s.sink.Abort()
 	})
@@ -161,6 +175,7 @@ func (s *coordinatedStagedTopWriteSink) Abort() error {
 func (s *coordinatedStagedTopWriteSink) detachForFillPreempt() func() error {
 	var cleanup func() error
 	s.once.Do(func() {
+		defer s.coord.releaseReference()
 		s.coord.unregisterReservation(s.generation)
 		s.err = ErrTopWriteInvalidated
 		cleanup = s.sink.Abort
@@ -193,11 +208,11 @@ func newConditionalGenerationWriteSink(sink WriteSink, coord *writeCoordinator, 
 func (s *conditionalGenerationWriteSink) Close() error {
 	s.once.Do(func() {
 		err := closeCore(context.Background(), closeCoreParams{
-			generation:     s.generation,
-			coord:          s.coord,
-			waitTimeout:    s.waitTimeout,
-			onInvalidated:  s.onInvalidated,
-			advanceGen:     false, // conditional sinks never advance generation
+			generation:    s.generation,
+			coord:         s.coord,
+			waitTimeout:   s.waitTimeout,
+			onInvalidated: s.onInvalidated,
+			advanceGen:    false, // conditional sinks never advance generation
 		}, func(ctx context.Context) error {
 			return s.WriteSink.Close()
 		}, func() error {
@@ -210,6 +225,7 @@ func (s *conditionalGenerationWriteSink) Close() error {
 
 func (s *conditionalGenerationWriteSink) Abort() error {
 	s.once.Do(func() {
+		defer s.coord.releaseReference()
 		s.err = s.WriteSink.Abort()
 	})
 	return s.err

--- a/write_coordinator_test.go
+++ b/write_coordinator_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -12,6 +13,215 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestTopWriteManagerRetiresCompletedHighCardinalityWrites(t *testing.T) {
+	store := &stubStagingStore{}
+	cache := &DaramjweeCache{
+		tiers:  []Store{store},
+		config: cacheConfig{opTimeout: time.Second, closeTimeout: time.Second},
+	}
+
+	const keyCount = 128
+	for i := range keyCount {
+		writer, err := cache.Set(context.Background(), fmt.Sprintf("key-%d", i), &Metadata{})
+		if err != nil {
+			t.Fatalf("Set key %d: %v", i, err)
+		}
+		if i%2 == 0 {
+			err = writer.Close()
+		} else {
+			err = writer.Abort()
+		}
+		if err != nil {
+			t.Fatalf("finish key %d: %v", i, err)
+		}
+	}
+
+	retained := 0
+	cache.topWrites.coords.Range(func(_, _ any) bool {
+		retained++
+		return true
+	})
+	if retained != 0 {
+		t.Fatalf("expected completed coordinators to retire, retained %d", retained)
+	}
+}
+
+func TestTopWriteManagerConcurrentAcquiresShareCoordinator(t *testing.T) {
+	manager := &topWriteManager{}
+	const callers = 64
+
+	start := make(chan struct{})
+	release := make(chan struct{})
+	results := make(chan *writeCoordinator, callers)
+	var workers sync.WaitGroup
+	workers.Add(callers)
+	for range callers {
+		go func() {
+			defer workers.Done()
+			<-start
+			coord := manager.coordinator("key")
+			results <- coord
+			<-release
+			coord.releaseReference()
+		}()
+	}
+
+	close(start)
+	first := <-results
+	for range callers - 1 {
+		if got := <-results; got != first {
+			t.Fatalf("concurrent callers split across coordinators: first=%p got=%p", first, got)
+		}
+	}
+	close(release)
+	workers.Wait()
+	if _, ok := manager.coords.Load("key"); ok {
+		t.Fatal("expected shared coordinator to retire after the last caller")
+	}
+}
+
+func TestTopWriteManagerRejectsReleasedObservationAfterReplacement(t *testing.T) {
+	manager := &topWriteManager{}
+	stale := manager.currentGeneration("key")
+	retired := stale.coord
+	stale.release()
+
+	fresh := manager.coordinator("key")
+	defer fresh.releaseReference()
+	if fresh == retired {
+		t.Fatal("expected a fresh coordinator after retirement")
+	}
+
+	if coord, _, err := manager.coordinatorForWrite("key", stale); !errors.Is(err, ErrTopWriteInvalidated) || coord != nil {
+		t.Fatalf("expected released observation to be rejected, coord=%p err=%v", coord, err)
+	}
+	if current, ok := manager.coords.Load("key"); !ok || current != fresh {
+		t.Fatal("stale observation changed or removed the fresh coordinator")
+	}
+}
+
+func TestTopWriteManagerUnrelatedKeyDoesNotInvalidateObservation(t *testing.T) {
+	cache := &DaramjweeCache{}
+	observed := cache.currentTopWriteGeneration("key-a")
+	defer observed.release()
+
+	cache.noteTopWriteGeneration("key-b")
+	if !cache.canAttemptExpectedTopWrite("key-a", observed) {
+		t.Fatal("unrelated key write invalidated key-a observation")
+	}
+	if got := observed.coord.current(); got != observed.generation {
+		t.Fatalf("unrelated key changed visible generation: got %d want %d", got, observed.generation)
+	}
+}
+
+func TestCloseCorePanicReleasesCoordinatorReferenceAndWriteLease(t *testing.T) {
+	tests := []struct {
+		name           string
+		conditional    bool
+		panicFromAbort bool
+	}{
+		{name: "non-staging commit"},
+		{name: "conditional commit", conditional: true},
+		{name: "abort", panicFromAbort: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &topWriteManager{}
+			coord := manager.coordinator("key")
+			var generation uint64
+			var err error
+			if tt.conditional {
+				generation, err = coord.reserve(context.Background(), nil)
+			} else {
+				generation, err = coord.begin(context.Background(), nil)
+			}
+			require.NoError(t, err)
+
+			if tt.panicFromAbort {
+				coord.stateMu.Lock()
+				coord.committedGeneration = generation + 1
+				coord.stateMu.Unlock()
+			}
+
+			var recovered any
+			var releaseLease func()
+			if !tt.conditional {
+				releaseLease = coord.releaseWrite
+			}
+			func() {
+				defer func() { recovered = recover() }()
+				_ = closeCore(context.Background(), closeCoreParams{
+					generation: generation,
+					coord:      coord,
+				}, func(context.Context) error {
+					panic("commit panic")
+				}, func() error {
+					if tt.panicFromAbort {
+						panic("abort panic")
+					}
+					return nil
+				}, releaseLease)
+			}()
+			require.NotNil(t, recovered)
+			if tt.panicFromAbort {
+				require.Equal(t, "abort panic", recovered)
+			} else {
+				require.Equal(t, "commit panic", recovered)
+			}
+			if _, ok := manager.coords.Load("key"); ok {
+				t.Fatal("expected coordinator reference to be released after panic")
+			}
+
+			if !tt.conditional {
+				leaseCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				require.NoError(t, coord.acquireWrite(leaseCtx))
+				coord.releaseWrite()
+			}
+		})
+	}
+}
+
+func TestStagedClosePreservesCommitPanicWhenAbortPanics(t *testing.T) {
+	manager := &topWriteManager{}
+	coord := manager.coordinator("key")
+	generation, err := coord.reserve(context.Background(), nil)
+	require.NoError(t, err)
+
+	commitPanic := errors.New("commit panic")
+	abortPanic := errors.New("abort panic")
+	underlying := &panicStagedWriteSink{
+		commitPanic: commitPanic,
+		abortPanic:  abortPanic,
+	}
+	sink := &coordinatedStagedTopWriteSink{
+		sink:       underlying,
+		coord:      coord,
+		generation: generation,
+	}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		_ = sink.Close()
+	}()
+	require.Same(t, commitPanic, recovered)
+	require.Equal(t, 1, underlying.abortCalls)
+	if _, ok := manager.coords.Load("key"); ok {
+		t.Fatal("expected coordinator reference to be released after panic")
+	}
+	coord.stateMu.Lock()
+	_, reserved := coord.activeReservations[generation]
+	coord.stateMu.Unlock()
+	require.False(t, reserved)
+
+	leaseCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, coord.acquireCommit(leaseCtx))
+	coord.releaseCommit()
+}
 
 func TestSetStreamToStoreWithTopGenerationRejectsStaleWriterBeforeBeginSet(t *testing.T) {
 	store := &destructiveReservationStore{
@@ -25,10 +235,11 @@ func TestSetStreamToStoreWithTopGenerationRejectsStaleWriterBeforeBeginSet(t *te
 			closeTimeout: time.Second,
 		},
 	}
+	expectedGeneration := cache.currentTopWriteGeneration("key")
+	defer expectedGeneration.release()
 	cache.noteTopWriteGeneration("key")
 
-	expectedGeneration := uint64(0)
-	writer, err := cache.setStreamToTopStoreWithGeneration(context.Background(), "key", &Metadata{CacheTag: "stale"}, &expectedGeneration)
+	writer, err := cache.setStreamToTopStoreWithGeneration(context.Background(), "key", &Metadata{CacheTag: "stale"}, expectedGeneration)
 	if !errors.Is(err, ErrTopWriteInvalidated) {
 		t.Fatalf("expected invalidated error, got writer=%v err=%v", writer, err)
 	}
@@ -50,15 +261,18 @@ func TestSetStreamToStoreWithTopGenerationRestoresGenerationOnBeginSetFailure(t 
 		},
 	}
 
-	expectedGeneration := uint64(0)
-	writer, err := cache.setStreamToTopStoreWithGeneration(context.Background(), "key", &Metadata{CacheTag: "v1"}, &expectedGeneration)
+	expectedGeneration := cache.currentTopWriteGeneration("key")
+	defer expectedGeneration.release()
+	writer, err := cache.setStreamToTopStoreWithGeneration(context.Background(), "key", &Metadata{CacheTag: "v1"}, expectedGeneration)
 	if writer != nil {
 		t.Fatalf("expected no writer on BeginSet failure, got %T", writer)
 	}
 	if !errors.Is(err, store.err) {
 		t.Fatalf("expected BeginSet error, got %v", err)
 	}
-	if got := cache.currentTopWriteGeneration("key"); got != 0 {
+	current := cache.currentTopWriteGeneration("key")
+	defer current.release()
+	if got := current.generation; got != 0 {
 		t.Fatalf("expected generation to be restored after BeginSet failure, got %d", got)
 	}
 }
@@ -85,7 +299,7 @@ func TestRolledBackReservationDoesNotInvalidateConditionalWrite(t *testing.T) {
 func TestSetStreamToTopStoreDoesNotExposeStagedCommitBypass(t *testing.T) {
 	store := &stubStagingStore{}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
@@ -111,7 +325,7 @@ func TestLaterStagedBeginFailureDoesNotInvalidateOlderWriter(t *testing.T) {
 		secondBeginErr:     beginErr,
 	}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
@@ -165,7 +379,7 @@ func TestLaterStagedAbortCleanupDoesNotInvalidateOlderWriter(t *testing.T) {
 		releaseAbort: make(chan struct{}),
 	}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
@@ -220,14 +434,16 @@ func TestStagedFillPreemptDoesNotWaitForAbortCleanup(t *testing.T) {
 		releaseAbort: make(chan struct{}),
 	}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
 		},
 	}
 
-	fill, err := cache.setStreamToTopStoreForFill(context.Background(), "key", &Metadata{CacheTag: "fill"}, 0)
+	observed := cache.currentTopWriteGeneration("key")
+	defer observed.release()
+	fill, err := cache.setStreamToTopStoreForFill(context.Background(), "key", &Metadata{CacheTag: "fill"}, observed)
 	if err != nil {
 		t.Fatalf("fill writer failed: %v", err)
 	}
@@ -269,14 +485,16 @@ func TestStagedFillDeletePreemptDoesNotWaitForAbortCleanup(t *testing.T) {
 		releaseAbort: make(chan struct{}),
 	}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
 		},
 	}
 
-	fill, err := cache.setStreamToTopStoreForFill(context.Background(), "key", &Metadata{CacheTag: "fill"}, 0)
+	observed := cache.currentTopWriteGeneration("key")
+	defer observed.release()
+	fill, err := cache.setStreamToTopStoreForFill(context.Background(), "key", &Metadata{CacheTag: "fill"}, observed)
 	if err != nil {
 		t.Fatalf("fill writer failed: %v", err)
 	}
@@ -314,7 +532,7 @@ func TestLegacyFillContextCancelPreemptsPendingBeginSet(t *testing.T) {
 		releaseBegin: make(chan struct{}),
 	}
 	cache := &DaramjweeCache{
-		tiers:            []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:        time.Second,
 			closeTimeout:     time.Second,
@@ -323,9 +541,11 @@ func TestLegacyFillContextCancelPreemptsPendingBeginSet(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	observed := cache.currentTopWriteGeneration("key")
+	defer observed.release()
 	fillDone := make(chan error, 1)
 	go func() {
-		writer, err := cache.setStreamToTopStoreForFill(ctx, "key", &Metadata{CacheTag: "fill"}, 0)
+		writer, err := cache.setStreamToTopStoreForFill(ctx, "key", &Metadata{CacheTag: "fill"}, observed)
 		if writer != nil {
 			_ = writer.Abort()
 		}
@@ -380,7 +600,7 @@ func TestLegacyFillPreemptCancelsPendingBeginSet(t *testing.T) {
 		releaseBegin: make(chan struct{}),
 	}
 	cache := &DaramjweeCache{
-		tiers:            []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:        time.Second,
 			closeTimeout:     time.Second,
@@ -388,9 +608,11 @@ func TestLegacyFillPreemptCancelsPendingBeginSet(t *testing.T) {
 		},
 	}
 
+	observed := cache.currentTopWriteGeneration("key")
+	defer observed.release()
 	fillDone := make(chan error, 1)
 	go func() {
-		writer, err := cache.setStreamToTopStoreForFill(context.Background(), "key", &Metadata{CacheTag: "fill"}, 0)
+		writer, err := cache.setStreamToTopStoreForFill(context.Background(), "key", &Metadata{CacheTag: "fill"}, observed)
 		if writer != nil {
 			_ = writer.Abort()
 		}
@@ -438,7 +660,7 @@ func TestStaleStagedCloseAbortCleanupDoesNotBlockNewerCommit(t *testing.T) {
 		releaseAbort: make(chan struct{}),
 	}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
@@ -498,7 +720,7 @@ func TestStaleStagedCloseAbortCleanupDoesNotBlockNewerCommit(t *testing.T) {
 func TestStagedCloseWaitingForDeleteTimesOutAndReleasesReservation(t *testing.T) {
 	store := &stubStagingStore{}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: 25 * time.Millisecond,
@@ -534,7 +756,7 @@ func TestStagedCloseWaitingForDeleteTimesOutAndReleasesReservation(t *testing.T)
 func TestLegacyTopWriteCloseWaitingForDeleteTimesOut(t *testing.T) {
 	store := &countingBeginSetStore{}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: 25 * time.Millisecond,
@@ -607,7 +829,7 @@ func TestStagedCloseWaitingForCommitLeaseTimesOutAndReleasesReservation(t *testi
 		releaseCommit: make(chan struct{}),
 	}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: 25 * time.Millisecond,
@@ -668,7 +890,7 @@ func TestStagedCloseWaitingForCommitLeaseTimesOutAndReleasesReservation(t *testi
 func TestCommittedStagedWritePrunesOlderAbandonedReservations(t *testing.T) {
 	store := &stubStagingStore{}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
@@ -701,7 +923,7 @@ func TestStagedCloseAbortsUnderlyingSinkAfterCommitFailure(t *testing.T) {
 	commitErr := errors.New("commit failed")
 	store := &failingCommitStagingStore{commitErr: commitErr}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
@@ -729,7 +951,7 @@ func TestFailedStagedCommitAbortCleanupDoesNotHoldCommitLease(t *testing.T) {
 		releaseAbort: make(chan struct{}),
 	}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: 25 * time.Millisecond,
@@ -784,18 +1006,20 @@ func TestFailedStagedCommitAbortCleanupDoesNotHoldCommitLease(t *testing.T) {
 func TestCurrentTopWriteGenerationDoesNotCreateCoordinatorForMissingKey(t *testing.T) {
 	cache := &DaramjweeCache{}
 
-	if got := cache.currentTopWriteGeneration("missing"); got != 0 {
+	observed := cache.currentTopWriteGeneration("missing")
+	if got := observed.generation; got != 0 {
 		t.Fatalf("expected zero generation for missing key, got %d", got)
 	}
+	observed.release()
 	if _, ok := cache.topWrites.coords.Load("missing"); ok {
-		t.Fatal("expected read-only generation lookup not to create coordinator")
+		t.Fatal("expected completed generation observation not to retain a coordinator")
 	}
 }
 
 func TestSetStreamToTopStoreWithGenerationHonorsCanceledContextWhileDeleteInProgress(t *testing.T) {
 	store := &failingBeginSetStore{}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
@@ -878,7 +1102,7 @@ func TestConditionalGenerationWriteSinkDoesNotReturnTimeoutAfterSuccessfulClose(
 func TestSetWithAbandonedTopWriteSinkReturnsWhenContextExpires(t *testing.T) {
 	store := &countingBeginSetStore{}
 	cache := &DaramjweeCache{
-		tiers:        []Store{store},
+		tiers: []Store{store},
 		config: cacheConfig{
 			opTimeout:    time.Second,
 			closeTimeout: time.Second,
@@ -1817,6 +2041,21 @@ func (s *stubStagedWriteSink) Commit(ctx context.Context) error {
 	return nil
 }
 func (s *stubStagedWriteSink) Abort() error { return nil }
+
+type panicStagedWriteSink struct {
+	commitPanic any
+	abortPanic  any
+	abortCalls  int
+}
+
+func (s *panicStagedWriteSink) Write(p []byte) (int, error) { return len(p), nil }
+func (s *panicStagedWriteSink) Commit(context.Context) error {
+	panic(s.commitPanic)
+}
+func (s *panicStagedWriteSink) Abort() error {
+	s.abortCalls++
+	panic(s.abortPanic)
+}
 
 type blockingFirstBeginSetStore struct {
 	beginStarted chan struct{}


### PR DESCRIPTION
## Summary

- serialize ObjectStore publication and compaction, add bounded flush retries, safe crash-staging cleanup, and streaming packed uploads
- retire per-key top-write coordinators safely across foreground, background, panic, drop, and sink terminal paths
- fix SIEVE and S3-FIFO victim liveness, FileStore startup scan atomicity, and caller-owned metadata mutation
- stream stale-304 refreshes for staging stores; genuine non-staging stores now skip `CachedAt` extension and revalidate on the next access without body I/O
- forward staging capability through the deprecated objectstore adapter

## Why

The audited cache and storage paths had several concurrency, crash-recovery, capacity, and unbounded-memory failure modes. The fixes are bounded and preserve the existing public API and persistent formats. A metadata-only refresh API was intentionally not added because safe semantics require generation/CAS and backend-specific durability contracts.

## Integration

This branch is rebased onto `main` at `6b81d5254cd5464665b982f6f1d0904d27a0757f`. The latest upstream read decision/execution split and `closeCore` refactor were retained. Hardening cleanup was integrated into the new base sink shape, including deterministic preservation of the original commit panic when cleanup also panics. `go.mod` and `go.sum` have no branch-local delta.

## Verification

- `gofmt` and `git diff --check`
- `go vet -mod=readonly ./...`
- `go test -mod=readonly ./...`
- `go test -mod=readonly -race -covermode=atomic ./...`
- race suites with `stress` and `race` tags
- bounded top-write liveness/fuzz and lock-contention race scripts
- `DJ_REPRO_CACHE_STUCK` reproducer
- focused race repetitions for coordinator, stale-304, policies, adapter, FileStore, and ObjectStore publication/compaction/retry/packed upload paths
- independent post-rebase review and fix confirmation
- GitHub Actions run 30891884759

All checks passed. `staticcheck` was not installed and was not added as a dependency.
